### PR TITLE
Fix checkstyle and spotbugs issues, enable fail on issue for both.

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -205,8 +205,7 @@ subprojects {
         tasks["checkstyleTest"].enabled = false
 
         tasks.withType<Checkstyle>() {
-            // generate the report but don't fail the build
-            ignoreFailures = true
+            ignoreFailures = false
         }
 
         /*
@@ -251,8 +250,7 @@ subprojects {
 
         // Configure the bug filter for spotbugs.
         tasks.withType<com.github.spotbugs.SpotBugsTask> {
-            // generate the report but don't fail the build
-            ignoreFailures = true
+            ignoreFailures = false
 
             effort = "max"
             excludeFilterConfig = project.resources.text.fromFile("${project.rootDir}/config/spotbugs/filter.xml")

--- a/codegen/smithy-ruby-codegen/build.gradle.kts
+++ b/codegen/smithy-ruby-codegen/build.gradle.kts
@@ -22,13 +22,3 @@ dependencies {
     implementation("software.amazon.smithy:smithy-waiters:[1.4.0,2.0.0[")
     implementation("software.amazon.smithy:smithy-protocol-test-traits:[1.9.0,2.0.0[")
 }
-
-// Override project settings and fail on checkstyle
-tasks.withType<Checkstyle>() {
-    ignoreFailures = false
-}
-
-// Override project settings and fail on spotbugs
-tasks.withType<com.github.spotbugs.SpotBugsTask> {
-    ignoreFailures = false
-}

--- a/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/integrations/RailsIntegration.java
+++ b/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/integrations/RailsIntegration.java
@@ -1,11 +1,25 @@
-package software.amazon.smithy.ruby.codegen.integrations;
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
 
-import software.amazon.smithy.ruby.codegen.ProtocolGenerator;
-import software.amazon.smithy.ruby.codegen.RubyIntegration;
-import software.amazon.smithy.ruby.codegen.protocol.railsjson.RailsJsonGenerator;
+package software.amazon.smithy.ruby.codegen.integrations;
 
 import java.util.Arrays;
 import java.util.List;
+import software.amazon.smithy.ruby.codegen.ProtocolGenerator;
+import software.amazon.smithy.ruby.codegen.RubyIntegration;
+import software.amazon.smithy.ruby.codegen.protocol.railsjson.RailsJsonGenerator;
 
 // Provide support for generating SDKs for Rails (RailsJson)
 public class RailsIntegration implements RubyIntegration {

--- a/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/protocol/railsjson/RailsJsonGenerator.java
+++ b/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/protocol/railsjson/RailsJsonGenerator.java
@@ -1,20 +1,31 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package software.amazon.smithy.ruby.codegen.protocol.railsjson;
 
-import software.amazon.smithy.model.shapes.OperationShape;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.ruby.codegen.ApplicationTransport;
 import software.amazon.smithy.ruby.codegen.GenerationContext;
 import software.amazon.smithy.ruby.codegen.ProtocolGenerator;
-import software.amazon.smithy.ruby.codegen.RubyCodegenPlugin;
-import software.amazon.smithy.ruby.codegen.generators.ClientGenerator;
 import software.amazon.smithy.ruby.codegen.protocol.railsjson.generators.BuilderGenerator;
 import software.amazon.smithy.ruby.codegen.protocol.railsjson.generators.ErrorsGenerator;
 import software.amazon.smithy.ruby.codegen.protocol.railsjson.generators.ParserGenerator;
-
-import java.util.logging.Logger;
-import java.util.stream.Stream;
 import software.amazon.smithy.ruby.codegen.protocol.railsjson.generators.StubsGenerator;
 
 // Protocol Implementation for Rails-Json

--- a/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/protocol/railsjson/generators/BuilderGenerator.java
+++ b/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/protocol/railsjson/generators/BuilderGenerator.java
@@ -15,14 +15,29 @@
 
 package software.amazon.smithy.ruby.codegen.protocol.railsjson.generators;
 
-import java.util.*;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import software.amazon.smithy.build.FileManifest;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.neighbor.Walker;
-import software.amazon.smithy.model.shapes.*;
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.shapes.SetShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ShapeVisitor;
+import software.amazon.smithy.model.shapes.StructureShape;
+import software.amazon.smithy.model.shapes.TimestampShape;
+import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.HttpHeaderTrait;
 import software.amazon.smithy.model.traits.HttpLabelTrait;
 import software.amazon.smithy.model.traits.HttpQueryTrait;
@@ -97,7 +112,8 @@ public class BuilderGenerator extends ShapeVisitor.Default<Void> {
 
         generatedBuilders.add(operation.toShapeId());
 
-        for (Iterator<Shape> it = new Walker(model).iterateShapes(inputShape); it.hasNext(); ) {
+        Iterator<Shape> it = new Walker(model).iterateShapes(inputShape);
+        while (it.hasNext()) {
             Shape s = it.next();
             if (!generatedBuilders.contains(s.getId())) {
                 generatedBuilders.add(s.getId());
@@ -116,13 +132,14 @@ public class BuilderGenerator extends ShapeVisitor.Default<Void> {
         generatedBuilders.add(inputShape.getId());
 
         //determine if there are any members of the input that need to be serialized to the body
-        boolean serializeBody = inputShape.members().stream().anyMatch((m) -> !m.hasTrait(HttpLabelTrait.class) && !m.hasTrait(HttpQueryTrait.class) && !m.hasTrait((HttpHeaderTrait.class)));
+        boolean serializeBody = inputShape.members().stream().anyMatch((m) -> !m.hasTrait(HttpLabelTrait.class)
+                && !m.hasTrait(HttpQueryTrait.class) && !m.hasTrait((HttpHeaderTrait.class)));
         if (serializeBody) {
             writer
-                .write("")
-                .write("http_req.headers['Content-Type'] = 'application/json'")
-                .call(() -> renderMemberBuilders(writer, inputShape))
-                .write("http_req.body = StringIO.new(Seahorse::JSON.dump(data))");
+                    .write("")
+                    .write("http_req.headers['Content-Type'] = 'application/json'")
+                    .call(() -> renderMemberBuilders(writer, inputShape))
+                    .write("http_req.body = StringIO.new(Seahorse::JSON.dump(data))");
         }
     }
 
@@ -134,13 +151,14 @@ public class BuilderGenerator extends ShapeVisitor.Default<Void> {
                 .collect(Collectors.toList());
         System.out.println("\tQUERY BUILDER: " + operation.getId() + " has " + queryMembers.size() + " query input...");
 
-        for(MemberShape m : queryMembers) {
+        for (MemberShape m : queryMembers) {
             HttpQueryTrait queryTrait = m.expectTrait(HttpQueryTrait.class);
             Shape target = model.expectShape(m.getTarget());
             System.out.println("\t\tAdding query input for: " + queryTrait.getValue() + " -> " + target.getId());
-            String symbolName =  RubyFormatter.asSymbol(m.getMemberName());
+            String symbolName = RubyFormatter.asSymbol(m.getMemberName());
             // TODO: Handle required
-            writer.write("http_req.append_query_param('$1L', input[$2L].to_str) unless input[$2L].nil?", queryTrait.getValue(), symbolName);
+            writer.write("http_req.append_query_param('$1L', input[$2L].to_str) unless input[$2L].nil?",
+                    queryTrait.getValue(), symbolName);
         }
     }
 
@@ -150,15 +168,17 @@ public class BuilderGenerator extends ShapeVisitor.Default<Void> {
                 .stream()
                 .filter((m) -> m.hasTrait(HttpHeaderTrait.class))
                 .collect(Collectors.toList());
-        System.out.println("\tHEADER BUILDER: " + operation.getId() + " has " + headerMembers.size() + " query input...");
+        System.out
+                .println("\tHEADER BUILDER: " + operation.getId() + " has " + headerMembers.size() + " query input...");
 
-        for(MemberShape m : headerMembers) {
+        for (MemberShape m : headerMembers) {
             HttpHeaderTrait headerTrait = m.expectTrait(HttpHeaderTrait.class);
             Shape target = model.expectShape(m.getTarget());
             System.out.println("\t\tAdding headers for: " + headerTrait.getValue() + " -> " + target.getId());
-            String symbolName =  RubyFormatter.asSymbol(m.getMemberName());
+            String symbolName = RubyFormatter.asSymbol(m.getMemberName());
             // TODO: Handle required
-            writer.write("http_req.headers['$1L'] = input[$2L].to_str if input.key?($2L)", headerTrait.getValue(), symbolName);
+            writer.write("http_req.headers['$1L'] = input[$2L].to_str if input.key?($2L)", headerTrait.getValue(),
+                    symbolName);
         }
     }
 
@@ -174,18 +194,20 @@ public class BuilderGenerator extends ShapeVisitor.Default<Void> {
         if (labelMembers.size() > 0) {
             String formatUri = httpTrait.getUri().toString()
                     .replaceAll("[{]([a-zA-Z0-9_]+)[}]", "%<$1>s"); //TODO: Handle greedy labels?
-            String formatArgs = ""; // use string builder instead?
+            StringBuffer formatArgs = new StringBuffer();
             System.out.println("\t\tURI: " + httpTrait.getUri() + " -> " + formatUri);
 
-            for(MemberShape m : labelMembers) {
+            for (MemberShape m : labelMembers) {
                 HttpLabelTrait label = m.expectTrait(HttpLabelTrait.class);
                 Shape target = model.expectShape(m.getTarget());
                 System.out.println("\t\tAdding url subs for: " + target.getId());
-                String symbolName =  RubyFormatter.asSymbol(m.getMemberName());
-                formatArgs += ",\n  " + m.getMemberName() + ": Seahorse::HTTP.uri_escape(input[" + symbolName + "].to_str)";
+                String symbolName = RubyFormatter.asSymbol(m.getMemberName());
+                formatArgs.append(
+                        ",\n  " + m.getMemberName() + ": Seahorse::HTTP.uri_escape(input[" + symbolName + "].to_str)"
+                );
             }
             writer.openBlock("http_req.append_path(format(");
-            writer.write("  '$L'$L\n)", formatUri, formatArgs);
+            writer.write("  '$L'$L\n)", formatUri, formatArgs.toString());
             writer.closeBlock(")");
         } else {
             writer.write("http_req.append_path('$L')", httpTrait.getUri());
@@ -218,7 +240,7 @@ public class BuilderGenerator extends ShapeVisitor.Default<Void> {
                 .openBlock("def self.build(input)")
                 .write("data = []")
                 .openBlock("input.each do |element|")
-                .call( () -> memberTarget.accept(new MemberSerializer(writer, "data << ", "element")))
+                .call(() -> memberTarget.accept(new MemberSerializer(writer, "data << ", "element")))
                 .closeBlock("end")
                 .write("data")
                 .closeBlock("end")
@@ -238,7 +260,7 @@ public class BuilderGenerator extends ShapeVisitor.Default<Void> {
                 .openBlock("def self.build(input)")
                 .write("data = {}")
                 .openBlock("input.each do |key, value|")
-                .call( () -> valueTarget.accept(new MemberSerializer(writer, "data[key] = ", "value")))
+                .call(() -> valueTarget.accept(new MemberSerializer(writer, "data[key] = ", "value")))
                 .closeBlock("end")
                 .write("data")
                 .closeBlock("end")
@@ -258,7 +280,7 @@ public class BuilderGenerator extends ShapeVisitor.Default<Void> {
                 .openBlock("def self.build(input)")
                 .write("data = Set.new")
                 .openBlock("input.each do |element|")
-                .call( () -> memberTarget.accept(new MemberSerializer(writer, "data << ", "element")))
+                .call(() -> memberTarget.accept(new MemberSerializer(writer, "data << ", "element")))
                 .closeBlock("end")
                 .write("data")
                 .closeBlock("end")
@@ -277,7 +299,9 @@ public class BuilderGenerator extends ShapeVisitor.Default<Void> {
         writer.write("data = {}");
 
         //remove members w/ http traits or marked NoSerialize
-        Stream<MemberShape> serializeMembers = s.members().stream().filter((m) -> !m.hasTrait(HttpLabelTrait.class) && !m.hasTrait(HttpQueryTrait.class) && !m.hasTrait((HttpHeaderTrait.class)));
+        Stream<MemberShape> serializeMembers = s.members().stream()
+                .filter((m) -> !m.hasTrait(HttpLabelTrait.class) && !m.hasTrait(HttpQueryTrait.class)
+                        && !m.hasTrait((HttpHeaderTrait.class)));
         serializeMembers = serializeMembers.filter(NoSerializeTrait.excludeNoSerializeMembers());
 
         serializeMembers.forEach((member) -> {
@@ -306,13 +330,13 @@ public class BuilderGenerator extends ShapeVisitor.Default<Void> {
         private final String inputGetter;
         private final String dataSetter;
 
-        public MemberSerializer(RubyCodeWriter writer, String dataSetter, String inputGetter) {
+        MemberSerializer(RubyCodeWriter writer, String dataSetter, String inputGetter) {
             this.writer = writer;
             this.inputGetter = inputGetter;
             this.dataSetter = dataSetter;
         }
 
-        public String checkRequired(Shape shape) {
+        private String checkRequired(Shape shape) {
             return " unless " + inputGetter + ".nil?";
         }
 
@@ -330,10 +354,11 @@ public class BuilderGenerator extends ShapeVisitor.Default<Void> {
         }
 
         /**
-         *  For complex shapes, simply delegate to their builder
+         * For complex shapes, simply delegate to their builder.
          */
         private void defaultComplexSerializer(Shape shape) {
-            writer.write("$LBuilders::$L.build($L)$L", dataSetter, shape.getId().getName(), inputGetter, checkRequired(shape));
+            writer.write("$LBuilders::$L.build($L)$L", dataSetter, shape.getId().getName(), inputGetter,
+                    checkRequired(shape));
         }
 
         @Override

--- a/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/protocol/railsjson/generators/ErrorsGenerator.java
+++ b/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/protocol/railsjson/generators/ErrorsGenerator.java
@@ -22,7 +22,6 @@ import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.ErrorTrait;
 import software.amazon.smithy.ruby.codegen.RubyCodeWriter;
 import software.amazon.smithy.ruby.codegen.RubySettings;
-import software.amazon.smithy.utils.CodeWriter;
 
 public class ErrorsGenerator {
 

--- a/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/protocol/railsjson/generators/StubsGenerator.java
+++ b/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/protocol/railsjson/generators/StubsGenerator.java
@@ -125,7 +125,8 @@ public class StubsGenerator extends ShapeVisitor.Default<Void> {
 
         generatedStubs.add(operation.toShapeId());
 
-        for (Iterator<Shape> it = new Walker(model).iterateShapes(outputShape); it.hasNext(); ) {
+        Iterator<Shape> it = new Walker(model).iterateShapes(outputShape);
+        while (it.hasNext()) {
             Shape s = it.next();
             if (!generatedStubs.contains(s.getId())) {
                 generatedStubs.add(s.getId());
@@ -144,8 +145,8 @@ public class StubsGenerator extends ShapeVisitor.Default<Void> {
 
         //determine if there are any members of the input that need to be serialized to the body
         boolean serializeBody = outputShape.members().stream().anyMatch(
-                (m) -> !m.hasTrait(HttpLabelTrait.class) && !m.hasTrait(HttpQueryTrait.class) &&
-                        !m.hasTrait((HttpHeaderTrait.class)));
+                (m) -> !m.hasTrait(HttpLabelTrait.class) && !m.hasTrait(HttpQueryTrait.class)
+                        && !m.hasTrait((HttpHeaderTrait.class)));
         if (serializeBody) {
             writer
                     .write("")
@@ -226,7 +227,8 @@ public class StubsGenerator extends ShapeVisitor.Default<Void> {
                 .openBlock("\nclass $L", shape.getId().getName())
                 .openBlock("\ndef self.default")
                 .openBlock("{")
-                .call(() -> valueTarget.accept(new MemberDefaults(writer, "test_key: ", "", valueTarget.getId().getName())))
+                .call(() -> valueTarget
+                        .accept(new MemberDefaults(writer, "test_key: ", "", valueTarget.getId().getName())))
                 .closeBlock("}")
                 .closeBlock("end")
                 .openBlock("\ndef self.stub(stub = {})")
@@ -273,7 +275,8 @@ public class StubsGenerator extends ShapeVisitor.Default<Void> {
     }
 
     private void renderMemberStubbers(Shape s) {
-        Optional<MemberShape> payload = s.members().stream().filter((m) -> m.hasTrait(HttpPayloadTrait.class)).findFirst();
+        Optional<MemberShape> payload =
+                s.members().stream().filter((m) -> m.hasTrait(HttpPayloadTrait.class)).findFirst();
 
         if (payload.isPresent()) {
             MemberShape member = payload.get();
@@ -286,8 +289,8 @@ public class StubsGenerator extends ShapeVisitor.Default<Void> {
         } else {
             //remove members w/ http traits or marked NoSerialize
             Stream<MemberShape> serializeMembers = s.members().stream()
-                    .filter((m) -> !m.hasTrait(HttpLabelTrait.class) && !m.hasTrait(HttpQueryTrait.class) &&
-                            !m.hasTrait((HttpHeaderTrait.class)));
+                    .filter((m) -> !m.hasTrait(HttpLabelTrait.class) && !m.hasTrait(HttpQueryTrait.class)
+                            && !m.hasTrait((HttpHeaderTrait.class)));
             serializeMembers = serializeMembers.filter(NoSerializeTrait.excludeNoSerializeMembers());
 
             writer.write("data = {}");
@@ -328,7 +331,7 @@ public class StubsGenerator extends ShapeVisitor.Default<Void> {
         private final String inputGetter;
         private final String dataSetter;
 
-        public MemberSerializer(RubyCodeWriter writer, String dataSetter, String inputGetter) {
+        MemberSerializer(RubyCodeWriter writer, String dataSetter, String inputGetter) {
             this.writer = writer;
             this.inputGetter = inputGetter;
             this.dataSetter = dataSetter;
@@ -352,7 +355,7 @@ public class StubsGenerator extends ShapeVisitor.Default<Void> {
         }
 
         /**
-         * For complex shapes, simply delegate to their Stubber
+         * For complex shapes, simply delegate to their Stubber.
          */
         private void defaultComplexSerializer(Shape shape) {
             writer.write("$LStubs::$L.stub($L)$L", dataSetter, shape.getId().getName(), inputGetter,
@@ -397,7 +400,7 @@ public class StubsGenerator extends ShapeVisitor.Default<Void> {
         private final String dataSetter;
         private final String memberName;
 
-        public MemberDefaults(RubyCodeWriter writer, String dataSetter, String eol, String memberName) {
+        MemberDefaults(RubyCodeWriter writer, String dataSetter, String eol, String memberName) {
             this.writer = writer;
             this.eol = eol;
             this.dataSetter = dataSetter;
@@ -425,17 +428,20 @@ public class StubsGenerator extends ShapeVisitor.Default<Void> {
         @Override
         public Void shortShape(ShortShape shape) {
             writer.write("$L1$L", dataSetter, eol);
-            return null;        }
+            return null;
+        }
 
         @Override
         public Void integerShape(IntegerShape shape) {
             writer.write("$L1$L", dataSetter, eol);
-            return null;        }
+            return null;
+        }
 
         @Override
         public Void longShape(LongShape shape) {
             writer.write("$L1$L", dataSetter, eol);
-            return null;        }
+            return null;
+        }
 
         @Override
         public Void floatShape(FloatShape shape) {
@@ -474,7 +480,7 @@ public class StubsGenerator extends ShapeVisitor.Default<Void> {
         }
 
         /**
-         * For complex shapes, simply delegate to their Stubber
+         * For complex shapes, simply delegate to their Stubber.
          */
         private void complexShapeDefaults(Shape shape) {
             writer.write("$LStubs::$L.default$L", dataSetter, shape.getId().getName(), eol);

--- a/sample_service/spec/protocol_spec.rb
+++ b/sample_service/spec/protocol_spec.rb
@@ -14,7 +14,6 @@ module SampleService
     let(:endpoint) { 'http://127.0.0.1' }
     let(:client) { Client.new(stub_responses: true, endpoint: endpoint) }
 
-
     describe '#create_high_score' do
 
     end


### PR DESCRIPTION
*Description of changes:* 
We previously had checkstyle/spotbug fail builds only for the core project.  the smithy-ruby-rails-codegen project had a large number of violations that needed fixing.

This PR fixes those and then enables failures on violations for all projects.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
