### PR TITLE
Add double underscore for reserved and bad naming

### DIFF
--- a/codegen/projections/rails_json/lib/rails_json/builders.rb
+++ b/codegen/projections/rails_json/lib/rails_json/builders.rb
@@ -897,27 +897,27 @@ module RailsJson
     end
 
     # Operation Builder for __789BadName
-    class Operation__789BadName
+    class Operation____789BadName
       def self.build(http_req, input:)
         http_req.http_method = 'POST'
         http_req.append_path(format(
             '/BadName/%<__123abc>s',
-            __123abc: Seahorse::HTTP.uri_escape(input[:member___123abc].to_s)
+            __123abc: Seahorse::HTTP.uri_escape(input[:member____123abc].to_s)
           )
         )
 
         http_req.headers['Content-Type'] = 'application/json'
         data = {}
-        data[:member] = Builders::Struct__456efg.build(input[:member]) unless input[:member].nil?
+        data[:member] = Builders::Struct____456efg.build(input[:member]) unless input[:member].nil?
         http_req.body = StringIO.new(Seahorse::JSON.dump(data))
       end
     end
 
     # Structure Builder for __456efg
-    class Struct__456efg
+    class Struct____456efg
       def self.build(input)
         data = {}
-        data[:__123foo] = input[:member___123foo] unless input[:member___123foo].nil?
+        data[:__123foo] = input[:member____123foo] unless input[:member____123foo].nil?
         data
       end
     end

--- a/codegen/projections/rails_json/lib/rails_json/client.rb
+++ b/codegen/projections/rails_json/lib/rails_json/client.rb
@@ -2050,44 +2050,44 @@ module RailsJson
     end
 
     # @param [Hash] params
-    #   See {Types::Struct__789BadNameInput}.
+    #   See {Types::Struct____789BadNameInput}.
     #
-    # @return [Types::Struct__789BadNameOutput]
+    # @return [Types::Struct____789BadNameOutput]
     #
     # @example Request syntax with placeholder values
     #
-    #   resp = client.operation__789_bad_name(
-    #     member___123abc: '__123abc', # required
+    #   resp = client.operation____789_bad_name(
+    #     member____123abc: '__123abc', # required
     #     member: {
-    #       member___123foo: '__123foo'
+    #       member____123foo: '__123foo'
     #     }
     #   )
     #
     # @example Response structure
     #
-    #   resp #=> Types::Struct__789BadNameOutput
-    #   resp.member #=> Types::Struct__456efg
-    #   resp.member.member___123foo #=> String
+    #   resp #=> Types::Struct____789BadNameOutput
+    #   resp.member #=> Types::Struct____456efg
+    #   resp.member.member____123foo #=> String
     #
-    def operation__789_bad_name(params = {}, options = {}, &block)
+    def operation____789_bad_name(params = {}, options = {}, &block)
       stack = Seahorse::MiddlewareStack.new
-      input = Params::Struct__789BadNameInput.build(params)
+      input = Params::Struct____789BadNameInput.build(params)
       stack.use(Seahorse::Middleware::Validate,
-        validator: Validators::Struct__789BadNameInput,
+        validator: Validators::Struct____789BadNameInput,
         validate_input: options.fetch(:validate_input, @validate_input)
       )
       stack.use(Seahorse::Middleware::Build,
-        builder: Builders::Operation__789BadName
+        builder: Builders::Operation____789BadName
       )
       stack.use(Seahorse::HTTP::Middleware::ContentLength)
       stack.use(Seahorse::Middleware::Parse,
         error_parser: Seahorse::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
-        data_parser: Parsers::Operation__789BadName
+        data_parser: Parsers::Operation____789BadName
       )
       stack.use(Seahorse::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Seahorse::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
-        stub_class: Stubs::Operation__789BadName,
+        stub_class: Stubs::Operation____789BadName,
         stubs: options.fetch(:stubs, @stubs)
       )
       apply_middleware(stack, options[:middleware])
@@ -2099,7 +2099,7 @@ module RailsJson
           response: Seahorse::HTTP::Response.new(body: output_stream(options, &block)),
           params: params,
           logger: @logger,
-          operation_name: :operation__789_bad_name
+          operation_name: :operation____789_bad_name
         )
       )
       raise resp.error if resp.error

--- a/codegen/projections/rails_json/lib/rails_json/params.rb
+++ b/codegen/projections/rails_json/lib/rails_json/params.rb
@@ -773,21 +773,21 @@ module RailsJson
       end
     end
 
-    module Struct__456efg
+    module Struct____456efg
       def self.build(params, context: '')
-        Seahorse::Validator.validate!(params, ::Hash, Types::Struct__456efg, context: context)
-        type = Types::Struct__456efg.new
-        type.member___123foo = params[:member___123foo]
+        Seahorse::Validator.validate!(params, ::Hash, Types::Struct____456efg, context: context)
+        type = Types::Struct____456efg.new
+        type.member____123foo = params[:member____123foo]
         type
       end
     end
 
-    module Struct__789BadNameInput
+    module Struct____789BadNameInput
       def self.build(params, context: '')
-        Seahorse::Validator.validate!(params, ::Hash, Types::Struct__789BadNameInput, context: context)
-        type = Types::Struct__789BadNameInput.new
-        type.member___123abc = params[:member___123abc]
-        type.member = Struct__456efg.build(params[:member], context: "#{context}[:member]") unless params[:member].nil?
+        Seahorse::Validator.validate!(params, ::Hash, Types::Struct____789BadNameInput, context: context)
+        type = Types::Struct____789BadNameInput.new
+        type.member____123abc = params[:member____123abc]
+        type.member = Struct____456efg.build(params[:member], context: "#{context}[:member]") unless params[:member].nil?
         type
       end
     end

--- a/codegen/projections/rails_json/lib/rails_json/parsers.rb
+++ b/codegen/projections/rails_json/lib/rails_json/parsers.rb
@@ -757,19 +757,19 @@ module RailsJson
     end
 
     # Operation Parser for __789BadName
-    class Operation__789BadName
+    class Operation____789BadName
       def self.parse(http_resp)
-        data = Types::Struct__789BadNameOutput.new
+        data = Types::Struct____789BadNameOutput.new
         map = Seahorse::JSON.load(http_resp.body)
-        data.member = Parsers::Struct__456efg.parse(map['member']) if map['member']
+        data.member = Parsers::Struct____456efg.parse(map['member']) if map['member']
         data
       end
     end
 
-    class Struct__456efg
+    class Struct____456efg
       def self.parse(map)
-        data = Types::Struct__456efg.new
-        data.member___123foo = map['__123foo']
+        data = Types::Struct____456efg.new
+        data.member____123foo = map['__123foo']
         return data
       end
     end

--- a/codegen/projections/rails_json/lib/rails_json/stubs.rb
+++ b/codegen/projections/rails_json/lib/rails_json/stubs.rb
@@ -1250,11 +1250,11 @@ module RailsJson
     end
 
     # Operation Stubber for __789BadName
-    class Operation__789BadName
+    class Operation____789BadName
 
       def self.default(visited=[])
         {
-          member: Stubs::Struct__456efg.default(visited),
+          member: Stubs::Struct____456efg.default(visited),
         }
       end
 
@@ -1262,26 +1262,26 @@ module RailsJson
         data = {}
         http_resp.status = 200
         http_resp.headers['Content-Type'] = 'application/json'
-        data[:member] = Stubs::Struct__456efg.stub(stub[:member]) unless stub[:member].nil?
+        data[:member] = Stubs::Struct____456efg.stub(stub[:member]) unless stub[:member].nil?
         http_resp.body = StringIO.new(Seahorse::JSON.dump(data))
       end
     end
 
     # Structure Stubber for __456efg
-    class Struct__456efg
+    class Struct____456efg
 
       def self.default(visited=[])
-        return nil if visited.include?('Struct__456efg')
-        visited = visited + ['Struct__456efg']
+        return nil if visited.include?('Struct____456efg')
+        visited = visited + ['Struct____456efg']
         {
-          member___123foo: 'member___123foo',
+          member____123foo: 'member____123foo',
         }
       end
 
       def self.stub(stub = {})
         stub ||= {}
         data = {}
-        data[:__123foo] = stub[:member___123foo] unless stub[:member___123foo].nil?
+        data[:__123foo] = stub[:member____123foo] unless stub[:member____123foo].nil?
         data
       end
     end

--- a/codegen/projections/rails_json/lib/rails_json/types.rb
+++ b/codegen/projections/rails_json/lib/rails_json/types.rb
@@ -1778,27 +1778,27 @@ module RailsJson
       include Seahorse::Structure
     end
 
-    # @!attribute member___123foo
+    # @!attribute member____123foo
     #
     #   @return [String]
     #
-    Struct__456efg = ::Struct.new(
-      :member___123foo,
+    Struct____456efg = ::Struct.new(
+      :member____123foo,
       keyword_init: true
     ) do
       include Seahorse::Structure
     end
 
-    # @!attribute member___123abc
+    # @!attribute member____123abc
     #
     #   @return [String]
     #
     # @!attribute member
     #
-    #   @return [Struct__456efg]
+    #   @return [Struct____456efg]
     #
-    Struct__789BadNameInput = ::Struct.new(
-      :member___123abc,
+    Struct____789BadNameInput = ::Struct.new(
+      :member____123abc,
       :member,
       keyword_init: true
     ) do
@@ -1807,9 +1807,9 @@ module RailsJson
 
     # @!attribute member
     #
-    #   @return [Struct__456efg]
+    #   @return [Struct____456efg]
     #
-    Struct__789BadNameOutput = ::Struct.new(
+    Struct____789BadNameOutput = ::Struct.new(
       :member,
       keyword_init: true
     ) do

--- a/codegen/projections/rails_json/lib/rails_json/validators.rb
+++ b/codegen/projections/rails_json/lib/rails_json/validators.rb
@@ -706,18 +706,18 @@ module RailsJson
       end
     end
 
-    class Struct__456efg
+    class Struct____456efg
       def self.validate!(input, context:)
-        Seahorse::Validator.validate!(input, Types::Struct__456efg, context: context)
-        Seahorse::Validator.validate!(input[:member___123foo], ::String, context: "#{context}[:member___123foo]")
+        Seahorse::Validator.validate!(input, Types::Struct____456efg, context: context)
+        Seahorse::Validator.validate!(input[:member____123foo], ::String, context: "#{context}[:member____123foo]")
       end
     end
 
-    class Struct__789BadNameInput
+    class Struct____789BadNameInput
       def self.validate!(input, context:)
-        Seahorse::Validator.validate!(input, Types::Struct__789BadNameInput, context: context)
-        Seahorse::Validator.validate!(input[:member___123abc], ::String, context: "#{context}[:member___123abc]")
-        Validators::Struct__456efg.validate!(input[:member], context: "#{context}[:member]") unless input[:member].nil?
+        Seahorse::Validator.validate!(input, Types::Struct____789BadNameInput, context: context)
+        Seahorse::Validator.validate!(input[:member____123abc], ::String, context: "#{context}[:member____123abc]")
+        Validators::Struct____456efg.validate!(input[:member], context: "#{context}[:member]") unless input[:member].nil?
       end
     end
 

--- a/codegen/projections/rails_json/sig/rails_json/client.rbs
+++ b/codegen/projections/rails_json/sig/rails_json/client.rbs
@@ -45,7 +45,7 @@ module RailsJson
     def put_and_get_inline_documents: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
     def query_params_as_string_list_map: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
     def timestamp_format_headers: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
-    def operation__789_bad_name: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
+    def operation____789_bad_name: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
 
   end
 end

--- a/codegen/projections/rails_json/sig/rails_json/types.rbs
+++ b/codegen/projections/rails_json/sig/rails_json/types.rbs
@@ -198,11 +198,11 @@ module RailsJson
 
     TimestampFormatHeadersOutput: untyped
 
-    Struct__456efg: untyped
+    Struct____456efg: untyped
 
-    Struct__789BadNameInput: untyped
+    Struct____789BadNameInput: untyped
 
-    Struct__789BadNameOutput: untyped
+    Struct____789BadNameOutput: untyped
 
   end
 end

--- a/codegen/projections/rails_json/spec/protocol_spec.rb
+++ b/codegen/projections/rails_json/spec/protocol_spec.rb
@@ -14,7 +14,7 @@ module RailsJson
     let(:endpoint) { 'http://127.0.0.1' }
     let(:client) { Client.new(stub_responses: true, endpoint: endpoint) }
 
-    describe '#operation__789_bad_name' do
+    describe '#operation____789_bad_name' do
       describe 'requests' do
         # Serializes requests for operations/members with bad names
         #
@@ -29,10 +29,10 @@ module RailsJson
             expect(JSON.parse(request.body.read)).to eq(JSON.parse('{"member":{"__123foo":"foo value"}}'))
             Seahorse::Output.new
           end
-          client.operation__789_bad_name({
-            member___123abc: "abc_value",
+          client.operation____789_bad_name({
+            member____123abc: "abc_value",
             member: {
-              member___123foo: "foo value"
+              member____123foo: "foo value"
             }
           }, middleware: middleware)
         end
@@ -50,10 +50,10 @@ module RailsJson
             Seahorse::Output.new
           end
           middleware.remove_send.remove_build
-          output = client.operation__789_bad_name({}, middleware: middleware)
+          output = client.operation____789_bad_name({}, middleware: middleware)
           expect(output.to_h).to eq({
             member: {
-              member___123foo: "foo value"
+              member____123foo: "foo value"
             }
           })
         end
@@ -67,15 +67,15 @@ module RailsJson
             expect(response.status).to eq(200)
           end
           middleware.remove_build
-          client.stub_responses(:operation__789_bad_name, {
+          client.stub_responses(:operation____789_bad_name, {
             member: {
-              member___123foo: "foo value"
+              member____123foo: "foo value"
             }
           })
-          output = client.operation__789_bad_name({}, middleware: middleware)
+          output = client.operation____789_bad_name({}, middleware: middleware)
           expect(output.to_h).to eq({
             member: {
-              member___123foo: "foo value"
+              member____123foo: "foo value"
             }
           })
         end

--- a/codegen/projections/weather/lib/weather/builders.rb
+++ b/codegen/projections/weather/lib/weather/builders.rb
@@ -73,13 +73,13 @@ module Weather
     end
 
     # Operation Builder for __789BadName
-    class Operation__789BadName
+    class Operation____789BadName
       def self.build(http_req, input:)
       end
     end
 
     # Structure Builder for __456efg
-    class Struct__456efg
+    class Struct____456efg
       def self.build(input)
         data = {}
         data

--- a/codegen/projections/weather/lib/weather/client.rb
+++ b/codegen/projections/weather/lib/weather/client.rb
@@ -411,45 +411,45 @@ module Weather
     end
 
     # @param [Hash] params
-    #   See {Types::Struct__789BadNameInput}.
+    #   See {Types::Struct____789BadNameInput}.
     #
-    # @return [Types::Struct__789BadNameOutput]
+    # @return [Types::Struct____789BadNameOutput]
     #
     # @example Request syntax with placeholder values
     #
-    #   resp = client.operation__789_bad_name(
-    #     member___123abc: '__123abc', # required
+    #   resp = client.operation____789_bad_name(
+    #     member____123abc: '__123abc', # required
     #     member: {
-    #       member___123foo: '__123foo'
+    #       member____123foo: '__123foo'
     #     }
     #   )
     #
     # @example Response structure
     #
-    #   resp #=> Types::Struct__789BadNameOutput
-    #   resp.member___123abc #=> String
-    #   resp.member #=> Types::Struct__456efg
-    #   resp.member.member___123foo #=> String
+    #   resp #=> Types::Struct____789BadNameOutput
+    #   resp.member____123abc #=> String
+    #   resp.member #=> Types::Struct____456efg
+    #   resp.member.member____123foo #=> String
     #
-    def operation__789_bad_name(params = {}, options = {}, &block)
+    def operation____789_bad_name(params = {}, options = {}, &block)
       stack = Seahorse::MiddlewareStack.new
-      input = Params::Struct__789BadNameInput.build(params)
+      input = Params::Struct____789BadNameInput.build(params)
       stack.use(Seahorse::Middleware::Validate,
-        validator: Validators::Struct__789BadNameInput,
+        validator: Validators::Struct____789BadNameInput,
         validate_input: options.fetch(:validate_input, @validate_input)
       )
       stack.use(Seahorse::Middleware::Build,
-        builder: Builders::Operation__789BadName
+        builder: Builders::Operation____789BadName
       )
       stack.use(Seahorse::HTTP::Middleware::ContentLength)
       stack.use(Seahorse::Middleware::Parse,
         error_parser: Seahorse::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: [Errors::NoSuchResource]),
-        data_parser: Parsers::Operation__789BadName
+        data_parser: Parsers::Operation____789BadName
       )
       stack.use(Seahorse::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Seahorse::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
-        stub_class: Stubs::Operation__789BadName,
+        stub_class: Stubs::Operation____789BadName,
         stubs: options.fetch(:stubs, @stubs)
       )
       apply_middleware(stack, options[:middleware])
@@ -461,7 +461,7 @@ module Weather
           response: Seahorse::HTTP::Response.new(body: output_stream(options, &block)),
           params: params,
           logger: @logger,
-          operation_name: :operation__789_bad_name
+          operation_name: :operation____789_bad_name
         )
       )
       raise resp.error if resp.error

--- a/codegen/projections/weather/lib/weather/params.rb
+++ b/codegen/projections/weather/lib/weather/params.rb
@@ -106,21 +106,21 @@ module Weather
       end
     end
 
-    module Struct__456efg
+    module Struct____456efg
       def self.build(params, context: '')
-        Seahorse::Validator.validate!(params, ::Hash, Types::Struct__456efg, context: context)
-        type = Types::Struct__456efg.new
-        type.member___123foo = params[:member___123foo]
+        Seahorse::Validator.validate!(params, ::Hash, Types::Struct____456efg, context: context)
+        type = Types::Struct____456efg.new
+        type.member____123foo = params[:member____123foo]
         type
       end
     end
 
-    module Struct__789BadNameInput
+    module Struct____789BadNameInput
       def self.build(params, context: '')
-        Seahorse::Validator.validate!(params, ::Hash, Types::Struct__789BadNameInput, context: context)
-        type = Types::Struct__789BadNameInput.new
-        type.member___123abc = params[:member___123abc]
-        type.member = Struct__456efg.build(params[:member], context: "#{context}[:member]") unless params[:member].nil?
+        Seahorse::Validator.validate!(params, ::Hash, Types::Struct____789BadNameInput, context: context)
+        type = Types::Struct____789BadNameInput.new
+        type.member____123abc = params[:member____123abc]
+        type.member = Struct____456efg.build(params[:member], context: "#{context}[:member]") unless params[:member].nil?
         type
       end
     end

--- a/codegen/projections/weather/lib/weather/parsers.rb
+++ b/codegen/projections/weather/lib/weather/parsers.rb
@@ -179,16 +179,16 @@ module Weather
     end
 
     # Operation Parser for __789BadName
-    class Operation__789BadName
+    class Operation____789BadName
       def self.parse(http_resp)
-        data = Types::Struct__789BadNameOutput.new
+        data = Types::Struct____789BadNameOutput.new
         data
       end
     end
 
-    class Struct__456efg
+    class Struct____456efg
       def self.parse(map)
-        data = Types::Struct__456efg.new
+        data = Types::Struct____456efg.new
         return data
       end
     end

--- a/codegen/projections/weather/lib/weather/stubs.rb
+++ b/codegen/projections/weather/lib/weather/stubs.rb
@@ -316,12 +316,12 @@ module Weather
     end
 
     # Operation Stubber for __789BadName
-    class Operation__789BadName
+    class Operation____789BadName
 
       def self.default(visited=[])
         {
-          member___123abc: 'member___123abc',
-          member: Stubs::Struct__456efg.default(visited),
+          member____123abc: 'member____123abc',
+          member: Stubs::Struct____456efg.default(visited),
         }
       end
 
@@ -332,13 +332,13 @@ module Weather
     end
 
     # Structure Stubber for __456efg
-    class Struct__456efg
+    class Struct____456efg
 
       def self.default(visited=[])
-        return nil if visited.include?('Struct__456efg')
-        visited = visited + ['Struct__456efg']
+        return nil if visited.include?('Struct____456efg')
+        visited = visited + ['Struct____456efg']
         {
-          member___123foo: 'member___123foo',
+          member____123foo: 'member____123foo',
         }
       end
 

--- a/codegen/projections/weather/lib/weather/types.rb
+++ b/codegen/projections/weather/lib/weather/types.rb
@@ -557,43 +557,43 @@ module Weather
       end
     end
 
-    # @!attribute member___123foo
+    # @!attribute member____123foo
     #
     #   @return [String]
     #
-    Struct__456efg = ::Struct.new(
-      :member___123foo,
+    Struct____456efg = ::Struct.new(
+      :member____123foo,
       keyword_init: true
     ) do
       include Seahorse::Structure
     end
 
-    # @!attribute member___123abc
+    # @!attribute member____123abc
     #
     #   @return [String]
     #
     # @!attribute member
     #
-    #   @return [Struct__456efg]
+    #   @return [Struct____456efg]
     #
-    Struct__789BadNameInput = ::Struct.new(
-      :member___123abc,
+    Struct____789BadNameInput = ::Struct.new(
+      :member____123abc,
       :member,
       keyword_init: true
     ) do
       include Seahorse::Structure
     end
 
-    # @!attribute member___123abc
+    # @!attribute member____123abc
     #
     #   @return [String]
     #
     # @!attribute member
     #
-    #   @return [Struct__456efg]
+    #   @return [Struct____456efg]
     #
-    Struct__789BadNameOutput = ::Struct.new(
-      :member___123abc,
+    Struct____789BadNameOutput = ::Struct.new(
+      :member____123abc,
       :member,
       keyword_init: true
     ) do

--- a/codegen/projections/weather/lib/weather/validators.rb
+++ b/codegen/projections/weather/lib/weather/validators.rb
@@ -94,18 +94,18 @@ module Weather
       end
     end
 
-    class Struct__456efg
+    class Struct____456efg
       def self.validate!(input, context:)
-        Seahorse::Validator.validate!(input, Types::Struct__456efg, context: context)
-        Seahorse::Validator.validate!(input[:member___123foo], ::String, context: "#{context}[:member___123foo]")
+        Seahorse::Validator.validate!(input, Types::Struct____456efg, context: context)
+        Seahorse::Validator.validate!(input[:member____123foo], ::String, context: "#{context}[:member____123foo]")
       end
     end
 
-    class Struct__789BadNameInput
+    class Struct____789BadNameInput
       def self.validate!(input, context:)
-        Seahorse::Validator.validate!(input, Types::Struct__789BadNameInput, context: context)
-        Seahorse::Validator.validate!(input[:member___123abc], ::String, context: "#{context}[:member___123abc]")
-        Validators::Struct__456efg.validate!(input[:member], context: "#{context}[:member]") unless input[:member].nil?
+        Seahorse::Validator.validate!(input, Types::Struct____789BadNameInput, context: context)
+        Seahorse::Validator.validate!(input[:member____123abc], ::String, context: "#{context}[:member____123abc]")
+        Validators::Struct____456efg.validate!(input[:member], context: "#{context}[:member]") unless input[:member].nil?
       end
     end
 

--- a/codegen/projections/weather/sig/weather/client.rbs
+++ b/codegen/projections/weather/sig/weather/client.rbs
@@ -20,7 +20,7 @@ module Weather
     def get_current_time: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
     def get_forecast: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
     def list_cities: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
-    def operation__789_bad_name: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
+    def operation____789_bad_name: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
 
   end
 end

--- a/codegen/projections/weather/sig/weather/types.rbs
+++ b/codegen/projections/weather/sig/weather/types.rbs
@@ -124,11 +124,11 @@ module Weather
       end
     end
 
-    Struct__456efg: untyped
+    Struct____456efg: untyped
 
-    Struct__789BadNameInput: untyped
+    Struct____789BadNameInput: untyped
 
-    Struct__789BadNameOutput: untyped
+    Struct____789BadNameOutput: untyped
 
   end
 end

--- a/codegen/projections/weather/spec/protocol_spec.rb
+++ b/codegen/projections/weather/spec/protocol_spec.rb
@@ -14,7 +14,7 @@ module Weather
     let(:endpoint) { 'http://127.0.0.1' }
     let(:client) { Client.new(stub_responses: true, endpoint: endpoint) }
 
-    describe '#operation__789_bad_name' do
+    describe '#operation____789_bad_name' do
 
       describe 'NoSuchResource Errors' do
         # Does something

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubyCodeWriter.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubyCodeWriter.java
@@ -90,7 +90,6 @@ public class RubyCodeWriter extends CodeWriter {
      */
     public RubyCodeWriter writeDocstring(String docstring) {
         doc(() -> {
-
             write("$L", docstring);
             write("");
         });

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubySymbolProvider.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubySymbolProvider.java
@@ -144,7 +144,7 @@ public class RubySymbolProvider implements SymbolProvider,
     // If they are a reserved word or start with a number they will be prefixed with “member_”.
     private String getDefaultMemberName(MemberShape shape) {
         return prefixLeadingInvalidIdentCharacters(
-                escaper.escapeMemberName(RubyFormatter.toSnakeCase(shape.getMemberName())), "member_");
+                escaper.escapeMemberName(RubyFormatter.toSnakeCase(shape.getMemberName())), "member__");
     }
 
     // Shape Names (generated Class names) should be PascalCase
@@ -255,7 +255,7 @@ public class RubySymbolProvider implements SymbolProvider,
     @Override
     public Symbol listShape(ListShape shape) {
         if (complexTypes) {
-            return createSymbolBuilder(shape, getDefaultShapeName(shape, "List"), "", "", moduleName)
+            return createSymbolBuilder(shape, getDefaultShapeName(shape, "List__"), "", "", moduleName)
                     .definitionFile("types.rb").build();
         } else {
             Symbol member = toSymbol(model.expectShape(shape.getMember().getTarget()));
@@ -268,7 +268,7 @@ public class RubySymbolProvider implements SymbolProvider,
     @Override
     public Symbol setShape(SetShape shape) {
         if (complexTypes) {
-            return createSymbolBuilder(shape, getDefaultShapeName(shape, "Set"), "", "", moduleName)
+            return createSymbolBuilder(shape, getDefaultShapeName(shape, "Set__"), "", "", moduleName)
                     .definitionFile("types.rb").build();
         } else {
             Symbol member = toSymbol(model.expectShape(shape.getMember().getTarget()));
@@ -281,7 +281,7 @@ public class RubySymbolProvider implements SymbolProvider,
     @Override
     public Symbol mapShape(MapShape shape) {
         if (complexTypes) {
-            return createSymbolBuilder(shape, getDefaultShapeName(shape, "Map"), "", "", moduleName)
+            return createSymbolBuilder(shape, getDefaultShapeName(shape, "Map__"), "", "", moduleName)
                     .definitionFile("types.rb").build();
         } else {
             Symbol key = toSymbol(model.expectShape(shape.getKey().getTarget()));
@@ -297,7 +297,7 @@ public class RubySymbolProvider implements SymbolProvider,
     @Override
     public Symbol documentShape(DocumentShape shape) {
         if (complexTypes) {
-            return createSymbolBuilder(shape, getDefaultShapeName(shape, "Document"), "", "", moduleName)
+            return createSymbolBuilder(shape, getDefaultShapeName(shape, "Document__"), "", "", moduleName)
                     .definitionFile("types.rb").build();
         } else {
             String rbsType = "document"; // alias defined in Seahorse
@@ -315,14 +315,14 @@ public class RubySymbolProvider implements SymbolProvider,
 
     @Override
     public Symbol structureShape(StructureShape shape) {
-        String name = getDefaultShapeName(shape, "Struct");
+        String name = getDefaultShapeName(shape, "Struct__");
         return createSymbolBuilder(shape, name, name, name, moduleName)
                 .definitionFile("types.rb").build();
     }
 
     @Override
     public Symbol unionShape(UnionShape shape) {
-        String name = getDefaultShapeName(shape, "Union");
+        String name = getDefaultShapeName(shape, "Union__");
         return createSymbolBuilder(shape, name, name, name, moduleName)
                 .definitionFile("types.rb").build();
     }
@@ -335,7 +335,7 @@ public class RubySymbolProvider implements SymbolProvider,
 
     @Override
     public Symbol operationShape(OperationShape shape) {
-        return createSymbolBuilder(shape, getDefaultShapeName(shape, "Operation"), "", "", moduleName)
+        return createSymbolBuilder(shape, getDefaultShapeName(shape, "Operation__"), "", "", moduleName)
                 .definitionFile("types.rb").build();
     }
 


### PR DESCRIPTION
For reserved words like `name` this makes sense. Other bad names will look worse.