### PR TITLE
Fix paginator path (and other bad names)

### DIFF
--- a/codegen/projections/white_label/lib/white_label/builders.rb
+++ b/codegen/projections/white_label/lib/white_label/builders.rb
@@ -123,7 +123,7 @@ module WhiteLabel
     end
 
     # Operation Builder for __PaginatorsTestWithBadNames
-    class Operation__PaginatorsTestWithBadNames
+    class Operation____PaginatorsTestWithBadNames
       def self.build(http_req, input:)
       end
     end

--- a/codegen/projections/white_label/lib/white_label/builders.rb
+++ b/codegen/projections/white_label/lib/white_label/builders.rb
@@ -121,5 +121,11 @@ module WhiteLabel
       def self.build(http_req, input:)
       end
     end
+
+    # Operation Builder for __PaginatorsTestWithBadNames
+    class Operation__PaginatorsTestWithBadNames
+      def self.build(http_req, input:)
+      end
+    end
   end
 end

--- a/codegen/projections/white_label/lib/white_label/client.rb
+++ b/codegen/projections/white_label/lib/white_label/client.rb
@@ -481,43 +481,43 @@ module WhiteLabel
     end
 
     # @param [Hash] params
-    #   See {Types::Struct__PaginatorsTestWithBadNamesInput}.
+    #   See {Types::Struct____PaginatorsTestWithBadNamesInput}.
     #
-    # @return [Types::Struct__PaginatorsTestWithBadNamesOutput]
+    # @return [Types::Struct____PaginatorsTestWithBadNamesOutput]
     #
     # @example Request syntax with placeholder values
     #
-    #   resp = client.operation__paginators_test_with_bad_names(
-    #     member___next_token: '__nextToken'
+    #   resp = client.operation____paginators_test_with_bad_names(
+    #     member____next_token: '__nextToken'
     #   )
     #
     # @example Response structure
     #
-    #   resp #=> Types::Struct__PaginatorsTestWithBadNamesOutput
-    #   resp.member___wrapper #=> Types::ResultWrapper
-    #   resp.member___wrapper.member___123next_token #=> String
-    #   resp.member___items #=> Array<String>
-    #   resp.member___items[0] #=> String
+    #   resp #=> Types::Struct____PaginatorsTestWithBadNamesOutput
+    #   resp.member____wrapper #=> Types::ResultWrapper
+    #   resp.member____wrapper.member____123next_token #=> String
+    #   resp.member____items #=> Array<String>
+    #   resp.member____items[0] #=> String
     #
-    def operation__paginators_test_with_bad_names(params = {}, options = {}, &block)
+    def operation____paginators_test_with_bad_names(params = {}, options = {}, &block)
       stack = Seahorse::MiddlewareStack.new
-      input = Params::Struct__PaginatorsTestWithBadNamesInput.build(params)
+      input = Params::Struct____PaginatorsTestWithBadNamesInput.build(params)
       stack.use(Seahorse::Middleware::Validate,
-        validator: Validators::Struct__PaginatorsTestWithBadNamesInput,
+        validator: Validators::Struct____PaginatorsTestWithBadNamesInput,
         validate_input: options.fetch(:validate_input, @validate_input)
       )
       stack.use(Seahorse::Middleware::Build,
-        builder: Builders::Operation__PaginatorsTestWithBadNames
+        builder: Builders::Operation____PaginatorsTestWithBadNames
       )
       stack.use(Seahorse::HTTP::Middleware::ContentLength)
       stack.use(Seahorse::Middleware::Parse,
         error_parser: Seahorse::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
-        data_parser: Parsers::Operation__PaginatorsTestWithBadNames
+        data_parser: Parsers::Operation____PaginatorsTestWithBadNames
       )
       stack.use(Seahorse::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Seahorse::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
-        stub_class: Stubs::Operation__PaginatorsTestWithBadNames,
+        stub_class: Stubs::Operation____PaginatorsTestWithBadNames,
         stubs: options.fetch(:stubs, @stubs)
       )
       apply_middleware(stack, options[:middleware])
@@ -529,7 +529,7 @@ module WhiteLabel
           response: Seahorse::HTTP::Response.new(body: output_stream(options, &block)),
           params: params,
           logger: @logger,
-          operation_name: :operation__paginators_test_with_bad_names
+          operation_name: :operation____paginators_test_with_bad_names
         )
       )
       raise resp.error if resp.error

--- a/codegen/projections/white_label/lib/white_label/client.rb
+++ b/codegen/projections/white_label/lib/white_label/client.rb
@@ -480,6 +480,62 @@ module WhiteLabel
       resp.data
     end
 
+    # @param [Hash] params
+    #   See {Types::Struct__PaginatorsTestWithBadNamesInput}.
+    #
+    # @return [Types::Struct__PaginatorsTestWithBadNamesOutput]
+    #
+    # @example Request syntax with placeholder values
+    #
+    #   resp = client.operation__paginators_test_with_bad_names(
+    #     member___next_token: '__nextToken'
+    #   )
+    #
+    # @example Response structure
+    #
+    #   resp #=> Types::Struct__PaginatorsTestWithBadNamesOutput
+    #   resp.member___wrapper #=> Types::ResultWrapper
+    #   resp.member___wrapper.member___123next_token #=> String
+    #   resp.member___items #=> Array<String>
+    #   resp.member___items[0] #=> String
+    #
+    def operation__paginators_test_with_bad_names(params = {}, options = {}, &block)
+      stack = Seahorse::MiddlewareStack.new
+      input = Params::Struct__PaginatorsTestWithBadNamesInput.build(params)
+      stack.use(Seahorse::Middleware::Validate,
+        validator: Validators::Struct__PaginatorsTestWithBadNamesInput,
+        validate_input: options.fetch(:validate_input, @validate_input)
+      )
+      stack.use(Seahorse::Middleware::Build,
+        builder: Builders::Operation__PaginatorsTestWithBadNames
+      )
+      stack.use(Seahorse::HTTP::Middleware::ContentLength)
+      stack.use(Seahorse::Middleware::Parse,
+        error_parser: Seahorse::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        data_parser: Parsers::Operation__PaginatorsTestWithBadNames
+      )
+      stack.use(Seahorse::Middleware::Send,
+        stub_responses: options.fetch(:stub_responses, @stub_responses),
+        client: Seahorse::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
+        stub_class: Stubs::Operation__PaginatorsTestWithBadNames,
+        stubs: options.fetch(:stubs, @stubs)
+      )
+      apply_middleware(stack, options[:middleware])
+
+      resp = stack.run(
+        input: input,
+        context: Seahorse::Context.new(
+          request: Seahorse::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
+          response: Seahorse::HTTP::Response.new(body: output_stream(options, &block)),
+          params: params,
+          logger: @logger,
+          operation_name: :operation__paginators_test_with_bad_names
+        )
+      )
+      raise resp.error if resp.error
+      resp.data
+    end
+
     private
 
     def apply_middleware(middleware_stack, middleware)

--- a/codegen/projections/white_label/lib/white_label/paginators.rb
+++ b/codegen/projections/white_label/lib/white_label/paginators.rb
@@ -10,40 +10,40 @@
 module WhiteLabel
   module Paginators
 
-    class Operation__PaginatorsTestWithBadNames
+    class Operation____PaginatorsTestWithBadNames
       # @param [Client] client
-      # @param [Hash] params (see Client#operation__paginators_test_with_bad_names)
-      # @param [Hash] options (see Client#operation__paginators_test_with_bad_names)
+      # @param [Hash] params (see Client#operation____paginators_test_with_bad_names)
+      # @param [Hash] options (see Client#operation____paginators_test_with_bad_names)
       def initialize(client, params = {}, options = {})
         @params = params
         @options = options
         @client = client
       end
-      # Iterate all response pages of the operation__paginators_test_with_bad_names operation.
+      # Iterate all response pages of the operation____paginators_test_with_bad_names operation.
       # @return [Enumerator]
       def pages
         params = @params
         Enumerator.new do |e|
-          @prev_token = params[:member___next_token]
-          response = @client.operation__paginators_test_with_bad_names(params, @options)
+          @prev_token = params[:member____next_token]
+          response = @client.operation____paginators_test_with_bad_names(params, @options)
           e.yield(response)
-          output_token = response.member___wrapper&.member___123next_token
+          output_token = response.member____wrapper&.member____123next_token
 
           until output_token.nil? || @prev_token == output_token
-            params = params.merge(member___next_token: output_token)
-            response = @client.operation__paginators_test_with_bad_names(params, @options)
+            params = params.merge(member____next_token: output_token)
+            response = @client.operation____paginators_test_with_bad_names(params, @options)
             e.yield(response)
-            output_token = response.member___wrapper&.member___123next_token
+            output_token = response.member____wrapper&.member____123next_token
           end
         end
       end
 
-      # Iterate all items from pages in the operation__paginators_test_with_bad_names operation.
+      # Iterate all items from pages in the operation____paginators_test_with_bad_names operation.
       # @return [Enumerator]
       def items
         Enumerator.new do |e|
           pages.each do |page|
-            page.member___items.each do |item|
+            page.member____items.each do |item|
               e.yield(item)
             end
           end

--- a/codegen/projections/white_label/lib/white_label/paginators.rb
+++ b/codegen/projections/white_label/lib/white_label/paginators.rb
@@ -10,6 +10,47 @@
 module WhiteLabel
   module Paginators
 
+    class Operation__PaginatorsTestWithBadNames
+      # @param [Client] client
+      # @param [Hash] params (see Client#operation__paginators_test_with_bad_names)
+      # @param [Hash] options (see Client#operation__paginators_test_with_bad_names)
+      def initialize(client, params = {}, options = {})
+        @params = params
+        @options = options
+        @client = client
+      end
+      # Iterate all response pages of the operation__paginators_test_with_bad_names operation.
+      # @return [Enumerator]
+      def pages
+        params = @params
+        Enumerator.new do |e|
+          @prev_token = params[:__next_token]
+          response = @client.operation__paginators_test_with_bad_names(params, @options)
+          e.yield(response)
+          output_token = response.__wrapper.__123next_token
+
+          until output_token.nil? || @prev_token == output_token
+            params = params.merge(__next_token: output_token)
+            response = @client.operation__paginators_test_with_bad_names(params, @options)
+            e.yield(response)
+            output_token = response.__wrapper.__123next_token
+          end
+        end
+      end
+
+      # Iterate all items from pages in the operation__paginators_test_with_bad_names operation.
+      # @return [Enumerator]
+      def items
+        Enumerator.new do |e|
+          pages.each do |page|
+            page.__items.each do |item|
+              e.yield(item)
+            end
+          end
+        end
+      end
+    end
+
     class PaginatorsTest
       # @param [Client] client
       # @param [Hash] params (see Client#paginators_test)

--- a/codegen/projections/white_label/lib/white_label/paginators.rb
+++ b/codegen/projections/white_label/lib/white_label/paginators.rb
@@ -24,16 +24,16 @@ module WhiteLabel
       def pages
         params = @params
         Enumerator.new do |e|
-          @prev_token = params[:__next_token]
+          @prev_token = params[:member___next_token]
           response = @client.operation__paginators_test_with_bad_names(params, @options)
           e.yield(response)
-          output_token = response.__wrapper.__123next_token
+          output_token = response.member___wrapper&.member___123next_token
 
           until output_token.nil? || @prev_token == output_token
-            params = params.merge(__next_token: output_token)
+            params = params.merge(member___next_token: output_token)
             response = @client.operation__paginators_test_with_bad_names(params, @options)
             e.yield(response)
-            output_token = response.__wrapper.__123next_token
+            output_token = response.member___wrapper&.member___123next_token
           end
         end
       end
@@ -43,7 +43,7 @@ module WhiteLabel
       def items
         Enumerator.new do |e|
           pages.each do |page|
-            page.__items.each do |item|
+            page.member___items.each do |item|
               e.yield(item)
             end
           end

--- a/codegen/projections/white_label/lib/white_label/params.rb
+++ b/codegen/projections/white_label/lib/white_label/params.rb
@@ -155,5 +155,14 @@ module WhiteLabel
       end
     end
 
+    module Struct__PaginatorsTestWithBadNamesInput
+      def self.build(params, context: '')
+        Seahorse::Validator.validate!(params, ::Hash, Types::Struct__PaginatorsTestWithBadNamesInput, context: context)
+        type = Types::Struct__PaginatorsTestWithBadNamesInput.new
+        type.member___next_token = params[:member___next_token]
+        type
+      end
+    end
+
   end
 end

--- a/codegen/projections/white_label/lib/white_label/params.rb
+++ b/codegen/projections/white_label/lib/white_label/params.rb
@@ -155,11 +155,11 @@ module WhiteLabel
       end
     end
 
-    module Struct__PaginatorsTestWithBadNamesInput
+    module Struct____PaginatorsTestWithBadNamesInput
       def self.build(params, context: '')
-        Seahorse::Validator.validate!(params, ::Hash, Types::Struct__PaginatorsTestWithBadNamesInput, context: context)
-        type = Types::Struct__PaginatorsTestWithBadNamesInput.new
-        type.member___next_token = params[:member___next_token]
+        Seahorse::Validator.validate!(params, ::Hash, Types::Struct____PaginatorsTestWithBadNamesInput, context: context)
+        type = Types::Struct____PaginatorsTestWithBadNamesInput.new
+        type.member____next_token = params[:member____next_token]
         type
       end
     end

--- a/codegen/projections/white_label/lib/white_label/parsers.rb
+++ b/codegen/projections/white_label/lib/white_label/parsers.rb
@@ -135,5 +135,20 @@ module WhiteLabel
         data
       end
     end
+
+    # Operation Parser for __PaginatorsTestWithBadNames
+    class Operation__PaginatorsTestWithBadNames
+      def self.parse(http_resp)
+        data = Types::Struct__PaginatorsTestWithBadNamesOutput.new
+        data
+      end
+    end
+
+    class ResultWrapper
+      def self.parse(map)
+        data = Types::ResultWrapper.new
+        return data
+      end
+    end
   end
 end

--- a/codegen/projections/white_label/lib/white_label/parsers.rb
+++ b/codegen/projections/white_label/lib/white_label/parsers.rb
@@ -137,9 +137,9 @@ module WhiteLabel
     end
 
     # Operation Parser for __PaginatorsTestWithBadNames
-    class Operation__PaginatorsTestWithBadNames
+    class Operation____PaginatorsTestWithBadNames
       def self.parse(http_resp)
-        data = Types::Struct__PaginatorsTestWithBadNamesOutput.new
+        data = Types::Struct____PaginatorsTestWithBadNamesOutput.new
         data
       end
     end

--- a/codegen/projections/white_label/lib/white_label/stubs.rb
+++ b/codegen/projections/white_label/lib/white_label/stubs.rb
@@ -250,12 +250,12 @@ module WhiteLabel
     end
 
     # Operation Stubber for __PaginatorsTestWithBadNames
-    class Operation__PaginatorsTestWithBadNames
+    class Operation____PaginatorsTestWithBadNames
 
       def self.default(visited=[])
         {
-          member___wrapper: Stubs::ResultWrapper.default(visited),
-          member___items: Stubs::Items.default(visited),
+          member____wrapper: Stubs::ResultWrapper.default(visited),
+          member____items: Stubs::Items.default(visited),
         }
       end
 
@@ -271,7 +271,7 @@ module WhiteLabel
         return nil if visited.include?('ResultWrapper')
         visited = visited + ['ResultWrapper']
         {
-          member___123next_token: 'member___123next_token',
+          member____123next_token: 'member____123next_token',
         }
       end
 

--- a/codegen/projections/white_label/lib/white_label/stubs.rb
+++ b/codegen/projections/white_label/lib/white_label/stubs.rb
@@ -248,5 +248,38 @@ module WhiteLabel
         data = {}
       end
     end
+
+    # Operation Stubber for __PaginatorsTestWithBadNames
+    class Operation__PaginatorsTestWithBadNames
+
+      def self.default(visited=[])
+        {
+          member___wrapper: Stubs::ResultWrapper.default(visited),
+          member___items: Stubs::Items.default(visited),
+        }
+      end
+
+      def self.stub(http_resp, stub:)
+        data = {}
+      end
+    end
+
+    # Structure Stubber for ResultWrapper
+    class ResultWrapper
+
+      def self.default(visited=[])
+        return nil if visited.include?('ResultWrapper')
+        visited = visited + ['ResultWrapper']
+        {
+          member___123next_token: 'member___123next_token',
+        }
+      end
+
+      def self.stub(stub = {})
+        stub ||= {}
+        data = {}
+        data
+      end
+    end
   end
 end

--- a/codegen/projections/white_label/lib/white_label/types.rb
+++ b/codegen/projections/white_label/lib/white_label/types.rb
@@ -357,6 +357,17 @@ module WhiteLabel
       include Seahorse::Structure
     end
 
+    # @!attribute member___123next_token
+    #
+    #   @return [String]
+    #
+    ResultWrapper = ::Struct.new(
+      :member___123next_token,
+      keyword_init: true
+    ) do
+      include Seahorse::Structure
+    end
+
     ServerError = ::Struct.new(
       nil,
       keyword_init: true
@@ -520,6 +531,33 @@ module WhiteLabel
     #
     WaitersTestOutput = ::Struct.new(
       :status,
+      keyword_init: true
+    ) do
+      include Seahorse::Structure
+    end
+
+    # @!attribute member___next_token
+    #
+    #   @return [String]
+    #
+    Struct__PaginatorsTestWithBadNamesInput = ::Struct.new(
+      :member___next_token,
+      keyword_init: true
+    ) do
+      include Seahorse::Structure
+    end
+
+    # @!attribute member___wrapper
+    #
+    #   @return [ResultWrapper]
+    #
+    # @!attribute member___items
+    #
+    #   @return [Array<String>]
+    #
+    Struct__PaginatorsTestWithBadNamesOutput = ::Struct.new(
+      :member___wrapper,
+      :member___items,
       keyword_init: true
     ) do
       include Seahorse::Structure

--- a/codegen/projections/white_label/lib/white_label/types.rb
+++ b/codegen/projections/white_label/lib/white_label/types.rb
@@ -357,12 +357,12 @@ module WhiteLabel
       include Seahorse::Structure
     end
 
-    # @!attribute member___123next_token
+    # @!attribute member____123next_token
     #
     #   @return [String]
     #
     ResultWrapper = ::Struct.new(
-      :member___123next_token,
+      :member____123next_token,
       keyword_init: true
     ) do
       include Seahorse::Structure
@@ -536,28 +536,28 @@ module WhiteLabel
       include Seahorse::Structure
     end
 
-    # @!attribute member___next_token
+    # @!attribute member____next_token
     #
     #   @return [String]
     #
-    Struct__PaginatorsTestWithBadNamesInput = ::Struct.new(
-      :member___next_token,
+    Struct____PaginatorsTestWithBadNamesInput = ::Struct.new(
+      :member____next_token,
       keyword_init: true
     ) do
       include Seahorse::Structure
     end
 
-    # @!attribute member___wrapper
+    # @!attribute member____wrapper
     #
     #   @return [ResultWrapper]
     #
-    # @!attribute member___items
+    # @!attribute member____items
     #
     #   @return [Array<String>]
     #
-    Struct__PaginatorsTestWithBadNamesOutput = ::Struct.new(
-      :member___wrapper,
-      :member___items,
+    Struct____PaginatorsTestWithBadNamesOutput = ::Struct.new(
+      :member____wrapper,
+      :member____items,
       keyword_init: true
     ) do
       include Seahorse::Structure

--- a/codegen/projections/white_label/lib/white_label/validators.rb
+++ b/codegen/projections/white_label/lib/white_label/validators.rb
@@ -153,10 +153,10 @@ module WhiteLabel
       end
     end
 
-    class Struct__PaginatorsTestWithBadNamesInput
+    class Struct____PaginatorsTestWithBadNamesInput
       def self.validate!(input, context:)
-        Seahorse::Validator.validate!(input, Types::Struct__PaginatorsTestWithBadNamesInput, context: context)
-        Seahorse::Validator.validate!(input[:member___next_token], ::String, context: "#{context}[:member___next_token]")
+        Seahorse::Validator.validate!(input, Types::Struct____PaginatorsTestWithBadNamesInput, context: context)
+        Seahorse::Validator.validate!(input[:member____next_token], ::String, context: "#{context}[:member____next_token]")
       end
     end
 

--- a/codegen/projections/white_label/lib/white_label/validators.rb
+++ b/codegen/projections/white_label/lib/white_label/validators.rb
@@ -153,5 +153,12 @@ module WhiteLabel
       end
     end
 
+    class Struct__PaginatorsTestWithBadNamesInput
+      def self.validate!(input, context:)
+        Seahorse::Validator.validate!(input, Types::Struct__PaginatorsTestWithBadNamesInput, context: context)
+        Seahorse::Validator.validate!(input[:member___next_token], ::String, context: "#{context}[:member___next_token]")
+      end
+    end
+
   end
 end

--- a/codegen/projections/white_label/sig/white_label/client.rbs
+++ b/codegen/projections/white_label/sig/white_label/client.rbs
@@ -18,6 +18,7 @@ module WhiteLabel
     def paginators_test: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
     def paginators_test_with_items: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
     def waiters_test: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
+    def operation__paginators_test_with_bad_names: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
 
   end
 end

--- a/codegen/projections/white_label/sig/white_label/client.rbs
+++ b/codegen/projections/white_label/sig/white_label/client.rbs
@@ -18,7 +18,7 @@ module WhiteLabel
     def paginators_test: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
     def paginators_test_with_items: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
     def waiters_test: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
-    def operation__paginators_test_with_bad_names: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
+    def operation____paginators_test_with_bad_names: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
 
   end
 end

--- a/codegen/projections/white_label/sig/white_label/paginators.rbs
+++ b/codegen/projections/white_label/sig/white_label/paginators.rbs
@@ -10,6 +10,13 @@
 module WhiteLabel
   module Paginators
 
+    class Operation__PaginatorsTestWithBadNames
+      def initialize: (untyped client, ?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options) -> void
+
+      def pages: () -> untyped
+      def items: () -> untyped
+    end
+
     class PaginatorsTest
       def initialize: (untyped client, ?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options) -> void
 

--- a/codegen/projections/white_label/sig/white_label/paginators.rbs
+++ b/codegen/projections/white_label/sig/white_label/paginators.rbs
@@ -10,7 +10,7 @@
 module WhiteLabel
   module Paginators
 
-    class Operation__PaginatorsTestWithBadNames
+    class Operation____PaginatorsTestWithBadNames
       def initialize: (untyped client, ?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options) -> void
 
       def pages: () -> untyped

--- a/codegen/projections/white_label/sig/white_label/types.rbs
+++ b/codegen/projections/white_label/sig/white_label/types.rbs
@@ -24,6 +24,8 @@ module WhiteLabel
 
     PaginatorsTestWithItemsOutput: untyped
 
+    ResultWrapper: untyped
+
     ServerError: untyped
 
     Struct: untyped
@@ -45,6 +47,10 @@ module WhiteLabel
     WaitersTestInput: untyped
 
     WaitersTestOutput: untyped
+
+    Struct__PaginatorsTestWithBadNamesInput: untyped
+
+    Struct__PaginatorsTestWithBadNamesOutput: untyped
 
   end
 end

--- a/codegen/projections/white_label/sig/white_label/types.rbs
+++ b/codegen/projections/white_label/sig/white_label/types.rbs
@@ -48,9 +48,9 @@ module WhiteLabel
 
     WaitersTestOutput: untyped
 
-    Struct__PaginatorsTestWithBadNamesInput: untyped
+    Struct____PaginatorsTestWithBadNamesInput: untyped
 
-    Struct__PaginatorsTestWithBadNamesOutput: untyped
+    Struct____PaginatorsTestWithBadNamesOutput: untyped
 
   end
 end

--- a/codegen/projections/white_label/spec/paginators_spec.rb
+++ b/codegen/projections/white_label/spec/paginators_spec.rb
@@ -96,22 +96,22 @@ module WhiteLabel
       end
     end
 
-    describe '__PaginatorsTestWithBadNames' do
+    describe Operation____PaginatorsTestWithBadNames do
       let(:client) { double('Client') }
       let(:params) { { param: 'param' } }
       let(:options) { { stub_responses: true } }
 
-      subject { Operation___PaginatorsTestWithBadNames.new(client, params, options) }
+      subject { Operation____PaginatorsTestWithBadNames.new(client, params, options) }
       let(:response_1) do
-        Types::Struct__PaginatorsTestWithBadNamesOutput.new(
-          member___wrapper: Types::ResultWrapper.new(member___123next_token: 'foo'), member___items: ['a', 'b', 'c'])
+        Types::Struct____PaginatorsTestWithBadNamesOutput.new(
+          member____wrapper: Types::ResultWrapper.new(member____123next_token: 'foo'), member____items: ['a', 'b', 'c'])
       end
       let(:response_2) do
         Types::Struct__PaginatorsTestWithBadNamesOutput.new(
-          member___wrapper: Types::ResultWrapper.new(member___123next_token: 'bar'), member___items: ['1', '2', '3'])
+          member____wrapper: Types::ResultWrapper.new(member____123next_token: 'bar'), member____items: ['1', '2', '3'])
       end
       let(:response_3) do
-        Types::Struct__PaginatorsTestWithBadNamesOutput.new(member___items: ['the end'])
+        Types::Struct__PaginatorsTestWithBadNamesOutput.new(member____items: ['the end'])
       end
 
       describe '.pages' do
@@ -120,12 +120,12 @@ module WhiteLabel
 
       describe '#items' do
         it 'yields items from paged response data' do
-          expect(client).to receive(:operation__paginators_test_with_bad_names)
+          expect(client).to receive(:operation____paginators_test_with_bad_names)
                               .with({ param: 'param' }, options).and_return(response_1)
-          expect(client).to receive(:operation__paginators_test_with_bad_names)
-                              .with({ param: 'param', member___next_token: 'foo' }, options).and_return(response_2)
-          expect(client).to receive(:operation__paginators_test_with_bad_names)
-                              .with({ param: 'param', member___next_token: 'bar' }, options).and_return(response_3)
+          expect(client).to receive(:operation____paginators_test_with_bad_names)
+                              .with({ param: 'param', member____next_token: 'foo' }, options).and_return(response_2)
+          expect(client).to receive(:operation____paginators_test_with_bad_names)
+                              .with({ param: 'param', member____next_token: 'bar' }, options).and_return(response_3)
 
           paginator = subject.items
           expect(paginator).to be_a(Enumerator)

--- a/codegen/projections/white_label/spec/paginators_spec.rb
+++ b/codegen/projections/white_label/spec/paginators_spec.rb
@@ -95,5 +95,45 @@ module WhiteLabel
         end
       end
     end
+
+    describe Operation__PaginatorsTestWithBadNames do
+      let(:client) { double('Client') }
+      let(:params) { { param: 'param' } }
+      let(:options) { { stub_responses: true } }
+
+      subject { Operation__PaginatorsTestWithBadNames.new(client, params, options) }
+      let(:response_1) do
+        Types::Struct__PaginatorsTestWithBadNamesOutput.new(
+          member___wrapper: Types::ResultWrapper.new(member___123next_token: 'foo'), member___items: ['a', 'b', 'c'])
+      end
+      let(:response_2) do
+        Types::Struct__PaginatorsTestWithBadNamesOutput.new(
+          member___wrapper: Types::ResultWrapper.new(member___123next_token: 'bar'), member___items: ['1', '2', '3'])
+      end
+      let(:response_3) do
+        Types::Struct__PaginatorsTestWithBadNamesOutput.new(member___items: ['the end'])
+      end
+
+      describe '.pages' do
+        # skip, already tested with PaginatorsTest.pages
+      end
+
+      describe '#items' do
+        it 'yields items from paged response data' do
+          expect(client).to receive(:operation__paginators_test_with_bad_names)
+                              .with({ param: 'param' }, options).and_return(response_1)
+          expect(client).to receive(:operation__paginators_test_with_bad_names)
+                              .with({ param: 'param', member___next_token: 'foo' }, options).and_return(response_2)
+          expect(client).to receive(:operation__paginators_test_with_bad_names)
+                              .with({ param: 'param', member___next_token: 'bar' }, options).and_return(response_3)
+
+          paginator = subject.items
+          expect(paginator).to be_a(Enumerator)
+          items = paginator.to_a
+          expect(items).to eq(['a', 'b', 'c', '1', '2', '3', 'the end'])
+        end
+      end
+    end
+
   end
 end

--- a/codegen/projections/white_label/spec/paginators_spec.rb
+++ b/codegen/projections/white_label/spec/paginators_spec.rb
@@ -96,12 +96,12 @@ module WhiteLabel
       end
     end
 
-    describe Operation__PaginatorsTestWithBadNames do
+    describe '__PaginatorsTestWithBadNames' do
       let(:client) { double('Client') }
       let(:params) { { param: 'param' } }
       let(:options) { { stub_responses: true } }
 
-      subject { Operation__PaginatorsTestWithBadNames.new(client, params, options) }
+      subject { Operation___PaginatorsTestWithBadNames.new(client, params, options) }
       let(:response_1) do
         Types::Struct__PaginatorsTestWithBadNamesOutput.new(
           member___wrapper: Types::ResultWrapper.new(member___123next_token: 'foo'), member___items: ['a', 'b', 'c'])

--- a/codegen/projections/white_label/spec/protocol_spec.rb
+++ b/codegen/projections/white_label/spec/protocol_spec.rb
@@ -14,6 +14,9 @@ module WhiteLabel
     let(:endpoint) { 'http://127.0.0.1' }
     let(:client) { Client.new(stub_responses: true, endpoint: endpoint) }
 
+    describe '#operation__paginators_test_with_bad_names' do
+
+    end
     describe '#kitchen_sink' do
 
     end

--- a/codegen/projections/white_label/spec/protocol_spec.rb
+++ b/codegen/projections/white_label/spec/protocol_spec.rb
@@ -14,7 +14,7 @@ module WhiteLabel
     let(:endpoint) { 'http://127.0.0.1' }
     let(:client) { Client.new(stub_responses: true, endpoint: endpoint) }
 
-    describe '#operation__paginators_test_with_bad_names' do
+    describe '#operation____paginators_test_with_bad_names' do
 
     end
     describe '#kitchen_sink' do

--- a/codegen/smithy-ruby-codegen-test/integration-specs/paginators_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/paginators_spec.rb
@@ -96,12 +96,12 @@ module WhiteLabel
       end
     end
 
-    describe Operation___PaginatorsTestWithBadNames do
+    describe '__PaginatorsTestWithBadNames' do
       let(:client) { double('Client') }
       let(:params) { { param: 'param' } }
       let(:options) { { stub_responses: true } }
 
-      subject { Operation___PaginatorsTestWithBadNames.new(client, params, options) }
+      subject { Operation__PaginatorsTestWithBadNames.new(client, params, options) }
       let(:response_1) do
         Types::Struct__PaginatorsTestWithBadNamesOutput.new(
           member___wrapper: Types::ResultWrapper.new(member___123next_token: 'foo'), member___items: ['a', 'b', 'c'])

--- a/codegen/smithy-ruby-codegen-test/integration-specs/paginators_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/paginators_spec.rb
@@ -95,5 +95,45 @@ module WhiteLabel
         end
       end
     end
+
+    describe Operation__PaginatorsTestWithBadNames do
+      let(:client) { double('Client') }
+      let(:params) { { param: 'param' } }
+      let(:options) { { stub_responses: true } }
+
+      subject { Operation__PaginatorsTestWithBadNames.new(client, params, options) }
+      let(:response_1) do
+        Types::Struct__PaginatorsTestWithBadNamesOutput.new(
+          member___wrapper: Types::ResultWrapper.new(member___123next_token: 'foo'), member___items: ['a', 'b', 'c'])
+      end
+      let(:response_2) do
+        Types::Struct__PaginatorsTestWithBadNamesOutput.new(
+          member___wrapper: Types::ResultWrapper.new(member___123next_token: 'bar'), member___items: ['1', '2', '3'])
+      end
+      let(:response_3) do
+        Types::Struct__PaginatorsTestWithBadNamesOutput.new(member___items: ['the end'])
+      end
+
+      describe '.pages' do
+        # skip, already tested with PaginatorsTest.pages
+      end
+
+      describe '#items' do
+        it 'yields items from paged response data' do
+          expect(client).to receive(:operation__paginators_test_with_bad_names)
+                              .with({ param: 'param' }, options).and_return(response_1)
+          expect(client).to receive(:operation__paginators_test_with_bad_names)
+                              .with({ param: 'param', member___next_token: 'foo' }, options).and_return(response_2)
+          expect(client).to receive(:operation__paginators_test_with_bad_names)
+                              .with({ param: 'param', member___next_token: 'bar' }, options).and_return(response_3)
+
+          paginator = subject.items
+          expect(paginator).to be_a(Enumerator)
+          items = paginator.to_a
+          expect(items).to eq(['a', 'b', 'c', '1', '2', '3', 'the end'])
+        end
+      end
+    end
+
   end
 end

--- a/codegen/smithy-ruby-codegen-test/integration-specs/paginators_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/paginators_spec.rb
@@ -96,12 +96,12 @@ module WhiteLabel
       end
     end
 
-    describe Operation__PaginatorsTestWithBadNames do
+    describe Operation___PaginatorsTestWithBadNames do
       let(:client) { double('Client') }
       let(:params) { { param: 'param' } }
       let(:options) { { stub_responses: true } }
 
-      subject { Operation__PaginatorsTestWithBadNames.new(client, params, options) }
+      subject { Operation___PaginatorsTestWithBadNames.new(client, params, options) }
       let(:response_1) do
         Types::Struct__PaginatorsTestWithBadNamesOutput.new(
           member___wrapper: Types::ResultWrapper.new(member___123next_token: 'foo'), member___items: ['a', 'b', 'c'])

--- a/codegen/smithy-ruby-codegen-test/integration-specs/paginators_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/paginators_spec.rb
@@ -96,22 +96,22 @@ module WhiteLabel
       end
     end
 
-    describe '__PaginatorsTestWithBadNames' do
+    describe Operation____PaginatorsTestWithBadNames do
       let(:client) { double('Client') }
       let(:params) { { param: 'param' } }
       let(:options) { { stub_responses: true } }
 
-      subject { Operation__PaginatorsTestWithBadNames.new(client, params, options) }
+      subject { Operation____PaginatorsTestWithBadNames.new(client, params, options) }
       let(:response_1) do
-        Types::Struct__PaginatorsTestWithBadNamesOutput.new(
-          member___wrapper: Types::ResultWrapper.new(member___123next_token: 'foo'), member___items: ['a', 'b', 'c'])
+        Types::Struct____PaginatorsTestWithBadNamesOutput.new(
+          member____wrapper: Types::ResultWrapper.new(member____123next_token: 'foo'), member____items: ['a', 'b', 'c'])
       end
       let(:response_2) do
-        Types::Struct__PaginatorsTestWithBadNamesOutput.new(
-          member___wrapper: Types::ResultWrapper.new(member___123next_token: 'bar'), member___items: ['1', '2', '3'])
+        Types::Struct____PaginatorsTestWithBadNamesOutput.new(
+          member____wrapper: Types::ResultWrapper.new(member____123next_token: 'bar'), member____items: ['1', '2', '3'])
       end
       let(:response_3) do
-        Types::Struct__PaginatorsTestWithBadNamesOutput.new(member___items: ['the end'])
+        Types::Struct____PaginatorsTestWithBadNamesOutput.new(member____items: ['the end'])
       end
 
       describe '.pages' do
@@ -120,12 +120,12 @@ module WhiteLabel
 
       describe '#items' do
         it 'yields items from paged response data' do
-          expect(client).to receive(:operation__paginators_test_with_bad_names)
+          expect(client).to receive(:operation____paginators_test_with_bad_names)
                               .with({ param: 'param' }, options).and_return(response_1)
-          expect(client).to receive(:operation__paginators_test_with_bad_names)
-                              .with({ param: 'param', member___next_token: 'foo' }, options).and_return(response_2)
-          expect(client).to receive(:operation__paginators_test_with_bad_names)
-                              .with({ param: 'param', member___next_token: 'bar' }, options).and_return(response_3)
+          expect(client).to receive(:operation____paginators_test_with_bad_names)
+                              .with({ param: 'param', member____next_token: 'foo' }, options).and_return(response_2)
+          expect(client).to receive(:operation____paginators_test_with_bad_names)
+                              .with({ param: 'param', member____next_token: 'bar' }, options).and_return(response_3)
 
           paginator = subject.items
           expect(paginator).to be_a(Enumerator)

--- a/codegen/smithy-ruby-codegen-test/model/component-test/main.smithy
+++ b/codegen/smithy-ruby-codegen-test/model/component-test/main.smithy
@@ -11,6 +11,7 @@ service WhiteLabel {
         KitchenSink,
         PaginatorsTest,
         PaginatorsTestWithItems,
+        __PaginatorsTestWithBadNames,
         WaitersTest
     ]
 }

--- a/codegen/smithy-ruby-codegen-test/model/component-test/paginators.smithy
+++ b/codegen/smithy-ruby-codegen-test/model/component-test/paginators.smithy
@@ -22,6 +22,25 @@ structure PaginatorsTestOutput {
     items: Items
 }
 
+@paginated(inputToken: "__nextToken", outputToken: "__wrapper.__123nextToken", items: "__items")
+operation __PaginatorsTestWithBadNames {
+    input: __PaginatorsTestWithBadNamesInput,
+    output: __PaginatorsTestWithBadNamesOutput
+}
+
+structure __PaginatorsTestWithBadNamesInput {
+    __nextToken: String
+}
+
+structure __PaginatorsTestWithBadNamesOutput {
+    __wrapper: ResultWrapper,
+    __items: Items
+}
+
+structure ResultWrapper {
+    __123nextToken: String
+}
+
 list Items {
     member: String
 }

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/PaginatorsGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/PaginatorsGenerator.java
@@ -164,10 +164,10 @@ public class PaginatorsGenerator {
     }
 
     private void renderPaginatorPages(String operationName, PaginationInfo paginationInfo) {
-        String inputToken = RubyFormatter.toSnakeCase(paginationInfo.getInputTokenMember().getMemberName());
+        String inputToken = symbolProvider.toMemberName(paginationInfo.getInputTokenMember());
         String outputToken = paginationInfo.getOutputTokenMemberPath().stream()
-                .map((member) -> RubyFormatter.toSnakeCase(member.getMemberName()))
-                .collect(Collectors.joining("."));
+                .map((member) -> symbolProvider.toMemberName(member))
+                .collect(Collectors.joining("&."));
         String snakeOperationName = RubyFormatter.toSnakeCase(operationName);
 
         writer
@@ -198,8 +198,8 @@ public class PaginatorsGenerator {
 
     private void renderPaginatorItems(PaginationInfo paginationInfo, String operationName) {
         String items = paginationInfo.getItemsMemberPath().stream()
-                .map((member) -> RubyFormatter.toSnakeCase(member.getMemberName()))
-                .collect(Collectors.joining("."));
+                .map((member) -> symbolProvider.toMemberName(member))
+                .collect(Collectors.joining("&."));
 
         writer
                 .write("")


### PR DESCRIPTION
*Description of changes:*
Use the symbolProvider for all symbol/member names when generating paginators.

Additionally - when building paths for outputTokens and items, join with "&." to handle nil/empty structures.

Note - to see the codegen change for the paginator fix only, diff against the first commit (The first commit adds only the model changes).  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
