### PR TITLE
Add query param matcher

### DIFF
--- a/codegen/projections/high_score_service/spec/protocol_spec.rb
+++ b/codegen/projections/high_score_service/spec/protocol_spec.rb
@@ -10,6 +10,7 @@
 require 'high_score_service'
 
 require 'hearth/xml/node_matcher'
+require 'hearth/query/param_matcher'
 
 module HighScoreService
   describe Client do

--- a/codegen/projections/rails_json/spec/protocol_spec.rb
+++ b/codegen/projections/rails_json/spec/protocol_spec.rb
@@ -10,6 +10,7 @@
 require 'rails_json'
 
 require 'hearth/xml/node_matcher'
+require 'hearth/query/param_matcher'
 
 module RailsJson
   describe Client do

--- a/codegen/projections/weather/spec/protocol_spec.rb
+++ b/codegen/projections/weather/spec/protocol_spec.rb
@@ -10,6 +10,7 @@
 require 'weather'
 
 require 'hearth/xml/node_matcher'
+require 'hearth/query/param_matcher'
 
 module Weather
   describe Client do

--- a/codegen/projections/white_label/spec/protocol_spec.rb
+++ b/codegen/projections/white_label/spec/protocol_spec.rb
@@ -10,6 +10,7 @@
 require 'white_label'
 
 require 'hearth/xml/node_matcher'
+require 'hearth/query/param_matcher'
 
 module WhiteLabel
   describe Client do

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ErrorsGeneratorBase.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ErrorsGeneratorBase.java
@@ -15,9 +15,9 @@
 
 package software.amazon.smithy.ruby.codegen.generators;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import software.amazon.smithy.build.FileManifest;
@@ -52,7 +52,7 @@ public abstract class ErrorsGeneratorBase {
     protected final RubyCodeWriter writer;
     protected final RubyCodeWriter rbsWriter;
     protected final SymbolProvider symbolProvider;
-    protected final Set<Shape> errorShapes;
+    protected final ArrayList<Shape> errorShapes;
 
     public ErrorsGeneratorBase(GenerationContext context) {
         this.context = context;
@@ -152,14 +152,17 @@ public abstract class ErrorsGeneratorBase {
         rbsWriter.write("def self.error_code: (untyped http_resp) -> untyped");
     }
 
-    protected Set<Shape> getErrorShapes() {
+    protected ArrayList<Shape> getErrorShapes() {
         TopDownIndex topDownIndex = TopDownIndex.of(model);
 
         return topDownIndex.getContainedOperations(context.getService()).stream()
                 .map(OperationShape::getErrors)
                 .flatMap(Collection::stream)
                 .map(model::expectShape)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toSet())
+                .stream()
+                .sorted()
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     private void renderServiceModelErrors() {

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ErrorsGeneratorBase.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ErrorsGeneratorBase.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.ruby.codegen.generators;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.List;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import software.amazon.smithy.build.FileManifest;
@@ -52,7 +53,7 @@ public abstract class ErrorsGeneratorBase {
     protected final RubyCodeWriter writer;
     protected final RubyCodeWriter rbsWriter;
     protected final SymbolProvider symbolProvider;
-    protected final ArrayList<Shape> errorShapes;
+    protected final List<Shape> errorShapes;
 
     public ErrorsGeneratorBase(GenerationContext context) {
         this.context = context;
@@ -152,7 +153,7 @@ public abstract class ErrorsGeneratorBase {
         rbsWriter.write("def self.error_code: (untyped http_resp) -> untyped");
     }
 
-    protected ArrayList<Shape> getErrorShapes() {
+    protected List<Shape> getErrorShapes() {
         TopDownIndex topDownIndex = TopDownIndex.of(model);
 
         return topDownIndex.getContainedOperations(context.getService()).stream()

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/HttpProtocolTestGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/HttpProtocolTestGenerator.java
@@ -71,6 +71,7 @@ public class HttpProtocolTestGenerator {
                 .writePreamble()
                 .write("require '$L'\n", settings.getGemName())
                 .write("require 'hearth/xml/node_matcher'")
+                .write("require 'hearth/query/param_matcher'")
                 .write("")
                 .openBlock("module $L", settings.getModule())
                 .openBlock("describe Client do")
@@ -337,8 +338,10 @@ public class HttpProtocolTestGenerator {
                         }
                         break;
                     case "application/x-www-form-urlencoded":
-                        // query params in the body - parse and compare
-                        writer.write("expect(CGI.parse(request.body.read)).to eq(CGI.parse('$L'))", body.get());
+                        writer
+                                .write("expect(CGI.parse(request.body.read)).to "
+                                                + "match_query_params(CGI.parse('$L'))",
+                                        body.get());
                         break;
                     default:
                         writer.write("expect(request.body.read).to eq('$L')", body.get());

--- a/hearth/.rubocop.yml
+++ b/hearth/.rubocop.yml
@@ -27,3 +27,7 @@ Metrics/ClassLength:
 Style/Documentation:
   Exclude:
     - 'spec/**/*.rb'
+
+Style/RescueModifier:
+  Exclude:
+    - 'lib/hearth/query/param_matcher.rb'

--- a/hearth/lib/hearth/query/param_matcher.rb
+++ b/hearth/lib/hearth/query/param_matcher.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rspec/expectations'
+
+# Provides an rspec matcher for CGI.parse to check Float precision.
+# @api private
+RSpec::Matchers.define :match_query_params do |expected|
+  match do |actual|
+    return true if actual == expected
+    return false unless actual.instance_of?(expected.class)
+
+    expect(actual.keys.length).to eq(expected.keys.length)
+    expect(actual.values.length).to eq(expected.values.length)
+
+    # CGI.parse is always a flat map with an array of values.
+    expected.values.zip(actual.values).each do |a, e|
+      a.zip(e).each do |a0, e0|
+        # Timestamps can have optional precision.
+        if (float = Float(a0, exception: false))
+          expect(float).to eq(e0.to_f)
+        else
+          expect(a0).to eq(e0)
+        end
+      end
+    end
+  end
+
+  diffable
+end

--- a/hearth/lib/hearth/query/param_matcher.rb
+++ b/hearth/lib/hearth/query/param_matcher.rb
@@ -16,7 +16,7 @@ RSpec::Matchers.define :match_query_params do |expected|
     expected.values.zip(actual.values).each do |a, e|
       a.zip(e).each do |a0, e0|
         # Timestamps can have optional precision.
-        if (float = Float(a0, exception: false))
+        if (float = Float(a0) rescue false)
           expect(float).to eq(e0.to_f)
         else
           expect(a0).to eq(e0)

--- a/hearth/spec/hearth/query/param_matcher_spec.rb
+++ b/hearth/spec/hearth/query/param_matcher_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# not included in lib
+require_relative '../../../lib/hearth/query/param_matcher'
+
+module Hearth
+  module Query
+    describe :match_query_params do
+      it 'is true when the node is self' do
+        cgi = CGI.parse('Param=Value')
+        expect(cgi).to match_query_params(cgi)
+      end
+
+      it 'is true for the same parsed params' do
+        actual = CGI.parse('Param=Value')
+        expected = CGI.parse('Param=Value')
+
+        expect(actual).to match_query_params(expected)
+      end
+
+      it 'is false when number of keys differs' do
+        actual = CGI.parse('Param=Value')
+        expected = CGI.parse('Param=Value&Other=Value')
+
+        expect(actual).not_to match_query_params(expected)
+      end
+
+      it 'is false when number of values differs' do
+        actual = CGI.parse('Param=Value')
+        expected = CGI.parse('Param=Value&Param=Other')
+
+        expect(actual).not_to match_query_params(expected)
+      end
+
+      it 'compares floats with precision' do
+        actual = CGI.parse('Param=Value&Time=123')
+        expected = CGI.parse('Param=Value&Time=123.0')
+
+        expect(actual).to match_query_params(expected)
+      end
+    end
+  end
+end

--- a/hearth/spec/hearth/xml/node_matcher_spec.rb
+++ b/hearth/spec/hearth/xml/node_matcher_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# not included in lib
 require_relative '../../../lib/hearth/xml/node_matcher'
 
 module Hearth


### PR DESCRIPTION
Add query param matcher for AWS Query tests. It compares the parsed CGI string (as a hash) but also checks float precision.