### PR TITLE
Convert stubs to Output types - apply params/validation

### DIFF
--- a/codegen/projections/high_score_service/lib/high_score_service/client.rb
+++ b/codegen/projections/high_score_service/lib/high_score_service/client.rb
@@ -386,5 +386,23 @@ module HighScoreService
 
       StringIO.new
     end
+
+    def transform_stubs(operation_name, stubs)
+      param_class = case operation_name
+      when :create_high_score then Params::CreateHighScoreOutput
+      when :delete_high_score then Params::DeleteHighScoreOutput
+      when :get_high_score then Params::GetHighScoreOutput
+      when :list_high_scores then Params::ListHighScoresOutput
+      when :update_high_score then Params::UpdateHighScoreOutput
+      end
+
+      stubs.map do |stub|
+        if Hash === stub
+          param_class.build(stub)
+        else
+          stub
+        end
+      end
+    end
   end
 end

--- a/codegen/projections/high_score_service/lib/high_score_service/params.rb
+++ b/codegen/projections/high_score_service/lib/high_score_service/params.rb
@@ -12,11 +12,32 @@ require 'securerandom'
 module HighScoreService
   module Params
 
+    module AttributeErrors
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, context: context)
+        data = {}
+        params.each do |key, value|
+          data[key] = ErrorMessages.build(value, context: "#{context}[:#{key}]") unless value.nil?
+        end
+        data
+      end
+    end
+
     module CreateHighScoreInput
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::CreateHighScoreInput, context: context)
         type = Types::CreateHighScoreInput.new
         type.high_score = HighScoreParams.build(params[:high_score], context: "#{context}[:high_score]") unless params[:high_score].nil?
+        type
+      end
+    end
+
+    module CreateHighScoreOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::CreateHighScoreOutput, context: context)
+        type = Types::CreateHighScoreOutput.new
+        type.high_score = HighScoreAttributes.build(params[:high_score], context: "#{context}[:high_score]") unless params[:high_score].nil?
+        type.location = params[:location]
         type
       end
     end
@@ -30,11 +51,52 @@ module HighScoreService
       end
     end
 
+    module DeleteHighScoreOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::DeleteHighScoreOutput, context: context)
+        type = Types::DeleteHighScoreOutput.new
+        type
+      end
+    end
+
+    module ErrorMessages
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Array, context: context)
+        data = []
+        params.each_with_index do |element, index|
+          data << element
+        end
+        data
+      end
+    end
+
     module GetHighScoreInput
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::GetHighScoreInput, context: context)
         type = Types::GetHighScoreInput.new
         type.id = params[:id]
+        type
+      end
+    end
+
+    module GetHighScoreOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::GetHighScoreOutput, context: context)
+        type = Types::GetHighScoreOutput.new
+        type.high_score = HighScoreAttributes.build(params[:high_score], context: "#{context}[:high_score]") unless params[:high_score].nil?
+        type
+      end
+    end
+
+    module HighScoreAttributes
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::HighScoreAttributes, context: context)
+        type = Types::HighScoreAttributes.new
+        type.id = params[:id]
+        type.game = params[:game]
+        type.score = params[:score]
+        type.created_at = params[:created_at]
+        type.updated_at = params[:updated_at]
         type
       end
     end
@@ -49,10 +111,39 @@ module HighScoreService
       end
     end
 
+    module HighScores
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Array, context: context)
+        data = []
+        params.each_with_index do |element, index|
+          data << HighScoreAttributes.build(element, context: "#{context}[#{index}]") unless element.nil?
+        end
+        data
+      end
+    end
+
     module ListHighScoresInput
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::ListHighScoresInput, context: context)
         type = Types::ListHighScoresInput.new
+        type
+      end
+    end
+
+    module ListHighScoresOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::ListHighScoresOutput, context: context)
+        type = Types::ListHighScoresOutput.new
+        type.high_scores = HighScores.build(params[:high_scores], context: "#{context}[:high_scores]") unless params[:high_scores].nil?
+        type
+      end
+    end
+
+    module UnprocessableEntityError
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::UnprocessableEntityError, context: context)
+        type = Types::UnprocessableEntityError.new
+        type.errors = AttributeErrors.build(params[:errors], context: "#{context}[:errors]") unless params[:errors].nil?
         type
       end
     end
@@ -63,6 +154,15 @@ module HighScoreService
         type = Types::UpdateHighScoreInput.new
         type.id = params[:id]
         type.high_score = HighScoreParams.build(params[:high_score], context: "#{context}[:high_score]") unless params[:high_score].nil?
+        type
+      end
+    end
+
+    module UpdateHighScoreOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::UpdateHighScoreOutput, context: context)
+        type = Types::UpdateHighScoreOutput.new
+        type.high_score = HighScoreAttributes.build(params[:high_score], context: "#{context}[:high_score]") unless params[:high_score].nil?
         type
       end
     end

--- a/codegen/projections/high_score_service/lib/high_score_service/validators.rb
+++ b/codegen/projections/high_score_service/lib/high_score_service/validators.rb
@@ -10,10 +10,28 @@
 module HighScoreService
   module Validators
 
+    class AttributeErrors
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, ::Hash, context: context)
+        input.each do |key, value|
+          Hearth::Validator.validate!(key, ::String, ::Symbol, context: "#{context}.keys")
+          Validators::ErrorMessages.validate!(value, context: "#{context}[:#{key}]") unless value.nil?
+        end
+      end
+    end
+
     class CreateHighScoreInput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::CreateHighScoreInput, context: context)
         Validators::HighScoreParams.validate!(input[:high_score], context: "#{context}[:high_score]") unless input[:high_score].nil?
+      end
+    end
+
+    class CreateHighScoreOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::CreateHighScoreOutput, context: context)
+        Validators::HighScoreAttributes.validate!(input[:high_score], context: "#{context}[:high_score]") unless input[:high_score].nil?
+        Hearth::Validator.validate!(input[:location], ::String, context: "#{context}[:location]")
       end
     end
 
@@ -24,10 +42,43 @@ module HighScoreService
       end
     end
 
+    class DeleteHighScoreOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::DeleteHighScoreOutput, context: context)
+      end
+    end
+
+    class ErrorMessages
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, ::Array, context: context)
+        input.each_with_index do |element, index|
+          Hearth::Validator.validate!(element, ::String, context: "#{context}[#{index}]")
+        end
+      end
+    end
+
     class GetHighScoreInput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::GetHighScoreInput, context: context)
         Hearth::Validator.validate!(input[:id], ::String, context: "#{context}[:id]")
+      end
+    end
+
+    class GetHighScoreOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::GetHighScoreOutput, context: context)
+        Validators::HighScoreAttributes.validate!(input[:high_score], context: "#{context}[:high_score]") unless input[:high_score].nil?
+      end
+    end
+
+    class HighScoreAttributes
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::HighScoreAttributes, context: context)
+        Hearth::Validator.validate!(input[:id], ::String, context: "#{context}[:id]")
+        Hearth::Validator.validate!(input[:game], ::String, context: "#{context}[:game]")
+        Hearth::Validator.validate!(input[:score], ::Integer, context: "#{context}[:score]")
+        Hearth::Validator.validate!(input[:created_at], ::Time, context: "#{context}[:created_at]")
+        Hearth::Validator.validate!(input[:updated_at], ::Time, context: "#{context}[:updated_at]")
       end
     end
 
@@ -39,9 +90,32 @@ module HighScoreService
       end
     end
 
+    class HighScores
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, ::Array, context: context)
+        input.each_with_index do |element, index|
+          Validators::HighScoreAttributes.validate!(element, context: "#{context}[#{index}]") unless element.nil?
+        end
+      end
+    end
+
     class ListHighScoresInput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::ListHighScoresInput, context: context)
+      end
+    end
+
+    class ListHighScoresOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::ListHighScoresOutput, context: context)
+        Validators::HighScores.validate!(input[:high_scores], context: "#{context}[:high_scores]") unless input[:high_scores].nil?
+      end
+    end
+
+    class UnprocessableEntityError
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::UnprocessableEntityError, context: context)
+        Validators::AttributeErrors.validate!(input[:errors], context: "#{context}[:errors]") unless input[:errors].nil?
       end
     end
 
@@ -50,6 +124,13 @@ module HighScoreService
         Hearth::Validator.validate!(input, Types::UpdateHighScoreInput, context: context)
         Hearth::Validator.validate!(input[:id], ::String, context: "#{context}[:id]")
         Validators::HighScoreParams.validate!(input[:high_score], context: "#{context}[:high_score]") unless input[:high_score].nil?
+      end
+    end
+
+    class UpdateHighScoreOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::UpdateHighScoreOutput, context: context)
+        Validators::HighScoreAttributes.validate!(input[:high_score], context: "#{context}[:high_score]") unless input[:high_score].nil?
       end
     end
 

--- a/codegen/projections/rails_json/lib/rails_json/client.rb
+++ b/codegen/projections/rails_json/lib/rails_json/client.rb
@@ -2339,5 +2339,53 @@ module RailsJson
 
       StringIO.new
     end
+
+    def transform_stubs(operation_name, stubs)
+      param_class = case operation_name
+      when :all_query_string_types then Params::AllQueryStringTypesOutput
+      when :constant_and_variable_query_string then Params::ConstantAndVariableQueryStringOutput
+      when :constant_query_string then Params::ConstantQueryStringOutput
+      when :document_type then Params::DocumentTypeOutput
+      when :document_type_as_payload then Params::DocumentTypeAsPayloadOutput
+      when :empty_operation then Params::EmptyOperationOutput
+      when :endpoint_operation then Params::EndpointOperationOutput
+      when :endpoint_with_host_label_operation then Params::EndpointWithHostLabelOperationOutput
+      when :greeting_with_errors then Params::GreetingWithErrorsOutput
+      when :http_payload_traits then Params::HttpPayloadTraitsOutput
+      when :http_payload_traits_with_media_type then Params::HttpPayloadTraitsWithMediaTypeOutput
+      when :http_payload_with_structure then Params::HttpPayloadWithStructureOutput
+      when :http_prefix_headers then Params::HttpPrefixHeadersOutput
+      when :http_prefix_headers_in_response then Params::HttpPrefixHeadersInResponseOutput
+      when :http_request_with_float_labels then Params::HttpRequestWithFloatLabelsOutput
+      when :http_request_with_greedy_label_in_path then Params::HttpRequestWithGreedyLabelInPathOutput
+      when :http_request_with_labels then Params::HttpRequestWithLabelsOutput
+      when :http_request_with_labels_and_timestamp_format then Params::HttpRequestWithLabelsAndTimestampFormatOutput
+      when :http_response_code then Params::HttpResponseCodeOutput
+      when :ignore_query_params_in_response then Params::IgnoreQueryParamsInResponseOutput
+      when :input_and_output_with_headers then Params::InputAndOutputWithHeadersOutput
+      when :json_enums then Params::JsonEnumsOutput
+      when :json_maps then Params::JsonMapsOutput
+      when :json_unions then Params::JsonUnionsOutput
+      when :kitchen_sink_operation then Params::KitchenSinkOperationOutput
+      when :media_type_header then Params::MediaTypeHeaderOutput
+      when :nested_attributes_operation then Params::NestedAttributesOperationOutput
+      when :null_and_empty_headers_client then Params::NullAndEmptyHeadersClientOutput
+      when :null_operation then Params::NullOperationOutput
+      when :omits_null_serializes_empty_string then Params::OmitsNullSerializesEmptyStringOutput
+      when :operation_with_optional_input_output then Params::OperationWithOptionalInputOutputOutput
+      when :query_idempotency_token_auto_fill then Params::QueryIdempotencyTokenAutoFillOutput
+      when :query_params_as_string_list_map then Params::QueryParamsAsStringListMapOutput
+      when :timestamp_format_headers then Params::TimestampFormatHeadersOutput
+      when :operation____789_bad_name then Params::Struct____789BadNameOutput
+      end
+
+      stubs.map do |stub|
+        if Hash === stub
+          param_class.build(stub)
+        else
+          stub
+        end
+      end
+    end
   end
 end

--- a/codegen/projections/rails_json/lib/rails_json/params.rb
+++ b/codegen/projections/rails_json/lib/rails_json/params.rb
@@ -39,6 +39,14 @@ module RailsJson
       end
     end
 
+    module AllQueryStringTypesOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::AllQueryStringTypesOutput, context: context)
+        type = Types::AllQueryStringTypesOutput.new
+        type
+      end
+    end
+
     module BooleanList
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Array, context: context)
@@ -47,6 +55,25 @@ module RailsJson
           data << element
         end
         data
+      end
+    end
+
+    module ComplexError
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::ComplexError, context: context)
+        type = Types::ComplexError.new
+        type.top_level = params[:top_level]
+        type.nested = ComplexNestedErrorData.build(params[:nested], context: "#{context}[:nested]") unless params[:nested].nil?
+        type
+      end
+    end
+
+    module ComplexNestedErrorData
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::ComplexNestedErrorData, context: context)
+        type = Types::ComplexNestedErrorData.new
+        type.foo = params[:foo]
+        type
       end
     end
 
@@ -60,11 +87,27 @@ module RailsJson
       end
     end
 
+    module ConstantAndVariableQueryStringOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::ConstantAndVariableQueryStringOutput, context: context)
+        type = Types::ConstantAndVariableQueryStringOutput.new
+        type
+      end
+    end
+
     module ConstantQueryStringInput
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::ConstantQueryStringInput, context: context)
         type = Types::ConstantQueryStringInput.new
         type.hello = params[:hello]
+        type
+      end
+    end
+
+    module ConstantQueryStringOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::ConstantQueryStringOutput, context: context)
+        type = Types::ConstantQueryStringOutput.new
         type
       end
     end
@@ -133,10 +176,29 @@ module RailsJson
       end
     end
 
+    module DocumentTypeAsPayloadOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::DocumentTypeAsPayloadOutput, context: context)
+        type = Types::DocumentTypeAsPayloadOutput.new
+        type.document_value = params[:document_value]
+        type
+      end
+    end
+
     module DocumentTypeInput
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::DocumentTypeInput, context: context)
         type = Types::DocumentTypeInput.new
+        type.string_value = params[:string_value]
+        type.document_value = params[:document_value]
+        type
+      end
+    end
+
+    module DocumentTypeOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::DocumentTypeOutput, context: context)
+        type = Types::DocumentTypeOutput.new
         type.string_value = params[:string_value]
         type.document_value = params[:document_value]
         type
@@ -162,6 +224,14 @@ module RailsJson
       end
     end
 
+    module EmptyOperationOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::EmptyOperationOutput, context: context)
+        type = Types::EmptyOperationOutput.new
+        type
+      end
+    end
+
     module EmptyStruct
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::EmptyStruct, context: context)
@@ -178,11 +248,50 @@ module RailsJson
       end
     end
 
+    module EndpointOperationOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::EndpointOperationOutput, context: context)
+        type = Types::EndpointOperationOutput.new
+        type
+      end
+    end
+
     module EndpointWithHostLabelOperationInput
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::EndpointWithHostLabelOperationInput, context: context)
         type = Types::EndpointWithHostLabelOperationInput.new
         type.label = params[:label]
+        type
+      end
+    end
+
+    module EndpointWithHostLabelOperationOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::EndpointWithHostLabelOperationOutput, context: context)
+        type = Types::EndpointWithHostLabelOperationOutput.new
+        type
+      end
+    end
+
+    module ErrorWithMembers
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::ErrorWithMembers, context: context)
+        type = Types::ErrorWithMembers.new
+        type.code = params[:code]
+        type.complex_data = KitchenSink.build(params[:complex_data], context: "#{context}[:complex_data]") unless params[:complex_data].nil?
+        type.integer_field = params[:integer_field]
+        type.list_field = ListOfStrings.build(params[:list_field], context: "#{context}[:list_field]") unless params[:list_field].nil?
+        type.map_field = MapOfStrings.build(params[:map_field], context: "#{context}[:map_field]") unless params[:map_field].nil?
+        type.message = params[:message]
+        type.string_field = params[:string_field]
+        type
+      end
+    end
+
+    module ErrorWithoutMembers
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::ErrorWithoutMembers, context: context)
+        type = Types::ErrorWithoutMembers.new
         type
       end
     end
@@ -237,10 +346,29 @@ module RailsJson
       end
     end
 
+    module GreetingWithErrorsOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::GreetingWithErrorsOutput, context: context)
+        type = Types::GreetingWithErrorsOutput.new
+        type.greeting = params[:greeting]
+        type
+      end
+    end
+
     module HttpPayloadTraitsInput
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::HttpPayloadTraitsInput, context: context)
         type = Types::HttpPayloadTraitsInput.new
+        type.foo = params[:foo]
+        type.blob = params[:blob]
+        type
+      end
+    end
+
+    module HttpPayloadTraitsOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::HttpPayloadTraitsOutput, context: context)
+        type = Types::HttpPayloadTraitsOutput.new
         type.foo = params[:foo]
         type.blob = params[:blob]
         type
@@ -257,10 +385,29 @@ module RailsJson
       end
     end
 
+    module HttpPayloadTraitsWithMediaTypeOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::HttpPayloadTraitsWithMediaTypeOutput, context: context)
+        type = Types::HttpPayloadTraitsWithMediaTypeOutput.new
+        type.foo = params[:foo]
+        type.blob = params[:blob]
+        type
+      end
+    end
+
     module HttpPayloadWithStructureInput
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::HttpPayloadWithStructureInput, context: context)
         type = Types::HttpPayloadWithStructureInput.new
+        type.nested = NestedPayload.build(params[:nested], context: "#{context}[:nested]") unless params[:nested].nil?
+        type
+      end
+    end
+
+    module HttpPayloadWithStructureOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::HttpPayloadWithStructureOutput, context: context)
+        type = Types::HttpPayloadWithStructureOutput.new
         type.nested = NestedPayload.build(params[:nested], context: "#{context}[:nested]") unless params[:nested].nil?
         type
       end
@@ -274,10 +421,29 @@ module RailsJson
       end
     end
 
+    module HttpPrefixHeadersInResponseOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::HttpPrefixHeadersInResponseOutput, context: context)
+        type = Types::HttpPrefixHeadersInResponseOutput.new
+        type.prefix_headers = StringMap.build(params[:prefix_headers], context: "#{context}[:prefix_headers]") unless params[:prefix_headers].nil?
+        type
+      end
+    end
+
     module HttpPrefixHeadersInput
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::HttpPrefixHeadersInput, context: context)
         type = Types::HttpPrefixHeadersInput.new
+        type.foo = params[:foo]
+        type.foo_map = StringMap.build(params[:foo_map], context: "#{context}[:foo_map]") unless params[:foo_map].nil?
+        type
+      end
+    end
+
+    module HttpPrefixHeadersOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::HttpPrefixHeadersOutput, context: context)
+        type = Types::HttpPrefixHeadersOutput.new
         type.foo = params[:foo]
         type.foo_map = StringMap.build(params[:foo_map], context: "#{context}[:foo_map]") unless params[:foo_map].nil?
         type
@@ -294,12 +460,28 @@ module RailsJson
       end
     end
 
+    module HttpRequestWithFloatLabelsOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::HttpRequestWithFloatLabelsOutput, context: context)
+        type = Types::HttpRequestWithFloatLabelsOutput.new
+        type
+      end
+    end
+
     module HttpRequestWithGreedyLabelInPathInput
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::HttpRequestWithGreedyLabelInPathInput, context: context)
         type = Types::HttpRequestWithGreedyLabelInPathInput.new
         type.foo = params[:foo]
         type.baz = params[:baz]
+        type
+      end
+    end
+
+    module HttpRequestWithGreedyLabelInPathOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::HttpRequestWithGreedyLabelInPathOutput, context: context)
+        type = Types::HttpRequestWithGreedyLabelInPathOutput.new
         type
       end
     end
@@ -315,6 +497,14 @@ module RailsJson
         type.target_epoch_seconds = params[:target_epoch_seconds]
         type.target_http_date = params[:target_http_date]
         type.target_date_time = params[:target_date_time]
+        type
+      end
+    end
+
+    module HttpRequestWithLabelsAndTimestampFormatOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::HttpRequestWithLabelsAndTimestampFormatOutput, context: context)
+        type = Types::HttpRequestWithLabelsAndTimestampFormatOutput.new
         type
       end
     end
@@ -335,10 +525,27 @@ module RailsJson
       end
     end
 
+    module HttpRequestWithLabelsOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::HttpRequestWithLabelsOutput, context: context)
+        type = Types::HttpRequestWithLabelsOutput.new
+        type
+      end
+    end
+
     module HttpResponseCodeInput
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::HttpResponseCodeInput, context: context)
         type = Types::HttpResponseCodeInput.new
+        type
+      end
+    end
+
+    module HttpResponseCodeOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::HttpResponseCodeOutput, context: context)
+        type = Types::HttpResponseCodeOutput.new
+        type.status = params[:status]
         type
       end
     end
@@ -351,10 +558,43 @@ module RailsJson
       end
     end
 
+    module IgnoreQueryParamsInResponseOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::IgnoreQueryParamsInResponseOutput, context: context)
+        type = Types::IgnoreQueryParamsInResponseOutput.new
+        type.baz = params[:baz]
+        type
+      end
+    end
+
     module InputAndOutputWithHeadersInput
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::InputAndOutputWithHeadersInput, context: context)
         type = Types::InputAndOutputWithHeadersInput.new
+        type.header_string = params[:header_string]
+        type.header_byte = params[:header_byte]
+        type.header_short = params[:header_short]
+        type.header_integer = params[:header_integer]
+        type.header_long = params[:header_long]
+        type.header_float = params[:header_float]
+        type.header_double = params[:header_double]
+        type.header_true_bool = params[:header_true_bool]
+        type.header_false_bool = params[:header_false_bool]
+        type.header_string_list = StringList.build(params[:header_string_list], context: "#{context}[:header_string_list]") unless params[:header_string_list].nil?
+        type.header_string_set = StringSet.build(params[:header_string_set], context: "#{context}[:header_string_set]") unless params[:header_string_set].nil?
+        type.header_integer_list = IntegerList.build(params[:header_integer_list], context: "#{context}[:header_integer_list]") unless params[:header_integer_list].nil?
+        type.header_boolean_list = BooleanList.build(params[:header_boolean_list], context: "#{context}[:header_boolean_list]") unless params[:header_boolean_list].nil?
+        type.header_timestamp_list = TimestampList.build(params[:header_timestamp_list], context: "#{context}[:header_timestamp_list]") unless params[:header_timestamp_list].nil?
+        type.header_enum = params[:header_enum]
+        type.header_enum_list = FooEnumList.build(params[:header_enum_list], context: "#{context}[:header_enum_list]") unless params[:header_enum_list].nil?
+        type
+      end
+    end
+
+    module InputAndOutputWithHeadersOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::InputAndOutputWithHeadersOutput, context: context)
+        type = Types::InputAndOutputWithHeadersOutput.new
         type.header_string = params[:header_string]
         type.header_byte = params[:header_byte]
         type.header_short = params[:header_short]
@@ -397,10 +637,33 @@ module RailsJson
       end
     end
 
+    module InvalidGreeting
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::InvalidGreeting, context: context)
+        type = Types::InvalidGreeting.new
+        type.message = params[:message]
+        type
+      end
+    end
+
     module JsonEnumsInput
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::JsonEnumsInput, context: context)
         type = Types::JsonEnumsInput.new
+        type.foo_enum1 = params[:foo_enum1]
+        type.foo_enum2 = params[:foo_enum2]
+        type.foo_enum3 = params[:foo_enum3]
+        type.foo_enum_list = FooEnumList.build(params[:foo_enum_list], context: "#{context}[:foo_enum_list]") unless params[:foo_enum_list].nil?
+        type.foo_enum_set = FooEnumSet.build(params[:foo_enum_set], context: "#{context}[:foo_enum_set]") unless params[:foo_enum_set].nil?
+        type.foo_enum_map = FooEnumMap.build(params[:foo_enum_map], context: "#{context}[:foo_enum_map]") unless params[:foo_enum_map].nil?
+        type
+      end
+    end
+
+    module JsonEnumsOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::JsonEnumsOutput, context: context)
+        type = Types::JsonEnumsOutput.new
         type.foo_enum1 = params[:foo_enum1]
         type.foo_enum2 = params[:foo_enum2]
         type.foo_enum3 = params[:foo_enum3]
@@ -429,10 +692,37 @@ module RailsJson
       end
     end
 
+    module JsonMapsOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::JsonMapsOutput, context: context)
+        type = Types::JsonMapsOutput.new
+        type.dense_struct_map = DenseStructMap.build(params[:dense_struct_map], context: "#{context}[:dense_struct_map]") unless params[:dense_struct_map].nil?
+        type.sparse_struct_map = SparseStructMap.build(params[:sparse_struct_map], context: "#{context}[:sparse_struct_map]") unless params[:sparse_struct_map].nil?
+        type.dense_number_map = DenseNumberMap.build(params[:dense_number_map], context: "#{context}[:dense_number_map]") unless params[:dense_number_map].nil?
+        type.dense_boolean_map = DenseBooleanMap.build(params[:dense_boolean_map], context: "#{context}[:dense_boolean_map]") unless params[:dense_boolean_map].nil?
+        type.dense_string_map = DenseStringMap.build(params[:dense_string_map], context: "#{context}[:dense_string_map]") unless params[:dense_string_map].nil?
+        type.sparse_number_map = SparseNumberMap.build(params[:sparse_number_map], context: "#{context}[:sparse_number_map]") unless params[:sparse_number_map].nil?
+        type.sparse_boolean_map = SparseBooleanMap.build(params[:sparse_boolean_map], context: "#{context}[:sparse_boolean_map]") unless params[:sparse_boolean_map].nil?
+        type.sparse_string_map = SparseStringMap.build(params[:sparse_string_map], context: "#{context}[:sparse_string_map]") unless params[:sparse_string_map].nil?
+        type.dense_set_map = DenseSetMap.build(params[:dense_set_map], context: "#{context}[:dense_set_map]") unless params[:dense_set_map].nil?
+        type.sparse_set_map = SparseSetMap.build(params[:sparse_set_map], context: "#{context}[:sparse_set_map]") unless params[:sparse_set_map].nil?
+        type
+      end
+    end
+
     module JsonUnionsInput
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::JsonUnionsInput, context: context)
         type = Types::JsonUnionsInput.new
+        type.contents = MyUnion.build(params[:contents], context: "#{context}[:contents]") unless params[:contents].nil?
+        type
+      end
+    end
+
+    module JsonUnionsOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::JsonUnionsOutput, context: context)
+        type = Types::JsonUnionsOutput.new
         type.contents = MyUnion.build(params[:contents], context: "#{context}[:contents]") unless params[:contents].nil?
         type
       end
@@ -476,6 +766,40 @@ module RailsJson
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::KitchenSinkOperationInput, context: context)
         type = Types::KitchenSinkOperationInput.new
+        type.blob = params[:blob]
+        type.boolean = params[:boolean]
+        type.double = params[:double]
+        type.empty_struct = EmptyStruct.build(params[:empty_struct], context: "#{context}[:empty_struct]") unless params[:empty_struct].nil?
+        type.float = params[:float]
+        type.httpdate_timestamp = params[:httpdate_timestamp]
+        type.integer = params[:integer]
+        type.iso8601_timestamp = params[:iso8601_timestamp]
+        type.json_value = params[:json_value]
+        type.list_of_lists = ListOfListOfStrings.build(params[:list_of_lists], context: "#{context}[:list_of_lists]") unless params[:list_of_lists].nil?
+        type.list_of_maps_of_strings = ListOfMapsOfStrings.build(params[:list_of_maps_of_strings], context: "#{context}[:list_of_maps_of_strings]") unless params[:list_of_maps_of_strings].nil?
+        type.list_of_strings = ListOfStrings.build(params[:list_of_strings], context: "#{context}[:list_of_strings]") unless params[:list_of_strings].nil?
+        type.list_of_structs = ListOfStructs.build(params[:list_of_structs], context: "#{context}[:list_of_structs]") unless params[:list_of_structs].nil?
+        type.long = params[:long]
+        type.map_of_lists_of_strings = MapOfListsOfStrings.build(params[:map_of_lists_of_strings], context: "#{context}[:map_of_lists_of_strings]") unless params[:map_of_lists_of_strings].nil?
+        type.map_of_maps = MapOfMapOfStrings.build(params[:map_of_maps], context: "#{context}[:map_of_maps]") unless params[:map_of_maps].nil?
+        type.map_of_strings = MapOfStrings.build(params[:map_of_strings], context: "#{context}[:map_of_strings]") unless params[:map_of_strings].nil?
+        type.map_of_structs = MapOfStructs.build(params[:map_of_structs], context: "#{context}[:map_of_structs]") unless params[:map_of_structs].nil?
+        type.recursive_list = ListOfKitchenSinks.build(params[:recursive_list], context: "#{context}[:recursive_list]") unless params[:recursive_list].nil?
+        type.recursive_map = MapOfKitchenSinks.build(params[:recursive_map], context: "#{context}[:recursive_map]") unless params[:recursive_map].nil?
+        type.recursive_struct = KitchenSink.build(params[:recursive_struct], context: "#{context}[:recursive_struct]") unless params[:recursive_struct].nil?
+        type.simple_struct = SimpleStruct.build(params[:simple_struct], context: "#{context}[:simple_struct]") unless params[:simple_struct].nil?
+        type.string = params[:string]
+        type.struct_with_location_name = StructWithLocationName.build(params[:struct_with_location_name], context: "#{context}[:struct_with_location_name]") unless params[:struct_with_location_name].nil?
+        type.timestamp = params[:timestamp]
+        type.unix_timestamp = params[:unix_timestamp]
+        type
+      end
+    end
+
+    module KitchenSinkOperationOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::KitchenSinkOperationOutput, context: context)
+        type = Types::KitchenSinkOperationOutput.new
         type.blob = params[:blob]
         type.boolean = params[:boolean]
         type.double = params[:double]
@@ -625,6 +949,15 @@ module RailsJson
       end
     end
 
+    module MediaTypeHeaderOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::MediaTypeHeaderOutput, context: context)
+        type = Types::MediaTypeHeaderOutput.new
+        type.json = params[:json]
+        type
+      end
+    end
+
     module MyUnion
       def self.build(params, context: '')
         return params if params.is_a?(Types::MyUnion)
@@ -687,6 +1020,15 @@ module RailsJson
       end
     end
 
+    module NestedAttributesOperationOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::NestedAttributesOperationOutput, context: context)
+        type = Types::NestedAttributesOperationOutput.new
+        type.value = params[:value]
+        type
+      end
+    end
+
     module NestedPayload
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::NestedPayload, context: context)
@@ -708,10 +1050,32 @@ module RailsJson
       end
     end
 
+    module NullAndEmptyHeadersClientOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::NullAndEmptyHeadersClientOutput, context: context)
+        type = Types::NullAndEmptyHeadersClientOutput.new
+        type.a = params[:a]
+        type.b = params[:b]
+        type.c = StringList.build(params[:c], context: "#{context}[:c]") unless params[:c].nil?
+        type
+      end
+    end
+
     module NullOperationInput
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::NullOperationInput, context: context)
         type = Types::NullOperationInput.new
+        type.string = params[:string]
+        type.sparse_string_list = SparseStringList.build(params[:sparse_string_list], context: "#{context}[:sparse_string_list]") unless params[:sparse_string_list].nil?
+        type.sparse_string_map = SparseStringMap.build(params[:sparse_string_map], context: "#{context}[:sparse_string_map]") unless params[:sparse_string_map].nil?
+        type
+      end
+    end
+
+    module NullOperationOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::NullOperationOutput, context: context)
+        type = Types::NullOperationOutput.new
         type.string = params[:string]
         type.sparse_string_list = SparseStringList.build(params[:sparse_string_list], context: "#{context}[:sparse_string_list]") unless params[:sparse_string_list].nil?
         type.sparse_string_map = SparseStringMap.build(params[:sparse_string_map], context: "#{context}[:sparse_string_map]") unless params[:sparse_string_map].nil?
@@ -729,10 +1093,27 @@ module RailsJson
       end
     end
 
+    module OmitsNullSerializesEmptyStringOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::OmitsNullSerializesEmptyStringOutput, context: context)
+        type = Types::OmitsNullSerializesEmptyStringOutput.new
+        type
+      end
+    end
+
     module OperationWithOptionalInputOutputInput
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::OperationWithOptionalInputOutputInput, context: context)
         type = Types::OperationWithOptionalInputOutputInput.new
+        type.value = params[:value]
+        type
+      end
+    end
+
+    module OperationWithOptionalInputOutputOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::OperationWithOptionalInputOutputOutput, context: context)
+        type = Types::OperationWithOptionalInputOutputOutput.new
         type.value = params[:value]
         type
       end
@@ -747,12 +1128,28 @@ module RailsJson
       end
     end
 
+    module QueryIdempotencyTokenAutoFillOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::QueryIdempotencyTokenAutoFillOutput, context: context)
+        type = Types::QueryIdempotencyTokenAutoFillOutput.new
+        type
+      end
+    end
+
     module QueryParamsAsStringListMapInput
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::QueryParamsAsStringListMapInput, context: context)
         type = Types::QueryParamsAsStringListMapInput.new
         type.qux = params[:qux]
         type.foo = StringListMap.build(params[:foo], context: "#{context}[:foo]") unless params[:foo].nil?
+        type
+      end
+    end
+
+    module QueryParamsAsStringListMapOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::QueryParamsAsStringListMapOutput, context: context)
+        type = Types::QueryParamsAsStringListMapOutput.new
         type
       end
     end
@@ -900,6 +1297,21 @@ module RailsJson
       end
     end
 
+    module TimestampFormatHeadersOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::TimestampFormatHeadersOutput, context: context)
+        type = Types::TimestampFormatHeadersOutput.new
+        type.member_epoch_seconds = params[:member_epoch_seconds]
+        type.member_http_date = params[:member_http_date]
+        type.member_date_time = params[:member_date_time]
+        type.default_format = params[:default_format]
+        type.target_epoch_seconds = params[:target_epoch_seconds]
+        type.target_http_date = params[:target_http_date]
+        type.target_date_time = params[:target_date_time]
+        type
+      end
+    end
+
     module TimestampList
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Array, context: context)
@@ -925,6 +1337,15 @@ module RailsJson
         Hearth::Validator.validate!(params, ::Hash, Types::Struct____789BadNameInput, context: context)
         type = Types::Struct____789BadNameInput.new
         type.member____123abc = params[:member____123abc]
+        type.member = Struct____456efg.build(params[:member], context: "#{context}[:member]") unless params[:member].nil?
+        type
+      end
+    end
+
+    module Struct____789BadNameOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::Struct____789BadNameOutput, context: context)
+        type = Types::Struct____789BadNameOutput.new
         type.member = Struct____456efg.build(params[:member], context: "#{context}[:member]") unless params[:member].nil?
         type
       end

--- a/codegen/projections/rails_json/lib/rails_json/stubs.rb
+++ b/codegen/projections/rails_json/lib/rails_json/stubs.rb
@@ -902,23 +902,36 @@ module RailsJson
       def self.default(visited=[])
         return nil if visited.include?('MyUnion')
         visited = visited + ['MyUnion']
-        {
-          string_value: 'string_value',
-        }
+        value = 'string_value'
+        Types::MyUnion::StringValue.new(value)
       end
 
       def self.stub(stub = {})
-        stub ||= {}
         data = {}
-        data[:string_value] = stub[:string_value] unless stub[:string_value].nil?
-        data[:boolean_value] = stub[:boolean_value] unless stub[:boolean_value].nil?
-        data[:number_value] = stub[:number_value] unless stub[:number_value].nil?
-        data[:blob_value] = Base64::encode64(stub[:blob_value]) unless stub[:blob_value].nil?
-        data[:timestamp_value] = Hearth::TimeHelper.to_date_time(stub[:timestamp_value]) unless stub[:timestamp_value].nil?
-        data[:enum_value] = stub[:enum_value] unless stub[:enum_value].nil?
-        data[:list_value] = Stubs::StringList.stub(stub[:list_value]) unless stub[:list_value].nil?
-        data[:map_value] = Stubs::StringMap.stub(stub[:map_value]) unless stub[:map_value].nil?
-        data[:structure_value] = Stubs::GreetingStruct.stub(stub[:structure_value]) unless stub[:structure_value].nil?
+        case stub
+        when Types::MyUnion::StringValue
+          data[:string_value] = stub
+        when Types::MyUnion::BooleanValue
+          data[:boolean_value] = stub
+        when Types::MyUnion::NumberValue
+          data[:number_value] = stub
+        when Types::MyUnion::BlobValue
+          data[:blob_value] = Base64::encode64(stub)
+        when Types::MyUnion::TimestampValue
+          data[:timestamp_value] = Hearth::TimeHelper.to_date_time(stub)
+        when Types::MyUnion::EnumValue
+          data[:enum_value] = stub
+        when Types::MyUnion::ListValue
+          data[:list_value] = (Stubs::StringList.stub(stub) unless stub.nil?)
+        when Types::MyUnion::MapValue
+          data[:map_value] = (Stubs::StringMap.stub(stub) unless stub.nil?)
+        when Types::MyUnion::StructureValue
+          data[:structure_value] = (Stubs::GreetingStruct.stub(stub) unless stub.nil?)
+        else
+          raise ArgumentError,
+          "Expected input to be one of the subclasses of Types::MyUnion"
+        end
+
         data
       end
     end

--- a/codegen/projections/rails_json/lib/rails_json/validators.rb
+++ b/codegen/projections/rails_json/lib/rails_json/validators.rb
@@ -35,12 +35,33 @@ module RailsJson
       end
     end
 
+    class AllQueryStringTypesOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::AllQueryStringTypesOutput, context: context)
+      end
+    end
+
     class BooleanList
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, ::Array, context: context)
         input.each_with_index do |element, index|
           Hearth::Validator.validate!(element, ::TrueClass, ::FalseClass, context: "#{context}[#{index}]")
         end
+      end
+    end
+
+    class ComplexError
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::ComplexError, context: context)
+        Hearth::Validator.validate!(input[:top_level], ::String, context: "#{context}[:top_level]")
+        Validators::ComplexNestedErrorData.validate!(input[:nested], context: "#{context}[:nested]") unless input[:nested].nil?
+      end
+    end
+
+    class ComplexNestedErrorData
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::ComplexNestedErrorData, context: context)
+        Hearth::Validator.validate!(input[:foo], ::String, context: "#{context}[:foo]")
       end
     end
 
@@ -52,10 +73,22 @@ module RailsJson
       end
     end
 
+    class ConstantAndVariableQueryStringOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::ConstantAndVariableQueryStringOutput, context: context)
+      end
+    end
+
     class ConstantQueryStringInput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::ConstantQueryStringInput, context: context)
         Hearth::Validator.validate!(input[:hello], ::String, context: "#{context}[:hello]")
+      end
+    end
+
+    class ConstantQueryStringOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::ConstantQueryStringOutput, context: context)
       end
     end
 
@@ -132,9 +165,24 @@ module RailsJson
       end
     end
 
+    class DocumentTypeAsPayloadOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::DocumentTypeAsPayloadOutput, context: context)
+        Validators::Document.validate!(input[:document_value], context: "#{context}[:document_value]") unless input[:document_value].nil?
+      end
+    end
+
     class DocumentTypeInput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::DocumentTypeInput, context: context)
+        Hearth::Validator.validate!(input[:string_value], ::String, context: "#{context}[:string_value]")
+        Validators::Document.validate!(input[:document_value], context: "#{context}[:document_value]") unless input[:document_value].nil?
+      end
+    end
+
+    class DocumentTypeOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::DocumentTypeOutput, context: context)
         Hearth::Validator.validate!(input[:string_value], ::String, context: "#{context}[:string_value]")
         Validators::Document.validate!(input[:document_value], context: "#{context}[:document_value]") unless input[:document_value].nil?
       end
@@ -155,6 +203,12 @@ module RailsJson
       end
     end
 
+    class EmptyOperationOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::EmptyOperationOutput, context: context)
+      end
+    end
+
     class EmptyStruct
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::EmptyStruct, context: context)
@@ -167,10 +221,41 @@ module RailsJson
       end
     end
 
+    class EndpointOperationOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::EndpointOperationOutput, context: context)
+      end
+    end
+
     class EndpointWithHostLabelOperationInput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::EndpointWithHostLabelOperationInput, context: context)
         Hearth::Validator.validate!(input[:label], ::String, context: "#{context}[:label]")
+      end
+    end
+
+    class EndpointWithHostLabelOperationOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::EndpointWithHostLabelOperationOutput, context: context)
+      end
+    end
+
+    class ErrorWithMembers
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::ErrorWithMembers, context: context)
+        Hearth::Validator.validate!(input[:code], ::String, context: "#{context}[:code]")
+        Validators::KitchenSink.validate!(input[:complex_data], context: "#{context}[:complex_data]") unless input[:complex_data].nil?
+        Hearth::Validator.validate!(input[:integer_field], ::Integer, context: "#{context}[:integer_field]")
+        Validators::ListOfStrings.validate!(input[:list_field], context: "#{context}[:list_field]") unless input[:list_field].nil?
+        Validators::MapOfStrings.validate!(input[:map_field], context: "#{context}[:map_field]") unless input[:map_field].nil?
+        Hearth::Validator.validate!(input[:message], ::String, context: "#{context}[:message]")
+        Hearth::Validator.validate!(input[:string_field], ::String, context: "#{context}[:string_field]")
+      end
+    end
+
+    class ErrorWithoutMembers
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::ErrorWithoutMembers, context: context)
       end
     end
 
@@ -215,9 +300,24 @@ module RailsJson
       end
     end
 
+    class GreetingWithErrorsOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::GreetingWithErrorsOutput, context: context)
+        Hearth::Validator.validate!(input[:greeting], ::String, context: "#{context}[:greeting]")
+      end
+    end
+
     class HttpPayloadTraitsInput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::HttpPayloadTraitsInput, context: context)
+        Hearth::Validator.validate!(input[:foo], ::String, context: "#{context}[:foo]")
+        Hearth::Validator.validate!(input[:blob], ::String, context: "#{context}[:blob]")
+      end
+    end
+
+    class HttpPayloadTraitsOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::HttpPayloadTraitsOutput, context: context)
         Hearth::Validator.validate!(input[:foo], ::String, context: "#{context}[:foo]")
         Hearth::Validator.validate!(input[:blob], ::String, context: "#{context}[:blob]")
       end
@@ -231,9 +331,24 @@ module RailsJson
       end
     end
 
+    class HttpPayloadTraitsWithMediaTypeOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::HttpPayloadTraitsWithMediaTypeOutput, context: context)
+        Hearth::Validator.validate!(input[:foo], ::String, context: "#{context}[:foo]")
+        Hearth::Validator.validate!(input[:blob], ::String, context: "#{context}[:blob]")
+      end
+    end
+
     class HttpPayloadWithStructureInput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::HttpPayloadWithStructureInput, context: context)
+        Validators::NestedPayload.validate!(input[:nested], context: "#{context}[:nested]") unless input[:nested].nil?
+      end
+    end
+
+    class HttpPayloadWithStructureOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::HttpPayloadWithStructureOutput, context: context)
         Validators::NestedPayload.validate!(input[:nested], context: "#{context}[:nested]") unless input[:nested].nil?
       end
     end
@@ -244,9 +359,24 @@ module RailsJson
       end
     end
 
+    class HttpPrefixHeadersInResponseOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::HttpPrefixHeadersInResponseOutput, context: context)
+        Validators::StringMap.validate!(input[:prefix_headers], context: "#{context}[:prefix_headers]") unless input[:prefix_headers].nil?
+      end
+    end
+
     class HttpPrefixHeadersInput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::HttpPrefixHeadersInput, context: context)
+        Hearth::Validator.validate!(input[:foo], ::String, context: "#{context}[:foo]")
+        Validators::StringMap.validate!(input[:foo_map], context: "#{context}[:foo_map]") unless input[:foo_map].nil?
+      end
+    end
+
+    class HttpPrefixHeadersOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::HttpPrefixHeadersOutput, context: context)
         Hearth::Validator.validate!(input[:foo], ::String, context: "#{context}[:foo]")
         Validators::StringMap.validate!(input[:foo_map], context: "#{context}[:foo_map]") unless input[:foo_map].nil?
       end
@@ -260,11 +390,23 @@ module RailsJson
       end
     end
 
+    class HttpRequestWithFloatLabelsOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::HttpRequestWithFloatLabelsOutput, context: context)
+      end
+    end
+
     class HttpRequestWithGreedyLabelInPathInput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::HttpRequestWithGreedyLabelInPathInput, context: context)
         Hearth::Validator.validate!(input[:foo], ::String, context: "#{context}[:foo]")
         Hearth::Validator.validate!(input[:baz], ::String, context: "#{context}[:baz]")
+      end
+    end
+
+    class HttpRequestWithGreedyLabelInPathOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::HttpRequestWithGreedyLabelInPathOutput, context: context)
       end
     end
 
@@ -278,6 +420,12 @@ module RailsJson
         Hearth::Validator.validate!(input[:target_epoch_seconds], ::Time, context: "#{context}[:target_epoch_seconds]")
         Hearth::Validator.validate!(input[:target_http_date], ::Time, context: "#{context}[:target_http_date]")
         Hearth::Validator.validate!(input[:target_date_time], ::Time, context: "#{context}[:target_date_time]")
+      end
+    end
+
+    class HttpRequestWithLabelsAndTimestampFormatOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::HttpRequestWithLabelsAndTimestampFormatOutput, context: context)
       end
     end
 
@@ -295,9 +443,22 @@ module RailsJson
       end
     end
 
+    class HttpRequestWithLabelsOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::HttpRequestWithLabelsOutput, context: context)
+      end
+    end
+
     class HttpResponseCodeInput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::HttpResponseCodeInput, context: context)
+      end
+    end
+
+    class HttpResponseCodeOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::HttpResponseCodeOutput, context: context)
+        Hearth::Validator.validate!(input[:status], ::Integer, context: "#{context}[:status]")
       end
     end
 
@@ -307,9 +468,38 @@ module RailsJson
       end
     end
 
+    class IgnoreQueryParamsInResponseOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::IgnoreQueryParamsInResponseOutput, context: context)
+        Hearth::Validator.validate!(input[:baz], ::String, context: "#{context}[:baz]")
+      end
+    end
+
     class InputAndOutputWithHeadersInput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::InputAndOutputWithHeadersInput, context: context)
+        Hearth::Validator.validate!(input[:header_string], ::String, context: "#{context}[:header_string]")
+        Hearth::Validator.validate!(input[:header_byte], ::Integer, context: "#{context}[:header_byte]")
+        Hearth::Validator.validate!(input[:header_short], ::Integer, context: "#{context}[:header_short]")
+        Hearth::Validator.validate!(input[:header_integer], ::Integer, context: "#{context}[:header_integer]")
+        Hearth::Validator.validate!(input[:header_long], ::Integer, context: "#{context}[:header_long]")
+        Hearth::Validator.validate!(input[:header_float], ::Float, context: "#{context}[:header_float]")
+        Hearth::Validator.validate!(input[:header_double], ::Float, context: "#{context}[:header_double]")
+        Hearth::Validator.validate!(input[:header_true_bool], ::TrueClass, ::FalseClass, context: "#{context}[:header_true_bool]")
+        Hearth::Validator.validate!(input[:header_false_bool], ::TrueClass, ::FalseClass, context: "#{context}[:header_false_bool]")
+        Validators::StringList.validate!(input[:header_string_list], context: "#{context}[:header_string_list]") unless input[:header_string_list].nil?
+        Validators::StringSet.validate!(input[:header_string_set], context: "#{context}[:header_string_set]") unless input[:header_string_set].nil?
+        Validators::IntegerList.validate!(input[:header_integer_list], context: "#{context}[:header_integer_list]") unless input[:header_integer_list].nil?
+        Validators::BooleanList.validate!(input[:header_boolean_list], context: "#{context}[:header_boolean_list]") unless input[:header_boolean_list].nil?
+        Validators::TimestampList.validate!(input[:header_timestamp_list], context: "#{context}[:header_timestamp_list]") unless input[:header_timestamp_list].nil?
+        Hearth::Validator.validate!(input[:header_enum], ::String, context: "#{context}[:header_enum]")
+        Validators::FooEnumList.validate!(input[:header_enum_list], context: "#{context}[:header_enum_list]") unless input[:header_enum_list].nil?
+      end
+    end
+
+    class InputAndOutputWithHeadersOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::InputAndOutputWithHeadersOutput, context: context)
         Hearth::Validator.validate!(input[:header_string], ::String, context: "#{context}[:header_string]")
         Hearth::Validator.validate!(input[:header_byte], ::Integer, context: "#{context}[:header_byte]")
         Hearth::Validator.validate!(input[:header_short], ::Integer, context: "#{context}[:header_short]")
@@ -347,9 +537,28 @@ module RailsJson
       end
     end
 
+    class InvalidGreeting
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::InvalidGreeting, context: context)
+        Hearth::Validator.validate!(input[:message], ::String, context: "#{context}[:message]")
+      end
+    end
+
     class JsonEnumsInput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::JsonEnumsInput, context: context)
+        Hearth::Validator.validate!(input[:foo_enum1], ::String, context: "#{context}[:foo_enum1]")
+        Hearth::Validator.validate!(input[:foo_enum2], ::String, context: "#{context}[:foo_enum2]")
+        Hearth::Validator.validate!(input[:foo_enum3], ::String, context: "#{context}[:foo_enum3]")
+        Validators::FooEnumList.validate!(input[:foo_enum_list], context: "#{context}[:foo_enum_list]") unless input[:foo_enum_list].nil?
+        Validators::FooEnumSet.validate!(input[:foo_enum_set], context: "#{context}[:foo_enum_set]") unless input[:foo_enum_set].nil?
+        Validators::FooEnumMap.validate!(input[:foo_enum_map], context: "#{context}[:foo_enum_map]") unless input[:foo_enum_map].nil?
+      end
+    end
+
+    class JsonEnumsOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::JsonEnumsOutput, context: context)
         Hearth::Validator.validate!(input[:foo_enum1], ::String, context: "#{context}[:foo_enum1]")
         Hearth::Validator.validate!(input[:foo_enum2], ::String, context: "#{context}[:foo_enum2]")
         Hearth::Validator.validate!(input[:foo_enum3], ::String, context: "#{context}[:foo_enum3]")
@@ -375,9 +584,32 @@ module RailsJson
       end
     end
 
+    class JsonMapsOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::JsonMapsOutput, context: context)
+        Validators::DenseStructMap.validate!(input[:dense_struct_map], context: "#{context}[:dense_struct_map]") unless input[:dense_struct_map].nil?
+        Validators::SparseStructMap.validate!(input[:sparse_struct_map], context: "#{context}[:sparse_struct_map]") unless input[:sparse_struct_map].nil?
+        Validators::DenseNumberMap.validate!(input[:dense_number_map], context: "#{context}[:dense_number_map]") unless input[:dense_number_map].nil?
+        Validators::DenseBooleanMap.validate!(input[:dense_boolean_map], context: "#{context}[:dense_boolean_map]") unless input[:dense_boolean_map].nil?
+        Validators::DenseStringMap.validate!(input[:dense_string_map], context: "#{context}[:dense_string_map]") unless input[:dense_string_map].nil?
+        Validators::SparseNumberMap.validate!(input[:sparse_number_map], context: "#{context}[:sparse_number_map]") unless input[:sparse_number_map].nil?
+        Validators::SparseBooleanMap.validate!(input[:sparse_boolean_map], context: "#{context}[:sparse_boolean_map]") unless input[:sparse_boolean_map].nil?
+        Validators::SparseStringMap.validate!(input[:sparse_string_map], context: "#{context}[:sparse_string_map]") unless input[:sparse_string_map].nil?
+        Validators::DenseSetMap.validate!(input[:dense_set_map], context: "#{context}[:dense_set_map]") unless input[:dense_set_map].nil?
+        Validators::SparseSetMap.validate!(input[:sparse_set_map], context: "#{context}[:sparse_set_map]") unless input[:sparse_set_map].nil?
+      end
+    end
+
     class JsonUnionsInput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::JsonUnionsInput, context: context)
+        Validators::MyUnion.validate!(input[:contents], context: "#{context}[:contents]") unless input[:contents].nil?
+      end
+    end
+
+    class JsonUnionsOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::JsonUnionsOutput, context: context)
         Validators::MyUnion.validate!(input[:contents], context: "#{context}[:contents]") unless input[:contents].nil?
       end
     end
@@ -417,6 +649,38 @@ module RailsJson
     class KitchenSinkOperationInput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::KitchenSinkOperationInput, context: context)
+        Hearth::Validator.validate!(input[:blob], ::String, context: "#{context}[:blob]")
+        Hearth::Validator.validate!(input[:boolean], ::TrueClass, ::FalseClass, context: "#{context}[:boolean]")
+        Hearth::Validator.validate!(input[:double], ::Float, context: "#{context}[:double]")
+        Validators::EmptyStruct.validate!(input[:empty_struct], context: "#{context}[:empty_struct]") unless input[:empty_struct].nil?
+        Hearth::Validator.validate!(input[:float], ::Float, context: "#{context}[:float]")
+        Hearth::Validator.validate!(input[:httpdate_timestamp], ::Time, context: "#{context}[:httpdate_timestamp]")
+        Hearth::Validator.validate!(input[:integer], ::Integer, context: "#{context}[:integer]")
+        Hearth::Validator.validate!(input[:iso8601_timestamp], ::Time, context: "#{context}[:iso8601_timestamp]")
+        Hearth::Validator.validate!(input[:json_value], ::String, context: "#{context}[:json_value]")
+        Validators::ListOfListOfStrings.validate!(input[:list_of_lists], context: "#{context}[:list_of_lists]") unless input[:list_of_lists].nil?
+        Validators::ListOfMapsOfStrings.validate!(input[:list_of_maps_of_strings], context: "#{context}[:list_of_maps_of_strings]") unless input[:list_of_maps_of_strings].nil?
+        Validators::ListOfStrings.validate!(input[:list_of_strings], context: "#{context}[:list_of_strings]") unless input[:list_of_strings].nil?
+        Validators::ListOfStructs.validate!(input[:list_of_structs], context: "#{context}[:list_of_structs]") unless input[:list_of_structs].nil?
+        Hearth::Validator.validate!(input[:long], ::Integer, context: "#{context}[:long]")
+        Validators::MapOfListsOfStrings.validate!(input[:map_of_lists_of_strings], context: "#{context}[:map_of_lists_of_strings]") unless input[:map_of_lists_of_strings].nil?
+        Validators::MapOfMapOfStrings.validate!(input[:map_of_maps], context: "#{context}[:map_of_maps]") unless input[:map_of_maps].nil?
+        Validators::MapOfStrings.validate!(input[:map_of_strings], context: "#{context}[:map_of_strings]") unless input[:map_of_strings].nil?
+        Validators::MapOfStructs.validate!(input[:map_of_structs], context: "#{context}[:map_of_structs]") unless input[:map_of_structs].nil?
+        Validators::ListOfKitchenSinks.validate!(input[:recursive_list], context: "#{context}[:recursive_list]") unless input[:recursive_list].nil?
+        Validators::MapOfKitchenSinks.validate!(input[:recursive_map], context: "#{context}[:recursive_map]") unless input[:recursive_map].nil?
+        Validators::KitchenSink.validate!(input[:recursive_struct], context: "#{context}[:recursive_struct]") unless input[:recursive_struct].nil?
+        Validators::SimpleStruct.validate!(input[:simple_struct], context: "#{context}[:simple_struct]") unless input[:simple_struct].nil?
+        Hearth::Validator.validate!(input[:string], ::String, context: "#{context}[:string]")
+        Validators::StructWithLocationName.validate!(input[:struct_with_location_name], context: "#{context}[:struct_with_location_name]") unless input[:struct_with_location_name].nil?
+        Hearth::Validator.validate!(input[:timestamp], ::Time, context: "#{context}[:timestamp]")
+        Hearth::Validator.validate!(input[:unix_timestamp], ::Time, context: "#{context}[:unix_timestamp]")
+      end
+    end
+
+    class KitchenSinkOperationOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::KitchenSinkOperationOutput, context: context)
         Hearth::Validator.validate!(input[:blob], ::String, context: "#{context}[:blob]")
         Hearth::Validator.validate!(input[:boolean], ::TrueClass, ::FalseClass, context: "#{context}[:boolean]")
         Hearth::Validator.validate!(input[:double], ::Float, context: "#{context}[:double]")
@@ -548,6 +812,13 @@ module RailsJson
       end
     end
 
+    class MediaTypeHeaderOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::MediaTypeHeaderOutput, context: context)
+        Hearth::Validator.validate!(input[:json], ::String, context: "#{context}[:json]")
+      end
+    end
+
     class MyUnion
       def self.validate!(input, context:)
         case input
@@ -638,6 +909,13 @@ module RailsJson
       end
     end
 
+    class NestedAttributesOperationOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::NestedAttributesOperationOutput, context: context)
+        Hearth::Validator.validate!(input[:value], ::String, context: "#{context}[:value]")
+      end
+    end
+
     class NestedPayload
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::NestedPayload, context: context)
@@ -655,9 +933,27 @@ module RailsJson
       end
     end
 
+    class NullAndEmptyHeadersClientOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::NullAndEmptyHeadersClientOutput, context: context)
+        Hearth::Validator.validate!(input[:a], ::String, context: "#{context}[:a]")
+        Hearth::Validator.validate!(input[:b], ::String, context: "#{context}[:b]")
+        Validators::StringList.validate!(input[:c], context: "#{context}[:c]") unless input[:c].nil?
+      end
+    end
+
     class NullOperationInput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::NullOperationInput, context: context)
+        Hearth::Validator.validate!(input[:string], ::String, context: "#{context}[:string]")
+        Validators::SparseStringList.validate!(input[:sparse_string_list], context: "#{context}[:sparse_string_list]") unless input[:sparse_string_list].nil?
+        Validators::SparseStringMap.validate!(input[:sparse_string_map], context: "#{context}[:sparse_string_map]") unless input[:sparse_string_map].nil?
+      end
+    end
+
+    class NullOperationOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::NullOperationOutput, context: context)
         Hearth::Validator.validate!(input[:string], ::String, context: "#{context}[:string]")
         Validators::SparseStringList.validate!(input[:sparse_string_list], context: "#{context}[:sparse_string_list]") unless input[:sparse_string_list].nil?
         Validators::SparseStringMap.validate!(input[:sparse_string_map], context: "#{context}[:sparse_string_map]") unless input[:sparse_string_map].nil?
@@ -672,9 +968,22 @@ module RailsJson
       end
     end
 
+    class OmitsNullSerializesEmptyStringOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::OmitsNullSerializesEmptyStringOutput, context: context)
+      end
+    end
+
     class OperationWithOptionalInputOutputInput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::OperationWithOptionalInputOutputInput, context: context)
+        Hearth::Validator.validate!(input[:value], ::String, context: "#{context}[:value]")
+      end
+    end
+
+    class OperationWithOptionalInputOutputOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::OperationWithOptionalInputOutputOutput, context: context)
         Hearth::Validator.validate!(input[:value], ::String, context: "#{context}[:value]")
       end
     end
@@ -686,11 +995,23 @@ module RailsJson
       end
     end
 
+    class QueryIdempotencyTokenAutoFillOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::QueryIdempotencyTokenAutoFillOutput, context: context)
+      end
+    end
+
     class QueryParamsAsStringListMapInput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::QueryParamsAsStringListMapInput, context: context)
         Hearth::Validator.validate!(input[:qux], ::String, context: "#{context}[:qux]")
         Validators::StringListMap.validate!(input[:foo], context: "#{context}[:foo]") unless input[:foo].nil?
+      end
+    end
+
+    class QueryParamsAsStringListMapOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::QueryParamsAsStringListMapOutput, context: context)
       end
     end
 
@@ -818,6 +1139,19 @@ module RailsJson
       end
     end
 
+    class TimestampFormatHeadersOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::TimestampFormatHeadersOutput, context: context)
+        Hearth::Validator.validate!(input[:member_epoch_seconds], ::Time, context: "#{context}[:member_epoch_seconds]")
+        Hearth::Validator.validate!(input[:member_http_date], ::Time, context: "#{context}[:member_http_date]")
+        Hearth::Validator.validate!(input[:member_date_time], ::Time, context: "#{context}[:member_date_time]")
+        Hearth::Validator.validate!(input[:default_format], ::Time, context: "#{context}[:default_format]")
+        Hearth::Validator.validate!(input[:target_epoch_seconds], ::Time, context: "#{context}[:target_epoch_seconds]")
+        Hearth::Validator.validate!(input[:target_http_date], ::Time, context: "#{context}[:target_http_date]")
+        Hearth::Validator.validate!(input[:target_date_time], ::Time, context: "#{context}[:target_date_time]")
+      end
+    end
+
     class TimestampList
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, ::Array, context: context)
@@ -838,6 +1172,13 @@ module RailsJson
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::Struct____789BadNameInput, context: context)
         Hearth::Validator.validate!(input[:member____123abc], ::String, context: "#{context}[:member____123abc]")
+        Validators::Struct____456efg.validate!(input[:member], context: "#{context}[:member]") unless input[:member].nil?
+      end
+    end
+
+    class Struct____789BadNameOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::Struct____789BadNameOutput, context: context)
         Validators::Struct____456efg.validate!(input[:member], context: "#{context}[:member]") unless input[:member].nil?
       end
     end

--- a/codegen/projections/weather/lib/weather/client.rb
+++ b/codegen/projections/weather/lib/weather/client.rb
@@ -482,5 +482,25 @@ module Weather
 
       StringIO.new
     end
+
+    def transform_stubs(operation_name, stubs)
+      param_class = case operation_name
+      when :get_city then Params::GetCityOutput
+      when :get_city_announcements then Params::GetCityAnnouncementsOutput
+      when :get_city_image then Params::GetCityImageOutput
+      when :get_current_time then Params::GetCurrentTimeOutput
+      when :get_forecast then Params::GetForecastOutput
+      when :list_cities then Params::ListCitiesOutput
+      when :operation____789_bad_name then Params::Struct____789BadNameOutput
+      end
+
+      stubs.map do |stub|
+        if Hash === stub
+          param_class.build(stub)
+        else
+          stub
+        end
+      end
+    end
   end
 end

--- a/codegen/projections/weather/lib/weather/params.rb
+++ b/codegen/projections/weather/lib/weather/params.rb
@@ -12,11 +12,103 @@ require 'securerandom'
 module Weather
   module Params
 
+    module Announcements
+      def self.build(params, context: '')
+        return params if params.is_a?(Types::Announcements)
+        Hearth::Validator.validate!(params, ::Hash, Types::Announcements, context: context)
+        unless params.size == 1
+          raise ArgumentError,
+                "Expected #{context} to have exactly one member, got: #{params}"
+        end
+        key, value = params.flatten
+        case key
+        when :police
+          Types::Announcements::Police.new(
+            (Message.build(params[:police], context: "#{context}[:police]") unless params[:police].nil?)
+          )
+        when :fire
+          Types::Announcements::Fire.new(
+            (Message.build(params[:fire], context: "#{context}[:fire]") unless params[:fire].nil?)
+          )
+        when :health
+          Types::Announcements::Health.new(
+            (Message.build(params[:health], context: "#{context}[:health]") unless params[:health].nil?)
+          )
+        else
+          raise ArgumentError,
+                "Expected #{context} to have one of :police, :fire, :health set"
+        end
+      end
+    end
+
+    module Baz
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::Baz, context: context)
+        type = Types::Baz.new
+        type.baz = params[:baz]
+        type.bar = params[:bar]
+        type
+      end
+    end
+
+    module CityCoordinates
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::CityCoordinates, context: context)
+        type = Types::CityCoordinates.new
+        type.latitude = params[:latitude]
+        type.longitude = params[:longitude]
+        type
+      end
+    end
+
+    module CitySummaries
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Array, context: context)
+        data = []
+        params.each_with_index do |element, index|
+          data << CitySummary.build(element, context: "#{context}[#{index}]") unless element.nil?
+        end
+        data
+      end
+    end
+
+    module CitySummary
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::CitySummary, context: context)
+        type = Types::CitySummary.new
+        type.city_id = params[:city_id]
+        type.member_name = params[:member_name]
+        type.number = params[:number]
+        type.case = params[:case]
+        type
+      end
+    end
+
+    module Foo
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::Foo, context: context)
+        type = Types::Foo.new
+        type.baz = params[:baz]
+        type.bar = params[:bar]
+        type
+      end
+    end
+
     module GetCityAnnouncementsInput
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::GetCityAnnouncementsInput, context: context)
         type = Types::GetCityAnnouncementsInput.new
         type.city_id = params[:city_id]
+        type
+      end
+    end
+
+    module GetCityAnnouncementsOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::GetCityAnnouncementsOutput, context: context)
+        type = Types::GetCityAnnouncementsOutput.new
+        type.last_updated = params[:last_updated]
+        type.announcements = Announcements.build(params[:announcements], context: "#{context}[:announcements]") unless params[:announcements].nil?
         type
       end
     end
@@ -31,11 +123,31 @@ module Weather
       end
     end
 
+    module GetCityImageOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::GetCityImageOutput, context: context)
+        type = Types::GetCityImageOutput.new
+        type.image = params[:image]
+        type
+      end
+    end
+
     module GetCityInput
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::GetCityInput, context: context)
         type = Types::GetCityInput.new
         type.city_id = params[:city_id]
+        type
+      end
+    end
+
+    module GetCityOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::GetCityOutput, context: context)
+        type = Types::GetCityOutput.new
+        type.member_name = params[:member_name]
+        type.coordinates = CityCoordinates.build(params[:coordinates], context: "#{context}[:coordinates]") unless params[:coordinates].nil?
+        type.city = CitySummary.build(params[:city], context: "#{context}[:city]") unless params[:city].nil?
         type
       end
     end
@@ -48,11 +160,30 @@ module Weather
       end
     end
 
+    module GetCurrentTimeOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::GetCurrentTimeOutput, context: context)
+        type = Types::GetCurrentTimeOutput.new
+        type.time = params[:time]
+        type
+      end
+    end
+
     module GetForecastInput
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::GetForecastInput, context: context)
         type = Types::GetForecastInput.new
         type.city_id = params[:city_id]
+        type
+      end
+    end
+
+    module GetForecastOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::GetForecastOutput, context: context)
+        type = Types::GetForecastOutput.new
+        type.chance_of_rain = params[:chance_of_rain]
+        type.precipitation = Precipitation.build(params[:precipitation], context: "#{context}[:precipitation]") unless params[:precipitation].nil?
         type
       end
     end
@@ -98,6 +229,51 @@ module Weather
       end
     end
 
+    module ListCitiesOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::ListCitiesOutput, context: context)
+        type = Types::ListCitiesOutput.new
+        type.next_token = params[:next_token]
+        type.some_enum = params[:some_enum]
+        type.a_string = params[:a_string]
+        type.default_bool = params[:default_bool]
+        type.boxed_bool = params[:boxed_bool]
+        type.default_number = params[:default_number]
+        type.boxed_number = params[:boxed_number]
+        type.items = CitySummaries.build(params[:items], context: "#{context}[:items]") unless params[:items].nil?
+        type.sparse_items = SparseCitySummaries.build(params[:sparse_items], context: "#{context}[:sparse_items]") unless params[:sparse_items].nil?
+        type
+      end
+    end
+
+    module Message
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::Message, context: context)
+        type = Types::Message.new
+        type.message = params[:message]
+        type.author = params[:author]
+        type
+      end
+    end
+
+    module NoSuchResource
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::NoSuchResource, context: context)
+        type = Types::NoSuchResource.new
+        type.resource_type = params[:resource_type]
+        type.message = params[:message]
+        type
+      end
+    end
+
+    module OtherStructure
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::OtherStructure, context: context)
+        type = Types::OtherStructure.new
+        type
+      end
+    end
+
     module PNGImage
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::PNGImage, context: context)
@@ -105,6 +281,81 @@ module Weather
         type.height = params[:height]
         type.width = params[:width]
         type
+      end
+    end
+
+    module Precipitation
+      def self.build(params, context: '')
+        return params if params.is_a?(Types::Precipitation)
+        Hearth::Validator.validate!(params, ::Hash, Types::Precipitation, context: context)
+        unless params.size == 1
+          raise ArgumentError,
+                "Expected #{context} to have exactly one member, got: #{params}"
+        end
+        key, value = params.flatten
+        case key
+        when :rain
+          Types::Precipitation::Rain.new(
+            params[:rain]
+          )
+        when :sleet
+          Types::Precipitation::Sleet.new(
+            params[:sleet]
+          )
+        when :hail
+          Types::Precipitation::Hail.new(
+            (StringMap.build(params[:hail], context: "#{context}[:hail]") unless params[:hail].nil?)
+          )
+        when :snow
+          Types::Precipitation::Snow.new(
+            params[:snow]
+          )
+        when :mixed
+          Types::Precipitation::Mixed.new(
+            params[:mixed]
+          )
+        when :other
+          Types::Precipitation::Other.new(
+            (OtherStructure.build(params[:other], context: "#{context}[:other]") unless params[:other].nil?)
+          )
+        when :blob
+          Types::Precipitation::Blob.new(
+            params[:blob]
+          )
+        when :foo
+          Types::Precipitation::Foo.new(
+            (Foo.build(params[:foo], context: "#{context}[:foo]") unless params[:foo].nil?)
+          )
+        when :baz
+          Types::Precipitation::Baz.new(
+            (Baz.build(params[:baz], context: "#{context}[:baz]") unless params[:baz].nil?)
+          )
+        else
+          raise ArgumentError,
+                "Expected #{context} to have one of :rain, :sleet, :hail, :snow, :mixed, :other, :blob, :foo, :baz set"
+        end
+      end
+    end
+
+    module SparseCitySummaries
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Array, context: context)
+        data = []
+        params.each_with_index do |element, index|
+          data << (CitySummary.build(element, context: "#{context}[#{index}]") unless element.nil?)
+        end
+        data
+      end
+    end
+
+    module StringMap
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, context: context)
+        data = {}
+        params.each do |key, value|
+          data[key] = value
+        end
+        data
       end
     end
 
@@ -121,6 +372,16 @@ module Weather
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::Struct____789BadNameInput, context: context)
         type = Types::Struct____789BadNameInput.new
+        type.member____123abc = params[:member____123abc]
+        type.member = Struct____456efg.build(params[:member], context: "#{context}[:member]") unless params[:member].nil?
+        type
+      end
+    end
+
+    module Struct____789BadNameOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::Struct____789BadNameOutput, context: context)
+        type = Types::Struct____789BadNameOutput.new
         type.member____123abc = params[:member____123abc]
         type.member = Struct____456efg.build(params[:member], context: "#{context}[:member]") unless params[:member].nil?
         type

--- a/codegen/projections/weather/lib/weather/stubs.rb
+++ b/codegen/projections/weather/lib/weather/stubs.rb
@@ -76,9 +76,8 @@ module Weather
       def self.default(visited=[])
         return nil if visited.include?('Announcements')
         visited = visited + ['Announcements']
-        {
-          police: Stubs::Message.default(visited),
-        }
+        value = Stubs::Message.default(visited)
+        Types::Announcements::Police.new(value)
       end
 
     end
@@ -145,9 +144,8 @@ module Weather
       def self.default(visited=[])
         return nil if visited.include?('Precipitation')
         visited = visited + ['Precipitation']
-        {
-          rain: false,
-        }
+        value = false
+        Types::Precipitation::Rain.new(value)
       end
 
     end

--- a/codegen/projections/weather/lib/weather/validators.rb
+++ b/codegen/projections/weather/lib/weather/validators.rb
@@ -10,10 +10,96 @@
 module Weather
   module Validators
 
+    class Announcements
+      def self.validate!(input, context:)
+        case input
+        when Types::Announcements::Police
+          Validators::Message.validate!(input.__getobj__, context: context) unless input.__getobj__.nil?
+        when Types::Announcements::Fire
+          Validators::Message.validate!(input.__getobj__, context: context) unless input.__getobj__.nil?
+        when Types::Announcements::Health
+          Validators::Message.validate!(input.__getobj__, context: context) unless input.__getobj__.nil?
+        else
+          raise ArgumentError,
+                "Expected #{context} to be a union member of "\
+                "Types::Announcements, got #{input.class}."
+        end
+      end
+
+      class Police
+        def self.validate!(input, context:)
+          Validators::Message.validate!(input, context: context) unless input.nil?
+        end
+      end
+
+      class Fire
+        def self.validate!(input, context:)
+          Validators::Message.validate!(input, context: context) unless input.nil?
+        end
+      end
+
+      class Health
+        def self.validate!(input, context:)
+          Validators::Message.validate!(input, context: context) unless input.nil?
+        end
+      end
+    end
+
+    class Baz
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::Baz, context: context)
+        Hearth::Validator.validate!(input[:baz], ::String, context: "#{context}[:baz]")
+        Hearth::Validator.validate!(input[:bar], ::String, context: "#{context}[:bar]")
+      end
+    end
+
+    class CityCoordinates
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::CityCoordinates, context: context)
+        Hearth::Validator.validate!(input[:latitude], ::Float, context: "#{context}[:latitude]")
+        Hearth::Validator.validate!(input[:longitude], ::Float, context: "#{context}[:longitude]")
+      end
+    end
+
+    class CitySummaries
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, ::Array, context: context)
+        input.each_with_index do |element, index|
+          Validators::CitySummary.validate!(element, context: "#{context}[#{index}]") unless element.nil?
+        end
+      end
+    end
+
+    class CitySummary
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::CitySummary, context: context)
+        Hearth::Validator.validate!(input[:city_id], ::String, context: "#{context}[:city_id]")
+        Hearth::Validator.validate!(input[:member_name], ::String, context: "#{context}[:member_name]")
+        Hearth::Validator.validate!(input[:number], ::String, context: "#{context}[:number]")
+        Hearth::Validator.validate!(input[:case], ::String, context: "#{context}[:case]")
+      end
+    end
+
+    class Foo
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::Foo, context: context)
+        Hearth::Validator.validate!(input[:baz], ::String, context: "#{context}[:baz]")
+        Hearth::Validator.validate!(input[:bar], ::String, context: "#{context}[:bar]")
+      end
+    end
+
     class GetCityAnnouncementsInput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::GetCityAnnouncementsInput, context: context)
         Hearth::Validator.validate!(input[:city_id], ::String, context: "#{context}[:city_id]")
+      end
+    end
+
+    class GetCityAnnouncementsOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::GetCityAnnouncementsOutput, context: context)
+        Hearth::Validator.validate!(input[:last_updated], ::Time, context: "#{context}[:last_updated]")
+        Validators::Announcements.validate!(input[:announcements], context: "#{context}[:announcements]") unless input[:announcements].nil?
       end
     end
 
@@ -25,10 +111,26 @@ module Weather
       end
     end
 
+    class GetCityImageOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::GetCityImageOutput, context: context)
+        Hearth::Validator.validate!(input[:image], ::String, context: "#{context}[:image]")
+      end
+    end
+
     class GetCityInput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::GetCityInput, context: context)
         Hearth::Validator.validate!(input[:city_id], ::String, context: "#{context}[:city_id]")
+      end
+    end
+
+    class GetCityOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::GetCityOutput, context: context)
+        Hearth::Validator.validate!(input[:member_name], ::String, context: "#{context}[:member_name]")
+        Validators::CityCoordinates.validate!(input[:coordinates], context: "#{context}[:coordinates]") unless input[:coordinates].nil?
+        Validators::CitySummary.validate!(input[:city], context: "#{context}[:city]") unless input[:city].nil?
       end
     end
 
@@ -38,10 +140,25 @@ module Weather
       end
     end
 
+    class GetCurrentTimeOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::GetCurrentTimeOutput, context: context)
+        Hearth::Validator.validate!(input[:time], ::Time, context: "#{context}[:time]")
+      end
+    end
+
     class GetForecastInput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::GetForecastInput, context: context)
         Hearth::Validator.validate!(input[:city_id], ::String, context: "#{context}[:city_id]")
+      end
+    end
+
+    class GetForecastOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::GetForecastOutput, context: context)
+        Hearth::Validator.validate!(input[:chance_of_rain], ::Float, context: "#{context}[:chance_of_rain]")
+        Validators::Precipitation.validate!(input[:precipitation], context: "#{context}[:precipitation]") unless input[:precipitation].nil?
       end
     end
 
@@ -86,11 +203,150 @@ module Weather
       end
     end
 
+    class ListCitiesOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::ListCitiesOutput, context: context)
+        Hearth::Validator.validate!(input[:next_token], ::String, context: "#{context}[:next_token]")
+        Hearth::Validator.validate!(input[:some_enum], ::String, context: "#{context}[:some_enum]")
+        Hearth::Validator.validate!(input[:a_string], ::String, context: "#{context}[:a_string]")
+        Hearth::Validator.validate!(input[:default_bool], ::TrueClass, ::FalseClass, context: "#{context}[:default_bool]")
+        Hearth::Validator.validate!(input[:boxed_bool], ::TrueClass, ::FalseClass, context: "#{context}[:boxed_bool]")
+        Hearth::Validator.validate!(input[:default_number], ::Integer, context: "#{context}[:default_number]")
+        Hearth::Validator.validate!(input[:boxed_number], ::Integer, context: "#{context}[:boxed_number]")
+        Validators::CitySummaries.validate!(input[:items], context: "#{context}[:items]") unless input[:items].nil?
+        Validators::SparseCitySummaries.validate!(input[:sparse_items], context: "#{context}[:sparse_items]") unless input[:sparse_items].nil?
+      end
+    end
+
+    class Message
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::Message, context: context)
+        Hearth::Validator.validate!(input[:message], ::String, context: "#{context}[:message]")
+        Hearth::Validator.validate!(input[:author], ::String, context: "#{context}[:author]")
+      end
+    end
+
+    class NoSuchResource
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::NoSuchResource, context: context)
+        Hearth::Validator.validate!(input[:resource_type], ::String, context: "#{context}[:resource_type]")
+        Hearth::Validator.validate!(input[:message], ::String, context: "#{context}[:message]")
+      end
+    end
+
+    class OtherStructure
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::OtherStructure, context: context)
+      end
+    end
+
     class PNGImage
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::PNGImage, context: context)
         Hearth::Validator.validate!(input[:height], ::Integer, context: "#{context}[:height]")
         Hearth::Validator.validate!(input[:width], ::Integer, context: "#{context}[:width]")
+      end
+    end
+
+    class Precipitation
+      def self.validate!(input, context:)
+        case input
+        when Types::Precipitation::Rain
+          Hearth::Validator.validate!(input.__getobj__, ::TrueClass, ::FalseClass, context: context)
+        when Types::Precipitation::Sleet
+          Hearth::Validator.validate!(input.__getobj__, ::TrueClass, ::FalseClass, context: context)
+        when Types::Precipitation::Hail
+          Validators::StringMap.validate!(input.__getobj__, context: context) unless input.__getobj__.nil?
+        when Types::Precipitation::Snow
+          Hearth::Validator.validate!(input.__getobj__, ::String, context: context)
+        when Types::Precipitation::Mixed
+          Hearth::Validator.validate!(input.__getobj__, ::String, context: context)
+        when Types::Precipitation::Other
+          Validators::OtherStructure.validate!(input.__getobj__, context: context) unless input.__getobj__.nil?
+        when Types::Precipitation::Blob
+          Hearth::Validator.validate!(input.__getobj__, ::String, context: context)
+        when Types::Precipitation::Foo
+          Validators::Foo.validate!(input.__getobj__, context: context) unless input.__getobj__.nil?
+        when Types::Precipitation::Baz
+          Validators::Baz.validate!(input.__getobj__, context: context) unless input.__getobj__.nil?
+        else
+          raise ArgumentError,
+                "Expected #{context} to be a union member of "\
+                "Types::Precipitation, got #{input.class}."
+        end
+      end
+
+      class Rain
+        def self.validate!(input, context:)
+          Hearth::Validator.validate!(input, ::TrueClass, ::FalseClass, context: context)
+        end
+      end
+
+      class Sleet
+        def self.validate!(input, context:)
+          Hearth::Validator.validate!(input, ::TrueClass, ::FalseClass, context: context)
+        end
+      end
+
+      class Hail
+        def self.validate!(input, context:)
+          Validators::StringMap.validate!(input, context: context) unless input.nil?
+        end
+      end
+
+      class Snow
+        def self.validate!(input, context:)
+          Hearth::Validator.validate!(input, ::String, context: context)
+        end
+      end
+
+      class Mixed
+        def self.validate!(input, context:)
+          Hearth::Validator.validate!(input, ::String, context: context)
+        end
+      end
+
+      class Other
+        def self.validate!(input, context:)
+          Validators::OtherStructure.validate!(input, context: context) unless input.nil?
+        end
+      end
+
+      class Blob
+        def self.validate!(input, context:)
+          Hearth::Validator.validate!(input, ::String, context: context)
+        end
+      end
+
+      class Foo
+        def self.validate!(input, context:)
+          Validators::Foo.validate!(input, context: context) unless input.nil?
+        end
+      end
+
+      class Baz
+        def self.validate!(input, context:)
+          Validators::Baz.validate!(input, context: context) unless input.nil?
+        end
+      end
+    end
+
+    class SparseCitySummaries
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, ::Array, context: context)
+        input.each_with_index do |element, index|
+          Validators::CitySummary.validate!(element, context: "#{context}[#{index}]") unless element.nil?
+        end
+      end
+    end
+
+    class StringMap
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, ::Hash, context: context)
+        input.each do |key, value|
+          Hearth::Validator.validate!(key, ::String, ::Symbol, context: "#{context}.keys")
+          Hearth::Validator.validate!(value, ::String, context: "#{context}[:#{key}]")
+        end
       end
     end
 
@@ -104,6 +360,14 @@ module Weather
     class Struct____789BadNameInput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::Struct____789BadNameInput, context: context)
+        Hearth::Validator.validate!(input[:member____123abc], ::String, context: "#{context}[:member____123abc]")
+        Validators::Struct____456efg.validate!(input[:member], context: "#{context}[:member]") unless input[:member].nil?
+      end
+    end
+
+    class Struct____789BadNameOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::Struct____789BadNameOutput, context: context)
         Hearth::Validator.validate!(input[:member____123abc], ::String, context: "#{context}[:member____123abc]")
         Validators::Struct____456efg.validate!(input[:member], context: "#{context}[:member]") unless input[:member].nil?
       end

--- a/codegen/projections/white_label/lib/white_label/client.rb
+++ b/codegen/projections/white_label/lib/white_label/client.rb
@@ -533,5 +533,23 @@ module WhiteLabel
 
       StringIO.new
     end
+
+    def transform_stubs(operation_name, stubs)
+      param_class = case operation_name
+      when :kitchen_sink then Params::KitchenSinkOutput
+      when :paginators_test then Params::PaginatorsTestOperationOutput
+      when :paginators_test_with_items then Params::PaginatorsTestWithItemsOutput
+      when :waiters_test then Params::WaitersTestOutput
+      when :operation____paginators_test_with_bad_names then Params::Struct____PaginatorsTestWithBadNamesOutput
+      end
+
+      stubs.map do |stub|
+        if Hash === stub
+          param_class.build(stub)
+        else
+          stub
+        end
+      end
+    end
   end
 end

--- a/codegen/projections/white_label/lib/white_label/params.rb
+++ b/codegen/projections/white_label/lib/white_label/params.rb
@@ -12,10 +12,47 @@ require 'securerandom'
 module WhiteLabel
   module Params
 
+    module ClientError
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::ClientError, context: context)
+        type = Types::ClientError.new
+        type.message = params[:message]
+        type
+      end
+    end
+
+    module Items
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Array, context: context)
+        data = []
+        params.each_with_index do |element, index|
+          data << element
+        end
+        data
+      end
+    end
+
     module KitchenSinkInput
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::KitchenSinkInput, context: context)
         type = Types::KitchenSinkInput.new
+        type.string = params[:string]
+        type.struct = Struct.build(params[:struct], context: "#{context}[:struct]") unless params[:struct].nil?
+        type.document = params[:document]
+        type.list_of_strings = ListOfStrings.build(params[:list_of_strings], context: "#{context}[:list_of_strings]") unless params[:list_of_strings].nil?
+        type.list_of_structs = ListOfStructs.build(params[:list_of_structs], context: "#{context}[:list_of_structs]") unless params[:list_of_structs].nil?
+        type.map_of_strings = MapOfStrings.build(params[:map_of_strings], context: "#{context}[:map_of_strings]") unless params[:map_of_strings].nil?
+        type.map_of_structs = MapOfStructs.build(params[:map_of_structs], context: "#{context}[:map_of_structs]") unless params[:map_of_structs].nil?
+        type.set_of_strings = SetOfStrings.build(params[:set_of_strings], context: "#{context}[:set_of_strings]") unless params[:set_of_strings].nil?
+        type.union = Union.build(params[:union], context: "#{context}[:union]") unless params[:union].nil?
+        type
+      end
+    end
+
+    module KitchenSinkOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::KitchenSinkOutput, context: context)
+        type = Types::KitchenSinkOutput.new
         type.string = params[:string]
         type.struct = Struct.build(params[:struct], context: "#{context}[:struct]") unless params[:struct].nil?
         type.document = params[:document]
@@ -82,11 +119,48 @@ module WhiteLabel
       end
     end
 
+    module PaginatorsTestOperationOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::PaginatorsTestOperationOutput, context: context)
+        type = Types::PaginatorsTestOperationOutput.new
+        type.next_token = params[:next_token]
+        type.items = Items.build(params[:items], context: "#{context}[:items]") unless params[:items].nil?
+        type
+      end
+    end
+
     module PaginatorsTestWithItemsInput
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::PaginatorsTestWithItemsInput, context: context)
         type = Types::PaginatorsTestWithItemsInput.new
         type.next_token = params[:next_token]
+        type
+      end
+    end
+
+    module PaginatorsTestWithItemsOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::PaginatorsTestWithItemsOutput, context: context)
+        type = Types::PaginatorsTestWithItemsOutput.new
+        type.next_token = params[:next_token]
+        type.items = Items.build(params[:items], context: "#{context}[:items]") unless params[:items].nil?
+        type
+      end
+    end
+
+    module ResultWrapper
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::ResultWrapper, context: context)
+        type = Types::ResultWrapper.new
+        type.member____123next_token = params[:member____123next_token]
+        type
+      end
+    end
+
+    module ServerError
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::ServerError, context: context)
+        type = Types::ServerError.new
         type
       end
     end
@@ -145,11 +219,30 @@ module WhiteLabel
       end
     end
 
+    module WaitersTestOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::WaitersTestOutput, context: context)
+        type = Types::WaitersTestOutput.new
+        type.status = params[:status]
+        type
+      end
+    end
+
     module Struct____PaginatorsTestWithBadNamesInput
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::Struct____PaginatorsTestWithBadNamesInput, context: context)
         type = Types::Struct____PaginatorsTestWithBadNamesInput.new
         type.member____next_token = params[:member____next_token]
+        type
+      end
+    end
+
+    module Struct____PaginatorsTestWithBadNamesOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::Struct____PaginatorsTestWithBadNamesOutput, context: context)
+        type = Types::Struct____PaginatorsTestWithBadNamesOutput.new
+        type.member____wrapper = ResultWrapper.build(params[:member____wrapper], context: "#{context}[:member____wrapper]") unless params[:member____wrapper].nil?
+        type.member____items = Items.build(params[:member____items], context: "#{context}[:member____items]") unless params[:member____items].nil?
         type
       end
     end

--- a/codegen/projections/white_label/lib/white_label/stubs.rb
+++ b/codegen/projections/white_label/lib/white_label/stubs.rb
@@ -37,9 +37,8 @@ module WhiteLabel
       def self.default(visited=[])
         return nil if visited.include?('Union')
         visited = visited + ['Union']
-        {
-          string: 'string',
-        }
+        value = 'string'
+        Types::Union::String.new(value)
       end
 
     end

--- a/codegen/projections/white_label/lib/white_label/validators.rb
+++ b/codegen/projections/white_label/lib/white_label/validators.rb
@@ -10,6 +10,13 @@
 module WhiteLabel
   module Validators
 
+    class ClientError
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::ClientError, context: context)
+        Hearth::Validator.validate!(input[:message], ::String, context: "#{context}[:message]")
+      end
+    end
+
     class Document
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, ::Hash, ::String, ::Array, ::TrueClass, ::FalseClass, ::Numeric, context: context)
@@ -26,9 +33,33 @@ module WhiteLabel
       end
     end
 
+    class Items
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, ::Array, context: context)
+        input.each_with_index do |element, index|
+          Hearth::Validator.validate!(element, ::String, context: "#{context}[#{index}]")
+        end
+      end
+    end
+
     class KitchenSinkInput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::KitchenSinkInput, context: context)
+        Hearth::Validator.validate!(input[:string], ::String, context: "#{context}[:string]")
+        Validators::Struct.validate!(input[:struct], context: "#{context}[:struct]") unless input[:struct].nil?
+        Validators::Document.validate!(input[:document], context: "#{context}[:document]") unless input[:document].nil?
+        Validators::ListOfStrings.validate!(input[:list_of_strings], context: "#{context}[:list_of_strings]") unless input[:list_of_strings].nil?
+        Validators::ListOfStructs.validate!(input[:list_of_structs], context: "#{context}[:list_of_structs]") unless input[:list_of_structs].nil?
+        Validators::MapOfStrings.validate!(input[:map_of_strings], context: "#{context}[:map_of_strings]") unless input[:map_of_strings].nil?
+        Validators::MapOfStructs.validate!(input[:map_of_structs], context: "#{context}[:map_of_structs]") unless input[:map_of_structs].nil?
+        Validators::SetOfStrings.validate!(input[:set_of_strings], context: "#{context}[:set_of_strings]") unless input[:set_of_strings].nil?
+        Validators::Union.validate!(input[:union], context: "#{context}[:union]") unless input[:union].nil?
+      end
+    end
+
+    class KitchenSinkOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::KitchenSinkOutput, context: context)
         Hearth::Validator.validate!(input[:string], ::String, context: "#{context}[:string]")
         Validators::Struct.validate!(input[:struct], context: "#{context}[:struct]") unless input[:struct].nil?
         Validators::Document.validate!(input[:document], context: "#{context}[:document]") unless input[:document].nil?
@@ -86,10 +117,39 @@ module WhiteLabel
       end
     end
 
+    class PaginatorsTestOperationOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::PaginatorsTestOperationOutput, context: context)
+        Hearth::Validator.validate!(input[:next_token], ::String, context: "#{context}[:next_token]")
+        Validators::Items.validate!(input[:items], context: "#{context}[:items]") unless input[:items].nil?
+      end
+    end
+
     class PaginatorsTestWithItemsInput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::PaginatorsTestWithItemsInput, context: context)
         Hearth::Validator.validate!(input[:next_token], ::String, context: "#{context}[:next_token]")
+      end
+    end
+
+    class PaginatorsTestWithItemsOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::PaginatorsTestWithItemsOutput, context: context)
+        Hearth::Validator.validate!(input[:next_token], ::String, context: "#{context}[:next_token]")
+        Validators::Items.validate!(input[:items], context: "#{context}[:items]") unless input[:items].nil?
+      end
+    end
+
+    class ResultWrapper
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::ResultWrapper, context: context)
+        Hearth::Validator.validate!(input[:member____123next_token], ::String, context: "#{context}[:member____123next_token]")
+      end
+    end
+
+    class ServerError
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::ServerError, context: context)
       end
     end
 
@@ -143,10 +203,25 @@ module WhiteLabel
       end
     end
 
+    class WaitersTestOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::WaitersTestOutput, context: context)
+        Hearth::Validator.validate!(input[:status], ::String, context: "#{context}[:status]")
+      end
+    end
+
     class Struct____PaginatorsTestWithBadNamesInput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::Struct____PaginatorsTestWithBadNamesInput, context: context)
         Hearth::Validator.validate!(input[:member____next_token], ::String, context: "#{context}[:member____next_token]")
+      end
+    end
+
+    class Struct____PaginatorsTestWithBadNamesOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::Struct____PaginatorsTestWithBadNamesOutput, context: context)
+        Validators::ResultWrapper.validate!(input[:member____wrapper], context: "#{context}[:member____wrapper]") unless input[:member____wrapper].nil?
+        Validators::Items.validate!(input[:member____items], context: "#{context}[:member____items]") unless input[:member____items].nil?
       end
     end
 

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/StubsGeneratorBase.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/StubsGeneratorBase.java
@@ -397,13 +397,12 @@ public abstract class StubsGeneratorBase {
                     .write("return nil if visited.include?('$L')", name)
                     .write("visited = visited + ['$L']", name)
                     .call(() -> {
-                        writer.openBlock("{");
                         MemberShape defaultMember = shape.members().iterator().next();
                         Shape target = model.expectShape(defaultMember.getTarget());
                         String symbolName = RubyFormatter.toSnakeCase(symbolProvider.toMemberName(defaultMember));
-                        String dataSetter = symbolName + ": ";
-                        target.accept(new MemberDefaults(dataSetter, ",", symbolName));
-                        writer.closeBlock("}");
+                        target.accept(new MemberDefaults("value = ", "", symbolName));
+                        writer.write("Types::$L::$L.new(value)",
+                                shape.getId().getName(), symbolProvider.toMemberName(defaultMember));
                     })
                     .closeBlock("end")
                     .write("")

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/StubsGeneratorBase.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/StubsGeneratorBase.java
@@ -386,6 +386,7 @@ public abstract class StubsGeneratorBase {
             return null;
         }
 
+        //TODO: Convert all the defaults!!!
         @Override
         public Void unionShape(UnionShape shape) {
             String name = symbolProvider.toSymbol(shape).getName();

--- a/hearth/lib/hearth/middleware/send.rb
+++ b/hearth/lib/hearth/middleware/send.rb
@@ -49,12 +49,14 @@ module Hearth
           output.error = stub
         when Class
           output.error = stub.new
-        when Hash
-          @stub_class.stub(context.response, stub: stub)
         when NilClass
           @stub_class.stub(context.response, stub: @stub_class.default)
         else
-          raise ArgumentError, 'Unsupported stub type'
+          if stub.class.include?(Hearth::Structure)
+            @stub_class.stub(context.response, stub: stub)
+          else
+            raise ArgumentError, 'Unsupported stub type'
+          end
         end
       end
     end

--- a/hearth/lib/hearth/middleware/send.rb
+++ b/hearth/lib/hearth/middleware/send.rb
@@ -45,18 +45,16 @@ module Hearth
         when Proc
           stub = stub.call(context)
           apply_stub(stub, context, output) if stub
-        when Exception
-          output.error = stub
-        when Class
-          output.error = stub.new
+        when Exception then output.error = stub
+        when Class then output.error = stub.new
         when NilClass
           @stub_class.stub(context.response, stub: @stub_class.default)
         else
-          if stub.class.include?(Hearth::Structure)
-            @stub_class.stub(context.response, stub: stub)
-          else
+          unless stub.class.include?(Hearth::Structure)
             raise ArgumentError, 'Unsupported stub type'
           end
+
+          @stub_class.stub(context.response, stub: stub)
         end
       end
     end

--- a/hearth/lib/hearth/stubbing/client_stubs.rb
+++ b/hearth/lib/hearth/stubbing/client_stubs.rb
@@ -104,7 +104,8 @@ module Hearth
     #   `:stub_responses => true`.
     def stub_responses(operation_name, *stubs)
       if @stub_responses
-        @stubs.add_stubs(operation_name, transform_stubs(operation_name, stubs.flatten))
+        @stubs.add_stubs(operation_name,
+                         transform_stubs(operation_name, stubs.flatten))
       else
         msg = 'Stubbing is not enabled. Enable stubbing in the constructor '\
               'with `stub_responses: true`'

--- a/hearth/lib/hearth/stubbing/client_stubs.rb
+++ b/hearth/lib/hearth/stubbing/client_stubs.rb
@@ -104,7 +104,7 @@ module Hearth
     #   `:stub_responses => true`.
     def stub_responses(operation_name, *stubs)
       if @stub_responses
-        @stubs.add_stubs(operation_name, stubs.flatten)
+        @stubs.add_stubs(operation_name, transform_stubs(operation_name, stubs.flatten))
       else
         msg = 'Stubbing is not enabled. Enable stubbing in the constructor '\
               'with `stub_responses: true`'

--- a/hearth/spec/hearth/middleware/send_spec.rb
+++ b/hearth/spec/hearth/middleware/send_spec.rb
@@ -2,6 +2,10 @@
 
 module Hearth
   module Middleware
+    StubOutput = ::Struct.new(:param1, keyword_init: true) do
+      include Hearth::Structure
+    end
+
     describe Send do
       let(:app) { double('app', call: output) }
       let(:client) { double('client') }
@@ -111,13 +115,13 @@ module Hearth
             end
           end
 
-          context 'stub is a hash' do
-            let(:stub_hash) { { param1: 'value' } }
-            before { stubs.add_stubs(operation, [stub_hash]) }
+          context 'stub is an output object' do
+            let(:stub_output) { StubOutput.new(param1: 'value') }
+            before { stubs.add_stubs(operation, [stub_output]) }
 
             it 'uses the stub class to stub the response' do
               expect(stub_class).to receive(:stub)
-                .with(response, stub: stub_hash)
+                .with(response, stub: stub_output)
               subject.call(input, context)
             end
           end

--- a/hearth/spec/hearth/stubbing/client_stubs_spec.rb
+++ b/hearth/spec/hearth/stubbing/client_stubs_spec.rb
@@ -9,6 +9,10 @@ module Hearth
       @stubs = Hearth::Stubbing::Stubs.new
     end
 
+    def transform_stubs(_operation_name, stubs)
+      stubs
+    end
+
     # for testing
     attr_reader :stubs
   end


### PR DESCRIPTION
*Description of changes:*
When stubs are supplied (eg when initializing the client or calling `stub_responses`), convert/transform Hash params to modeled Output Types using the Params/validators (as is done for inputs).  This gives the same validation that we get on normal method calls and will raise an error when stubs are invalid - this keeps our stub code from needing to handle error checking/invalid cases.

TODO: All of the stub defaults need to return the correct types.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
