### PR TITLE
Fix query param matcher false negatives when param names differ

### DIFF
--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/HttpProtocolTestGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/HttpProtocolTestGenerator.java
@@ -100,8 +100,8 @@ public class HttpProtocolTestGenerator {
             });
             writer.write("");
             operation.getTrait(HttpResponseTestsTrait.class).ifPresent((responseTests) -> {
-//                renderResponseTests(operationName, operation.getOutputShape(), responseTests);
-//                renderResponseStubberTests(operationName, operation.getOutputShape(), responseTests);
+                renderResponseTests(operationName, operation.getOutputShape(), responseTests);
+                renderResponseStubberTests(operationName, operation.getOutputShape(), responseTests);
             });
             renderErrorTests(operation);
             writer.closeBlock("\nend\n");

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/HttpProtocolTestGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/HttpProtocolTestGenerator.java
@@ -100,8 +100,8 @@ public class HttpProtocolTestGenerator {
             });
             writer.write("");
             operation.getTrait(HttpResponseTestsTrait.class).ifPresent((responseTests) -> {
-                renderResponseTests(operationName, operation.getOutputShape(), responseTests);
-                renderResponseStubberTests(operationName, operation.getOutputShape(), responseTests);
+//                renderResponseTests(operationName, operation.getOutputShape(), responseTests);
+//                renderResponseStubberTests(operationName, operation.getOutputShape(), responseTests);
             });
             renderErrorTests(operation);
             writer.closeBlock("\nend\n");

--- a/hearth/lib/hearth/query/param_matcher.rb
+++ b/hearth/lib/hearth/query/param_matcher.rb
@@ -12,7 +12,11 @@ RSpec::Matchers.define :match_query_params do |expected|
     expect(actual.keys.length).to eq(expected.keys.length)
     expect(actual.values.length).to eq(expected.values.length)
 
-    expected.values.sort.zip(actual.values.sort).each do |a, e|
+    expected.each do |ek, e|
+      expect(actual.keys).to include(ek)
+      a = actual[ek]
+      expect(e.length).to eq(a.length)
+
       a.zip(e).each do |a0, e0|
         # Timestamps can have optional precision.
         if (float = Float(a0) rescue false)

--- a/hearth/spec/hearth/query/param_matcher_spec.rb
+++ b/hearth/spec/hearth/query/param_matcher_spec.rb
@@ -32,6 +32,13 @@ module Hearth
         expect(actual).not_to match_query_params(expected)
       end
 
+      it 'is false when param names differs' do
+        actual = CGI.parse('Param1=Value1&Other=Value2')
+        expected = CGI.parse('Param1=Value1&Param2=Value2')
+
+        expect(actual).not_to match_query_params(expected)
+      end
+
       it 'compares floats with precision' do
         actual = CGI.parse('Param=Value&Time=123')
         expected = CGI.parse('Param=Value&Time=123.0')


### PR DESCRIPTION
*Description of changes:*
Currently the query param matcher will pass for params with different names:
```
expect(CGI.parse(request.body.read)).to match_query_params(CGI.parse('Action=SimpleInputParams&Version=2020-01-08&A=Hi'))
The request body here is:
Action=SimpleInputParams&HasQueryName=Hi&Version=2020-01-08"
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
