### PR TITLE
Update plugin/customization hooks

### DIFF
--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/CodegenOrchestrator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/CodegenOrchestrator.java
@@ -240,6 +240,7 @@ public class CodegenOrchestrator {
                 .map((integration) -> integration.writeAdditionalFiles(context))
                 .flatMap(Collection::stream)
                 .collect(Collectors.toList());
+        context.protocolGenerator().ifPresent((g) -> additionalFiles.addAll(g.writeAdditionalFiles(context)));
         ModuleGenerator moduleGenerator = new ModuleGenerator(context);
         moduleGenerator.render(additionalFiles);
         LOGGER.info("generated module");
@@ -252,6 +253,8 @@ public class CodegenOrchestrator {
                                 .additionalGemDependencies(context))
                         .flatMap(Collection::stream)
                         .collect(Collectors.toList());
+        context.protocolGenerator()
+                .ifPresent((g) -> additionalDependencies.addAll(g.additionalGemDependencies(context)));
         GemspecGenerator gemspecGenerator = new GemspecGenerator(context);
         gemspecGenerator.render(additionalDependencies);
         LOGGER.info("generated .gemspec");

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/ProtocolGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/ProtocolGenerator.java
@@ -15,7 +15,10 @@
 
 package software.amazon.smithy.ruby.codegen;
 
+import java.util.Collections;
+import java.util.List;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.ruby.codegen.middleware.MiddlewareBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
@@ -75,4 +78,47 @@ public interface ProtocolGenerator {
      * @param context context to use for generation
      */
     void generateStubs(GenerationContext context);
+
+    /**
+     * Return all of the Middleware to be registered on the Client.
+     *
+     * @param middlewareBuilder - Client middleware to be modified
+     * @param context - Generation context to process within
+     */
+    default void modifyClientMiddleware(MiddlewareBuilder middlewareBuilder, GenerationContext context) {
+        // pass
+    }
+
+    /**
+     * Returns a list of additional (non-middleware) Config
+     * to be added to the generated Client.
+     *
+     * @param context - Generation context to process within
+     *
+     * @return list of additional config
+     */
+    default List<ClientConfig> getAdditionalClientConfig(GenerationContext context) {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Writes additional files.
+     *
+     * @param context - context for generation
+     * @return List of relative paths generated to be added to module requires.
+     */
+    default List<String> writeAdditionalFiles(GenerationContext context) {
+        return Collections.emptyList();
+    }
+
+    /**
+     * Adds additional Gem Dependencies.
+     *
+     * @param context - context for generation
+     * @return List of relative paths generated to be added to module requires.
+     */
+    default List<RubyDependency> additionalGemDependencies(
+            GenerationContext context) {
+        return Collections.emptyList();
+    }
 }

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubyIntegration.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubyIntegration.java
@@ -20,7 +20,7 @@ import java.util.List;
 import software.amazon.smithy.codegen.core.SmithyIntegration;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ServiceShape;
-import software.amazon.smithy.ruby.codegen.middleware.Middleware;
+import software.amazon.smithy.ruby.codegen.middleware.MiddlewareBuilder;
 import software.amazon.smithy.utils.CodeWriter;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
@@ -56,7 +56,7 @@ public interface RubyIntegration extends SmithyIntegration<RubySettings, CodeWri
      * code generation starts. This plugin can be used to add RuntimeClientPlugins
      * to the integration's list of plugin.
      *
-     * @param context - generation context to process within
+     * @param context - generation context to process within. Contains the finalized model.
      */
     default void processFinalizedModel(GenerationContext context) {
         // pass
@@ -65,19 +65,21 @@ public interface RubyIntegration extends SmithyIntegration<RubySettings, CodeWri
     /**
      * Return all of the Middleware to be registered on the Client.
      *
-     * @return list of middleware to be registered on the client
+     * @param middlewareBuilder - Client middleware to be modified
+     * @param context           - Generation context to process within
      */
-    default List<Middleware> getClientMiddleware() {
-        return Collections.emptyList();
+    default void modifyClientMiddleware(MiddlewareBuilder middlewareBuilder, GenerationContext context) {
+        // pass
     }
 
     /**
      * Returns a list of additional (non-middleware) Config
      * to be added to the generated Client.
      *
+     * @param context - Generation context to process within
      * @return list of additional config
      */
-    default List<ClientConfig> getAdditionalClientConfig() {
+    default List<ClientConfig> getAdditionalClientConfig(GenerationContext context) {
         return Collections.emptyList();
     }
 

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/middleware/MiddlewareBuilder.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/middleware/MiddlewareBuilder.java
@@ -49,6 +49,10 @@ public class MiddlewareBuilder {
                         .put(step, new ArrayList<>()));
     }
 
+    public boolean remove(MiddlewareStackStep step, String klass) {
+        return middlewares.get(step).removeIf( (m) -> m.getKlass().equals(klass));
+    }
+
     public void register(Middleware middleware) {
         middlewares.get(middleware.getStep()).add(middleware);
     }

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/middleware/MiddlewareBuilder.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/middleware/MiddlewareBuilder.java
@@ -50,7 +50,7 @@ public class MiddlewareBuilder {
     }
 
     public boolean remove(MiddlewareStackStep step, String klass) {
-        return middlewares.get(step).removeIf( (m) -> m.getKlass().equals(klass));
+        return middlewares.get(step).removeIf((m) -> m.getKlass().equals(klass));
     }
 
     public void register(Middleware middleware) {


### PR DESCRIPTION
*Description of changes:*
This change does a few things:
- Add generation context to the calls for RubyIntegration modification points (eg, `getAdditionalClientConfig`) to be more consistent and give Integrations more discretion.
- Add the same hook points from RubyIntegration to ProtocolIntegration interface.  Those same methods get called on the protocol generator that is selected, giving protocol generators the ability to easily customize codegeneration.  (Note the same could be done using the generation context at the RubyIntegration level, but this would be somewhat clumsy code for Integrations that register many protocol generators, eg: AWS)
- Add a `remove` method for MiddlewareBuilder that allows middleware to be removed.
- Change the `addClientMiddleware` hook to `modifyClientMiddleware` - this gives Integrations/ProtocolGenerators more flexibility in customizing client middleware (specifically the ability to remove/replace middleware).

This lets us do something like the following in a ProtocolGenerator that needs to remove default middleware for specific operations:
```
    @Override
    public void modifyClientMiddleware(MiddlewareBuilder middlewareBuilder, GenerationContext context) {
        middlewareBuilder.remove(MiddlewareStackStep.BUILD,
                "Hearth::HTTP::Middleware::ContentLength");

        middlewareBuilder.register((new Middleware.Builder())
                .klass("Hearth::HTTP::Middleware::ContentLength")
                .step(MiddlewareStackStep.BUILD)
                .operationPredicate(
                        (model, service, operation) -> true) // filter here by whether there is a modeled body or not in o
                .build());
    }
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
