### PR TITLE
Update reserved words

### DIFF
--- a/codegen/projections/rails_json/lib/rails_json/builders.rb
+++ b/codegen/projections/rails_json/lib/rails_json/builders.rb
@@ -334,7 +334,7 @@ module RailsJson
       def self.build(input)
         data = {}
         data[:greeting] = input[:greeting] unless input[:greeting].nil?
-        data[:name] = input[:member_name] unless input[:member_name].nil?
+        data[:name] = input[:name] unless input[:name].nil?
         data
       end
     end

--- a/codegen/projections/rails_json/lib/rails_json/builders.rb
+++ b/codegen/projections/rails_json/lib/rails_json/builders.rb
@@ -1117,7 +1117,7 @@ module RailsJson
         http_req.http_method = 'POST'
         http_req.append_path(format(
             '/BadName/%<__123abc>s',
-            __123abc: Hearth::HTTP.uri_escape(input[:member____123abc].to_s)
+            __123abc: Hearth::HTTP.uri_escape(input[:member___123abc].to_s)
           )
         )
         params = Hearth::Query::ParamList.new
@@ -1134,7 +1134,7 @@ module RailsJson
     class Struct____456efg
       def self.build(input)
         data = {}
-        data[:__123foo] = input[:member____123foo] unless input[:member____123foo].nil?
+        data[:__123foo] = input[:member___123foo] unless input[:member___123foo].nil?
         data
       end
     end

--- a/codegen/projections/rails_json/lib/rails_json/client.rb
+++ b/codegen/projections/rails_json/lib/rails_json/client.rb
@@ -2348,9 +2348,9 @@ module RailsJson
     # @example Request syntax with placeholder values
     #
     #   resp = client.operation____789_bad_name(
-    #     member____123abc: '__123abc', # required
+    #     member___123abc: '__123abc', # required
     #     member: {
-    #       member____123foo: '__123foo'
+    #       member___123foo: '__123foo'
     #     }
     #   )
     #
@@ -2358,7 +2358,7 @@ module RailsJson
     #
     #   resp #=> Types::Struct____789BadNameOutput
     #   resp.member #=> Types::Struct____456efg
-    #   resp.member.member____123foo #=> String
+    #   resp.member.member___123foo #=> String
     #
     def operation____789_bad_name(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new

--- a/codegen/projections/rails_json/lib/rails_json/client.rb
+++ b/codegen/projections/rails_json/lib/rails_json/client.rb
@@ -756,7 +756,7 @@ module RailsJson
     #   resp = client.http_payload_with_structure(
     #     nested: {
     #       greeting: 'greeting',
-    #       member_name: 'name'
+    #       name: 'name'
     #     }
     #   )
     #
@@ -765,7 +765,7 @@ module RailsJson
     #   resp #=> Types::HttpPayloadWithStructureOutput
     #   resp.nested #=> Types::NestedPayload
     #   resp.nested.greeting #=> String
-    #   resp.nested.member_name #=> String
+    #   resp.nested.name #=> String
     #
     def http_payload_with_structure(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new

--- a/codegen/projections/rails_json/lib/rails_json/params.rb
+++ b/codegen/projections/rails_json/lib/rails_json/params.rb
@@ -1327,7 +1327,7 @@ module RailsJson
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::Struct____456efg, context: context)
         type = Types::Struct____456efg.new
-        type.member____123foo = params[:member____123foo]
+        type.member___123foo = params[:member___123foo]
         type
       end
     end
@@ -1336,7 +1336,7 @@ module RailsJson
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::Struct____789BadNameInput, context: context)
         type = Types::Struct____789BadNameInput.new
-        type.member____123abc = params[:member____123abc]
+        type.member___123abc = params[:member___123abc]
         type.member = Struct____456efg.build(params[:member], context: "#{context}[:member]") unless params[:member].nil?
         type
       end

--- a/codegen/projections/rails_json/lib/rails_json/params.rb
+++ b/codegen/projections/rails_json/lib/rails_json/params.rb
@@ -1034,7 +1034,7 @@ module RailsJson
         Hearth::Validator.validate!(params, ::Hash, Types::NestedPayload, context: context)
         type = Types::NestedPayload.new
         type.greeting = params[:greeting]
-        type.member_name = params[:member_name]
+        type.name = params[:name]
         type
       end
     end

--- a/codegen/projections/rails_json/lib/rails_json/parsers.rb
+++ b/codegen/projections/rails_json/lib/rails_json/parsers.rb
@@ -162,7 +162,7 @@ module RailsJson
       def self.parse(map)
         data = Types::NestedPayload.new
         data.greeting = map['greeting']
-        data.member_name = map['name']
+        data.name = map['name']
         return data
       end
     end

--- a/codegen/projections/rails_json/lib/rails_json/parsers.rb
+++ b/codegen/projections/rails_json/lib/rails_json/parsers.rb
@@ -898,7 +898,7 @@ module RailsJson
     class Struct____456efg
       def self.parse(map)
         data = Types::Struct____456efg.new
-        data.member____123foo = map['__123foo']
+        data.member___123foo = map['__123foo']
         return data
       end
     end

--- a/codegen/projections/rails_json/lib/rails_json/stubs.rb
+++ b/codegen/projections/rails_json/lib/rails_json/stubs.rb
@@ -1526,14 +1526,14 @@ module RailsJson
         return nil if visited.include?('Struct____456efg')
         visited = visited + ['Struct____456efg']
         {
-          member____123foo: 'member____123foo',
+          member___123foo: 'member___123foo',
         }
       end
 
       def self.stub(stub)
         stub ||= Types::Struct____456efg.new
         data = {}
-        data[:__123foo] = stub[:member____123foo] unless stub[:member____123foo].nil?
+        data[:__123foo] = stub[:member___123foo] unless stub[:member___123foo].nil?
         data
       end
     end

--- a/codegen/projections/rails_json/lib/rails_json/stubs.rb
+++ b/codegen/projections/rails_json/lib/rails_json/stubs.rb
@@ -213,7 +213,7 @@ module RailsJson
         visited = visited + ['NestedPayload']
         {
           greeting: 'greeting',
-          member_name: 'member_name',
+          name: 'name',
         }
       end
 
@@ -221,7 +221,7 @@ module RailsJson
         stub ||= Types::NestedPayload.new
         data = {}
         data[:greeting] = stub[:greeting] unless stub[:greeting].nil?
-        data[:name] = stub[:member_name] unless stub[:member_name].nil?
+        data[:name] = stub[:name] unless stub[:name].nil?
         data
       end
     end

--- a/codegen/projections/rails_json/lib/rails_json/types.rb
+++ b/codegen/projections/rails_json/lib/rails_json/types.rb
@@ -1654,13 +1654,13 @@ module RailsJson
     #
     #   @return [String]
     #
-    # @!attribute member_name
+    # @!attribute name
     #
     #   @return [String]
     #
     NestedPayload = ::Struct.new(
       :greeting,
-      :member_name,
+      :name,
       keyword_init: true
     ) do
       include Hearth::Structure

--- a/codegen/projections/rails_json/lib/rails_json/types.rb
+++ b/codegen/projections/rails_json/lib/rails_json/types.rb
@@ -1940,18 +1940,18 @@ module RailsJson
       include Hearth::Structure
     end
 
-    # @!attribute member____123foo
+    # @!attribute member___123foo
     #
     #   @return [String]
     #
     Struct____456efg = ::Struct.new(
-      :member____123foo,
+      :member___123foo,
       keyword_init: true
     ) do
       include Hearth::Structure
     end
 
-    # @!attribute member____123abc
+    # @!attribute member___123abc
     #
     #   @return [String]
     #
@@ -1960,7 +1960,7 @@ module RailsJson
     #   @return [Struct____456efg]
     #
     Struct____789BadNameInput = ::Struct.new(
-      :member____123abc,
+      :member___123abc,
       :member,
       keyword_init: true
     ) do

--- a/codegen/projections/rails_json/lib/rails_json/validators.rb
+++ b/codegen/projections/rails_json/lib/rails_json/validators.rb
@@ -1164,14 +1164,14 @@ module RailsJson
     class Struct____456efg
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::Struct____456efg, context: context)
-        Hearth::Validator.validate!(input[:member____123foo], ::String, context: "#{context}[:member____123foo]")
+        Hearth::Validator.validate!(input[:member___123foo], ::String, context: "#{context}[:member___123foo]")
       end
     end
 
     class Struct____789BadNameInput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::Struct____789BadNameInput, context: context)
-        Hearth::Validator.validate!(input[:member____123abc], ::String, context: "#{context}[:member____123abc]")
+        Hearth::Validator.validate!(input[:member___123abc], ::String, context: "#{context}[:member___123abc]")
         Validators::Struct____456efg.validate!(input[:member], context: "#{context}[:member]") unless input[:member].nil?
       end
     end

--- a/codegen/projections/rails_json/lib/rails_json/validators.rb
+++ b/codegen/projections/rails_json/lib/rails_json/validators.rb
@@ -920,7 +920,7 @@ module RailsJson
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::NestedPayload, context: context)
         Hearth::Validator.validate!(input[:greeting], ::String, context: "#{context}[:greeting]")
-        Hearth::Validator.validate!(input[:member_name], ::String, context: "#{context}[:member_name]")
+        Hearth::Validator.validate!(input[:name], ::String, context: "#{context}[:name]")
       end
     end
 

--- a/codegen/projections/rails_json/spec/protocol_spec.rb
+++ b/codegen/projections/rails_json/spec/protocol_spec.rb
@@ -1162,7 +1162,7 @@ module RailsJson
           client.http_payload_with_structure({
             nested: {
               greeting: "hello",
-              member_name: "Phreddy"
+              name: "Phreddy"
             }
           }, **opts)
         end
@@ -1187,7 +1187,7 @@ module RailsJson
           expect(output.to_h).to eq({
             nested: {
               greeting: "hello",
-              member_name: "Phreddy"
+              name: "Phreddy"
             }
           })
         end
@@ -1205,14 +1205,14 @@ module RailsJson
           client.stub_responses(:http_payload_with_structure, {
             nested: {
               greeting: "hello",
-              member_name: "Phreddy"
+              name: "Phreddy"
             }
           })
           output = client.http_payload_with_structure({}, middleware: middleware)
           expect(output.to_h).to eq({
             nested: {
               greeting: "hello",
-              member_name: "Phreddy"
+              name: "Phreddy"
             }
           })
         end

--- a/codegen/projections/rails_json/spec/protocol_spec.rb
+++ b/codegen/projections/rails_json/spec/protocol_spec.rb
@@ -35,9 +35,9 @@ module RailsJson
           end
           opts = {middleware: middleware}
           client.operation____789_bad_name({
-            member____123abc: "abc_value",
+            member___123abc: "abc_value",
             member: {
-              member____123foo: "foo value"
+              member___123foo: "foo value"
             }
           }, **opts)
         end
@@ -58,7 +58,7 @@ module RailsJson
           output = client.operation____789_bad_name({}, middleware: middleware)
           expect(output.to_h).to eq({
             member: {
-              member____123foo: "foo value"
+              member___123foo: "foo value"
             }
           })
         end
@@ -75,13 +75,13 @@ module RailsJson
           middleware.remove_build
           client.stub_responses(:operation____789_bad_name, {
             member: {
-              member____123foo: "foo value"
+              member___123foo: "foo value"
             }
           })
           output = client.operation____789_bad_name({}, middleware: middleware)
           expect(output.to_h).to eq({
             member: {
-              member____123foo: "foo value"
+              member___123foo: "foo value"
             }
           })
         end

--- a/codegen/projections/weather/lib/weather/client.rb
+++ b/codegen/projections/weather/lib/weather/client.rb
@@ -74,13 +74,13 @@ module Weather
     # @example Response structure
     #
     #   resp #=> Types::GetCityOutput
-    #   resp.member_name #=> String
+    #   resp.name #=> String
     #   resp.coordinates #=> Types::CityCoordinates
     #   resp.coordinates.latitude #=> Float
     #   resp.coordinates.longitude #=> Float
     #   resp.city #=> Types::CitySummary
     #   resp.city.city_id #=> String
-    #   resp.city.member_name #=> String
+    #   resp.city.name #=> String
     #   resp.city.number #=> String
     #   resp.city.case #=> String
     #
@@ -382,7 +382,7 @@ module Weather
     #   resp.items #=> Array<CitySummary>
     #   resp.items[0] #=> Types::CitySummary
     #   resp.items[0].city_id #=> String
-    #   resp.items[0].member_name #=> String
+    #   resp.items[0].name #=> String
     #   resp.items[0].number #=> String
     #   resp.items[0].case #=> String
     #   resp.sparse_items #=> Array<CitySummary>

--- a/codegen/projections/weather/lib/weather/client.rb
+++ b/codegen/projections/weather/lib/weather/client.rb
@@ -434,18 +434,18 @@ module Weather
     # @example Request syntax with placeholder values
     #
     #   resp = client.operation____789_bad_name(
-    #     member____123abc: '__123abc', # required
+    #     member___123abc: '__123abc', # required
     #     member: {
-    #       member____123foo: '__123foo'
+    #       member___123foo: '__123foo'
     #     }
     #   )
     #
     # @example Response structure
     #
     #   resp #=> Types::Struct____789BadNameOutput
-    #   resp.member____123abc #=> String
+    #   resp.member___123abc #=> String
     #   resp.member #=> Types::Struct____456efg
-    #   resp.member.member____123foo #=> String
+    #   resp.member.member___123foo #=> String
     #
     def operation____789_bad_name(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new

--- a/codegen/projections/weather/lib/weather/params.rb
+++ b/codegen/projections/weather/lib/weather/params.rb
@@ -77,7 +77,7 @@ module Weather
         Hearth::Validator.validate!(params, ::Hash, Types::CitySummary, context: context)
         type = Types::CitySummary.new
         type.city_id = params[:city_id]
-        type.member_name = params[:member_name]
+        type.name = params[:name]
         type.number = params[:number]
         type.case = params[:case]
         type
@@ -145,7 +145,7 @@ module Weather
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::GetCityOutput, context: context)
         type = Types::GetCityOutput.new
-        type.member_name = params[:member_name]
+        type.name = params[:name]
         type.coordinates = CityCoordinates.build(params[:coordinates], context: "#{context}[:coordinates]") unless params[:coordinates].nil?
         type.city = CitySummary.build(params[:city], context: "#{context}[:city]") unless params[:city].nil?
         type

--- a/codegen/projections/weather/lib/weather/params.rb
+++ b/codegen/projections/weather/lib/weather/params.rb
@@ -363,7 +363,7 @@ module Weather
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::Struct____456efg, context: context)
         type = Types::Struct____456efg.new
-        type.member____123foo = params[:member____123foo]
+        type.member___123foo = params[:member___123foo]
         type
       end
     end
@@ -372,7 +372,7 @@ module Weather
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::Struct____789BadNameInput, context: context)
         type = Types::Struct____789BadNameInput.new
-        type.member____123abc = params[:member____123abc]
+        type.member___123abc = params[:member___123abc]
         type.member = Struct____456efg.build(params[:member], context: "#{context}[:member]") unless params[:member].nil?
         type
       end
@@ -382,7 +382,7 @@ module Weather
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::Struct____789BadNameOutput, context: context)
         type = Types::Struct____789BadNameOutput.new
-        type.member____123abc = params[:member____123abc]
+        type.member___123abc = params[:member___123abc]
         type.member = Struct____456efg.build(params[:member], context: "#{context}[:member]") unless params[:member].nil?
         type
       end

--- a/codegen/projections/weather/lib/weather/stubs.rb
+++ b/codegen/projections/weather/lib/weather/stubs.rb
@@ -249,7 +249,7 @@ module Weather
     class Operation____789BadName
       def self.default(visited=[])
         {
-          member____123abc: 'member____123abc',
+          member___123abc: 'member___123abc',
           member: Stubs::Struct____456efg.default(visited),
         }
       end
@@ -266,7 +266,7 @@ module Weather
         return nil if visited.include?('Struct____456efg')
         visited = visited + ['Struct____456efg']
         {
-          member____123foo: 'member____123foo',
+          member___123foo: 'member___123foo',
         }
       end
 

--- a/codegen/projections/weather/lib/weather/stubs.rb
+++ b/codegen/projections/weather/lib/weather/stubs.rb
@@ -14,7 +14,7 @@ module Weather
     class GetCity
       def self.default(visited=[])
         {
-          member_name: 'member_name',
+          name: 'name',
           coordinates: Stubs::CityCoordinates.default(visited),
           city: Stubs::CitySummary.default(visited),
         }
@@ -33,7 +33,7 @@ module Weather
         visited = visited + ['CitySummary']
         {
           city_id: 'city_id',
-          member_name: 'member_name',
+          name: 'name',
           number: 'number',
           case: 'case',
         }

--- a/codegen/projections/weather/lib/weather/types.rb
+++ b/codegen/projections/weather/lib/weather/types.rb
@@ -557,18 +557,18 @@ module Weather
       end
     end
 
-    # @!attribute member____123foo
+    # @!attribute member___123foo
     #
     #   @return [String]
     #
     Struct____456efg = ::Struct.new(
-      :member____123foo,
+      :member___123foo,
       keyword_init: true
     ) do
       include Hearth::Structure
     end
 
-    # @!attribute member____123abc
+    # @!attribute member___123abc
     #
     #   @return [String]
     #
@@ -577,14 +577,14 @@ module Weather
     #   @return [Struct____456efg]
     #
     Struct____789BadNameInput = ::Struct.new(
-      :member____123abc,
+      :member___123abc,
       :member,
       keyword_init: true
     ) do
       include Hearth::Structure
     end
 
-    # @!attribute member____123abc
+    # @!attribute member___123abc
     #
     #   @return [String]
     #
@@ -593,7 +593,7 @@ module Weather
     #   @return [Struct____456efg]
     #
     Struct____789BadNameOutput = ::Struct.new(
-      :member____123abc,
+      :member___123abc,
       :member,
       keyword_init: true
     ) do

--- a/codegen/projections/weather/lib/weather/types.rb
+++ b/codegen/projections/weather/lib/weather/types.rb
@@ -91,7 +91,7 @@ module Weather
     #
     #   @return [String]
     #
-    # @!attribute member_name
+    # @!attribute name
     #
     #   @return [String]
     #
@@ -105,7 +105,7 @@ module Weather
     #
     CitySummary = ::Struct.new(
       :city_id,
-      :member_name,
+      :name,
       :number,
       :case,
       keyword_init: true
@@ -196,7 +196,7 @@ module Weather
       include Hearth::Structure
     end
 
-    # @!attribute member_name
+    # @!attribute name
     #
     #   @return [String]
     #
@@ -209,7 +209,7 @@ module Weather
     #   @return [CitySummary]
     #
     GetCityOutput = ::Struct.new(
-      :member_name,
+      :name,
       :coordinates,
       :city,
       keyword_init: true

--- a/codegen/projections/weather/lib/weather/validators.rb
+++ b/codegen/projections/weather/lib/weather/validators.rb
@@ -74,7 +74,7 @@ module Weather
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::CitySummary, context: context)
         Hearth::Validator.validate!(input[:city_id], ::String, context: "#{context}[:city_id]")
-        Hearth::Validator.validate!(input[:member_name], ::String, context: "#{context}[:member_name]")
+        Hearth::Validator.validate!(input[:name], ::String, context: "#{context}[:name]")
         Hearth::Validator.validate!(input[:number], ::String, context: "#{context}[:number]")
         Hearth::Validator.validate!(input[:case], ::String, context: "#{context}[:case]")
       end
@@ -128,7 +128,7 @@ module Weather
     class GetCityOutput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::GetCityOutput, context: context)
-        Hearth::Validator.validate!(input[:member_name], ::String, context: "#{context}[:member_name]")
+        Hearth::Validator.validate!(input[:name], ::String, context: "#{context}[:name]")
         Validators::CityCoordinates.validate!(input[:coordinates], context: "#{context}[:coordinates]") unless input[:coordinates].nil?
         Validators::CitySummary.validate!(input[:city], context: "#{context}[:city]") unless input[:city].nil?
       end

--- a/codegen/projections/weather/lib/weather/validators.rb
+++ b/codegen/projections/weather/lib/weather/validators.rb
@@ -353,14 +353,14 @@ module Weather
     class Struct____456efg
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::Struct____456efg, context: context)
-        Hearth::Validator.validate!(input[:member____123foo], ::String, context: "#{context}[:member____123foo]")
+        Hearth::Validator.validate!(input[:member___123foo], ::String, context: "#{context}[:member___123foo]")
       end
     end
 
     class Struct____789BadNameInput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::Struct____789BadNameInput, context: context)
-        Hearth::Validator.validate!(input[:member____123abc], ::String, context: "#{context}[:member____123abc]")
+        Hearth::Validator.validate!(input[:member___123abc], ::String, context: "#{context}[:member___123abc]")
         Validators::Struct____456efg.validate!(input[:member], context: "#{context}[:member]") unless input[:member].nil?
       end
     end
@@ -368,7 +368,7 @@ module Weather
     class Struct____789BadNameOutput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::Struct____789BadNameOutput, context: context)
-        Hearth::Validator.validate!(input[:member____123abc], ::String, context: "#{context}[:member____123abc]")
+        Hearth::Validator.validate!(input[:member___123abc], ::String, context: "#{context}[:member___123abc]")
         Validators::Struct____456efg.validate!(input[:member], context: "#{context}[:member]") unless input[:member].nil?
       end
     end

--- a/codegen/projections/weather/lib/weather/waiters.rb
+++ b/codegen/projections/weather/lib/weather/waiters.rb
@@ -55,7 +55,7 @@ module Weather
                 state: 'retry',
                 matcher: {
                   inputOutput: {
-                    path: "length(\"input\".\"city_id\") == length(\"output\".\"member_name\")",
+                    path: "length(\"input\".\"city_id\") == length(\"output\".\"name\")",
                     comparator: "booleanEquals",
                     expected: 'true'
                   }
@@ -65,7 +65,7 @@ module Weather
                 state: 'success',
                 matcher: {
                   output: {
-                    path: "\"member_name\"",
+                    path: "\"name\"",
                     comparator: "stringEquals",
                     expected: 'seattle'
                   }
@@ -120,7 +120,7 @@ module Weather
                 state: 'failure',
                 matcher: {
                   output: {
-                    path: "\"items\"[].\"member_name\"",
+                    path: "\"items\"[].\"name\"",
                     comparator: "allStringEquals",
                     expected: 'seattle'
                   }
@@ -130,7 +130,7 @@ module Weather
                 state: 'success',
                 matcher: {
                   output: {
-                    path: "\"items\"[].\"member_name\"",
+                    path: "\"items\"[].\"name\"",
                     comparator: "anyStringEquals",
                     expected: 'NewYork'
                   }

--- a/codegen/projections/weather/spec/protocol_spec.rb
+++ b/codegen/projections/weather/spec/protocol_spec.rb
@@ -92,14 +92,14 @@ module Weather
           middleware.remove_send.remove_build
           output = client.get_city({}, middleware: middleware)
           expect(output.to_h).to eq({
-            member_name: "Seattle",
+            name: "Seattle",
             coordinates: {
               latitude: 12.34,
               longitude: -56.78
             },
             city: {
               city_id: "123",
-              member_name: "Seattle",
+              name: "Seattle",
               number: "One",
               case: "Upper"
             }
@@ -117,28 +117,28 @@ module Weather
           end
           middleware.remove_build
           client.stub_responses(:get_city, {
-            member_name: "Seattle",
+            name: "Seattle",
             coordinates: {
               latitude: 12.34,
               longitude: -56.78
             },
             city: {
               city_id: "123",
-              member_name: "Seattle",
+              name: "Seattle",
               number: "One",
               case: "Upper"
             }
           })
           output = client.get_city({}, middleware: middleware)
           expect(output.to_h).to eq({
-            member_name: "Seattle",
+            name: "Seattle",
             coordinates: {
               latitude: 12.34,
               longitude: -56.78
             },
             city: {
               city_id: "123",
-              member_name: "Seattle",
+              name: "Seattle",
               number: "One",
               case: "Upper"
             }

--- a/codegen/projections/white_label/lib/white_label/client.rb
+++ b/codegen/projections/white_label/lib/white_label/client.rb
@@ -483,16 +483,16 @@ module WhiteLabel
     # @example Request syntax with placeholder values
     #
     #   resp = client.operation____paginators_test_with_bad_names(
-    #     member____next_token: '__nextToken'
+    #     member___next_token: '__nextToken'
     #   )
     #
     # @example Response structure
     #
     #   resp #=> Types::Struct____PaginatorsTestWithBadNamesOutput
-    #   resp.member____wrapper #=> Types::ResultWrapper
-    #   resp.member____wrapper.member____123next_token #=> String
-    #   resp.member____items #=> Array<String>
-    #   resp.member____items[0] #=> String
+    #   resp.member___wrapper #=> Types::ResultWrapper
+    #   resp.member___wrapper.member___123next_token #=> String
+    #   resp.member___items #=> Array<String>
+    #   resp.member___items[0] #=> String
     #
     def operation____paginators_test_with_bad_names(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new

--- a/codegen/projections/white_label/lib/white_label/paginators.rb
+++ b/codegen/projections/white_label/lib/white_label/paginators.rb
@@ -24,16 +24,16 @@ module WhiteLabel
       def pages
         params = @params
         Enumerator.new do |e|
-          @prev_token = params[:member____next_token]
+          @prev_token = params[:member___next_token]
           response = @client.operation____paginators_test_with_bad_names(params, @options)
           e.yield(response)
-          output_token = response.member____wrapper&.member____123next_token
+          output_token = response.member___wrapper&.member___123next_token
 
           until output_token.nil? || @prev_token == output_token
-            params = params.merge(member____next_token: output_token)
+            params = params.merge(member___next_token: output_token)
             response = @client.operation____paginators_test_with_bad_names(params, @options)
             e.yield(response)
-            output_token = response.member____wrapper&.member____123next_token
+            output_token = response.member___wrapper&.member___123next_token
           end
         end
       end
@@ -43,7 +43,7 @@ module WhiteLabel
       def items
         Enumerator.new do |e|
           pages.each do |page|
-            page.member____items.each do |item|
+            page.member___items.each do |item|
               e.yield(item)
             end
           end

--- a/codegen/projections/white_label/lib/white_label/params.rb
+++ b/codegen/projections/white_label/lib/white_label/params.rb
@@ -152,7 +152,7 @@ module WhiteLabel
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::ResultWrapper, context: context)
         type = Types::ResultWrapper.new
-        type.member____123next_token = params[:member____123next_token]
+        type.member___123next_token = params[:member___123next_token]
         type
       end
     end
@@ -232,7 +232,7 @@ module WhiteLabel
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::Struct____PaginatorsTestWithBadNamesInput, context: context)
         type = Types::Struct____PaginatorsTestWithBadNamesInput.new
-        type.member____next_token = params[:member____next_token]
+        type.member___next_token = params[:member___next_token]
         type
       end
     end
@@ -241,8 +241,8 @@ module WhiteLabel
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::Struct____PaginatorsTestWithBadNamesOutput, context: context)
         type = Types::Struct____PaginatorsTestWithBadNamesOutput.new
-        type.member____wrapper = ResultWrapper.build(params[:member____wrapper], context: "#{context}[:member____wrapper]") unless params[:member____wrapper].nil?
-        type.member____items = Items.build(params[:member____items], context: "#{context}[:member____items]") unless params[:member____items].nil?
+        type.member___wrapper = ResultWrapper.build(params[:member___wrapper], context: "#{context}[:member___wrapper]") unless params[:member___wrapper].nil?
+        type.member___items = Items.build(params[:member___items], context: "#{context}[:member___items]") unless params[:member___items].nil?
         type
       end
     end

--- a/codegen/projections/white_label/lib/white_label/stubs.rb
+++ b/codegen/projections/white_label/lib/white_label/stubs.rb
@@ -185,8 +185,8 @@ module WhiteLabel
     class Operation____PaginatorsTestWithBadNames
       def self.default(visited=[])
         {
-          member____wrapper: Stubs::ResultWrapper.default(visited),
-          member____items: Stubs::Items.default(visited),
+          member___wrapper: Stubs::ResultWrapper.default(visited),
+          member___items: Stubs::Items.default(visited),
         }
       end
 
@@ -201,7 +201,7 @@ module WhiteLabel
         return nil if visited.include?('ResultWrapper')
         visited = visited + ['ResultWrapper']
         {
-          member____123next_token: 'member____123next_token',
+          member___123next_token: 'member___123next_token',
         }
       end
 

--- a/codegen/projections/white_label/lib/white_label/types.rb
+++ b/codegen/projections/white_label/lib/white_label/types.rb
@@ -345,12 +345,12 @@ module WhiteLabel
       include Hearth::Structure
     end
 
-    # @!attribute member____123next_token
+    # @!attribute member___123next_token
     #
     #   @return [String]
     #
     ResultWrapper = ::Struct.new(
-      :member____123next_token,
+      :member___123next_token,
       keyword_init: true
     ) do
       include Hearth::Structure
@@ -524,28 +524,28 @@ module WhiteLabel
       include Hearth::Structure
     end
 
-    # @!attribute member____next_token
+    # @!attribute member___next_token
     #
     #   @return [String]
     #
     Struct____PaginatorsTestWithBadNamesInput = ::Struct.new(
-      :member____next_token,
+      :member___next_token,
       keyword_init: true
     ) do
       include Hearth::Structure
     end
 
-    # @!attribute member____wrapper
+    # @!attribute member___wrapper
     #
     #   @return [ResultWrapper]
     #
-    # @!attribute member____items
+    # @!attribute member___items
     #
     #   @return [Array<String>]
     #
     Struct____PaginatorsTestWithBadNamesOutput = ::Struct.new(
-      :member____wrapper,
-      :member____items,
+      :member___wrapper,
+      :member___items,
       keyword_init: true
     ) do
       include Hearth::Structure

--- a/codegen/projections/white_label/lib/white_label/validators.rb
+++ b/codegen/projections/white_label/lib/white_label/validators.rb
@@ -143,7 +143,7 @@ module WhiteLabel
     class ResultWrapper
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::ResultWrapper, context: context)
-        Hearth::Validator.validate!(input[:member____123next_token], ::String, context: "#{context}[:member____123next_token]")
+        Hearth::Validator.validate!(input[:member___123next_token], ::String, context: "#{context}[:member___123next_token]")
       end
     end
 
@@ -213,15 +213,15 @@ module WhiteLabel
     class Struct____PaginatorsTestWithBadNamesInput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::Struct____PaginatorsTestWithBadNamesInput, context: context)
-        Hearth::Validator.validate!(input[:member____next_token], ::String, context: "#{context}[:member____next_token]")
+        Hearth::Validator.validate!(input[:member___next_token], ::String, context: "#{context}[:member___next_token]")
       end
     end
 
     class Struct____PaginatorsTestWithBadNamesOutput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::Struct____PaginatorsTestWithBadNamesOutput, context: context)
-        Validators::ResultWrapper.validate!(input[:member____wrapper], context: "#{context}[:member____wrapper]") unless input[:member____wrapper].nil?
-        Validators::Items.validate!(input[:member____items], context: "#{context}[:member____items]") unless input[:member____items].nil?
+        Validators::ResultWrapper.validate!(input[:member___wrapper], context: "#{context}[:member___wrapper]") unless input[:member___wrapper].nil?
+        Validators::Items.validate!(input[:member___items], context: "#{context}[:member___items]") unless input[:member___items].nil?
       end
     end
 

--- a/codegen/smithy-ruby-codegen-test/integration-specs/paginators_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/paginators_spec.rb
@@ -104,14 +104,14 @@ module WhiteLabel
       subject { Operation____PaginatorsTestWithBadNames.new(client, params, options) }
       let(:response_1) do
         Types::Struct____PaginatorsTestWithBadNamesOutput.new(
-          member____wrapper: Types::ResultWrapper.new(member____123next_token: 'foo'), member____items: ['a', 'b', 'c'])
+          member___wrapper: Types::ResultWrapper.new(member___123next_token: 'foo'), member___items: ['a', 'b', 'c'])
       end
       let(:response_2) do
         Types::Struct____PaginatorsTestWithBadNamesOutput.new(
-          member____wrapper: Types::ResultWrapper.new(member____123next_token: 'bar'), member____items: ['1', '2', '3'])
+          member___wrapper: Types::ResultWrapper.new(member___123next_token: 'bar'), member___items: ['1', '2', '3'])
       end
       let(:response_3) do
-        Types::Struct____PaginatorsTestWithBadNamesOutput.new(member____items: ['the end'])
+        Types::Struct____PaginatorsTestWithBadNamesOutput.new(member___items: ['the end'])
       end
 
       describe '.pages' do
@@ -123,9 +123,9 @@ module WhiteLabel
           expect(client).to receive(:operation____paginators_test_with_bad_names)
                               .with({ param: 'param' }, options).and_return(response_1)
           expect(client).to receive(:operation____paginators_test_with_bad_names)
-                              .with({ param: 'param', member____next_token: 'foo' }, options).and_return(response_2)
+                              .with({ param: 'param', member___next_token: 'foo' }, options).and_return(response_2)
           expect(client).to receive(:operation____paginators_test_with_bad_names)
-                              .with({ param: 'param', member____next_token: 'bar' }, options).and_return(response_3)
+                              .with({ param: 'param', member___next_token: 'bar' }, options).and_return(response_3)
 
           paginator = subject.items
           expect(paginator).to be_a(Enumerator)

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubySymbolProvider.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubySymbolProvider.java
@@ -99,6 +99,7 @@ public class RubySymbolProvider implements SymbolProvider,
 
     // Mark all instances methods of a class as reserved. Shape members are accessors of a class.
     // Taken from "class Foo; end; Foo.new.methods.sort".
+    // Additionally add "each_pair" as we leverage this methods for Type's to_h of Struct.
     private ReservedWords memberReservedNames() {
         ReservedWordsBuilder reservedNames = new ReservedWordsBuilder();
         String[] reserved =
@@ -111,7 +112,8 @@ public class RubySymbolProvider implements SymbolProvider,
                         "pretty_print_instance_variables", "private_methods", "protected_methods", "public_method",
                         "public_methods", "public_send", "remove_instance_variable", "respond_to?", "send",
                         "singleton_class", "singleton_method", "singleton_methods", "taint", "tainted?", "tap", "then",
-                        "to_enum", "to_s", "trust", "untaint", "untrust", "untrusted?", "yield_self"};
+                        "to_enum", "to_s", "trust", "untaint", "untrust", "untrusted?", "yield_self",
+                        "each_pair" };
 
         for (String w : reserved) {
             reservedNames.put(w, "member_" + w);

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubySymbolProvider.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubySymbolProvider.java
@@ -157,7 +157,7 @@ public class RubySymbolProvider implements SymbolProvider,
     // If they are a reserved word or start with a number they will be prefixed with “member_”.
     private String getDefaultMemberName(MemberShape shape) {
         return prefixLeadingInvalidIdentCharacters(
-                escaper.escapeMemberName(RubyFormatter.toSnakeCase(shape.getMemberName())), "member__");
+                escaper.escapeMemberName(RubyFormatter.toSnakeCase(shape.getMemberName())), "member_");
     }
 
     // Shape Names (generated Class names) should be PascalCase

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubySymbolProvider.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubySymbolProvider.java
@@ -81,11 +81,15 @@ public class RubySymbolProvider implements SymbolProvider,
                 .buildEscaper();
     }
 
+    // Taken from https://docs.ruby-lang.org/en/3.1/doc/keywords_rdoc.html
+    // Some of these will never occur (like defined?) but define the entire list anyway for safety.
     private ReservedWords rubyReservedNames() {
         ReservedWordsBuilder reservedNames = new ReservedWordsBuilder();
         String[] reserved =
-                {"alias", "break", "BEGIN", "case", "class", "def", "do", "else", "elsif", "end", "ensure", "for",
-                        "if", "in", "next", "nil", "module"};
+                {"__ENCODING__", "__LINE__", "__FILE__", "BEGIN", "END", "alias", "and", "begin", "break", "case",
+                        "class", "def", "defined?", "do", "else", "elsif", "end", "ensure", "false", "for",
+                        "if", "in", "module", "next", "nil", "not", "or", "redo", "rescue", "retry", "return",
+                        "self", "super", "then", "true", "undef", "unless", "until", "when", "while", "yield"};
 
         for (String w : reserved) {
             reservedNames.put(w, w + "_");
@@ -93,23 +97,22 @@ public class RubySymbolProvider implements SymbolProvider,
         return reservedNames.build();
     }
 
+    // Mark all instances methods of a class as reserved. Shape members are accessors of a class.
+    // Taken from "class Foo; end; Foo.new.methods.sort".
     private ReservedWords memberReservedNames() {
         ReservedWordsBuilder reservedNames = new ReservedWordsBuilder();
         String[] reserved =
-                {"allocate", "superclass", "new", "included_modules", "name", "ancestors", "attr", "attr_reader",
-                        "attr_writer", "attr_accessor", "instance_methods", "public_instance_methods",
-                        "protected_instance_methods", "private_instance_methods", "constants", "const_get", "const_set",
-                        "class_variables", "remove_class_variable", "class_variable_get", "class_variable_set",
-                        "freeze", "inspect", "private_constant", "public_constant", "const_missing",
-                        "deprecate_constant", "include", "prepend", "module_exec", "module_eval", "class_eval",
-                        "remove_method", "undef_method", "class_exec", "alias_method", "to_s", "private_class_method",
-                        "public_class_method", "autoload", "instance_method", "public_instance_method", "define_method",
-                        "remove_instance_variable", "tap", "instance_variable_set", "protected_methods",
-                        "instance_variables", "instance_variable_get", "public_methods", "private_methods", "method",
-                        "public_method", "public_send", "singleton_method", "define_singleton_method", "extend",
-                        "to_enum", "enum_for", "object_id", "send", "display", "hash", "class", "singleton_class",
-                        "clone", "dup", "itself", "yield_self", "then", "taint", "untaint", "untrust", "trust",
-                        "methods", "singleton_methods", "instance_exec", "instance_eval", "__id__", "__send__"};
+                {"!", "!=", "!~", "<=>", "==", "===", "=~", "__id__", "__send__", "class", "clone",
+                        "define_singleton_method", "display", "dup", "enum_for", "eql?", "equal?", "extend", "freeze",
+                        "frozen?", "hash", "inspect", "instance_eval", "instance_exec", "instance_of?",
+                        "instance_variable_defined?", "instance_variable_get", "instance_variable_set",
+                        "instance_variables", "is_a?", "itself", "kind_of?", "method", "methods", "nil?", "object_id",
+                        "pretty_inspect", "pretty_print", "pretty_print_cycle", "pretty_print_inspect",
+                        "pretty_print_instance_variables", "private_methods", "protected_methods", "public_method",
+                        "public_methods", "public_send", "remove_instance_variable", "respond_to?", "send",
+                        "singleton_class", "singleton_method", "singleton_methods", "taint", "tainted?", "tap", "then",
+                        "to_enum", "to_s", "trust", "untaint", "untrust", "untrusted?", "yield_self"};
+
         for (String w : reserved) {
             reservedNames.put(w, "member_" + w);
         }

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubySymbolProvider.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubySymbolProvider.java
@@ -97,30 +97,21 @@ public class RubySymbolProvider implements SymbolProvider,
         return reservedNames.build();
     }
 
-    // Mark all instances methods of a struct class as reserved. Shape members are accessors of a class.
-    // Taken from "Foo = Struct.new(nil); Foo.new.methods.sort".
+    // Mark all instances methods of a class as reserved. Shape members are accessors of a class.
+    // Taken from "class Foo; end; Foo.new.methods.sort".
     private ReservedWords memberReservedNames() {
         ReservedWordsBuilder reservedNames = new ReservedWordsBuilder();
         String[] reserved =
-                {"!", "!=", "!~", "<=>", "==", "===", "=~", "[]", "[]=", "__id__", "__send__", "all?", "any?", "chain",
-                        "chunk", "chunk_while", "class", "clone", "collect", "collect_concat", "count", "cycle",
-                        "deconstruct", "deconstruct_keys", "define_singleton_method", "detect", "dig", "display",
-                        "drop", "drop_while", "dup", "each", "each_cons", "each_entry", "each_pair", "each_slice",
-                        "each_with_index", "each_with_object", "entries", "enum_for", "eql?", "equal?", "extend",
-                        "filter", "filter_map", "find", "find_all", "find_index", "first", "flat_map", "freeze",
-                        "frozen?", "grep", "grep_v", "group_by", "hash", "include?", "inject", "inspect",
-                        "instance_eval", "instance_exec", "instance_of?", "instance_variable_defined?",
-                        "instance_variable_get", "instance_variable_set", "instance_variables", "is_a?", "itself",
-                        "kind_of?", "lazy", "length", "map", "max", "max_by", "member?", "members", "method", "methods",
-                        "min", "min_by", "minmax", "minmax_by", "nil?", "none?", "object_id", "one?", "partition",
+                {"!", "!=", "!~", "<=>", "==", "===", "=~", "__id__", "__send__", "class", "clone",
+                        "define_singleton_method", "display", "dup", "enum_for", "eql?", "equal?", "extend", "freeze",
+                        "frozen?", "hash", "inspect", "instance_eval", "instance_exec", "instance_of?",
+                        "instance_variable_defined?", "instance_variable_get", "instance_variable_set",
+                        "instance_variables", "is_a?", "itself", "kind_of?", "method", "methods", "nil?", "object_id",
                         "pretty_inspect", "pretty_print", "pretty_print_cycle", "pretty_print_inspect",
                         "pretty_print_instance_variables", "private_methods", "protected_methods", "public_method",
-                        "public_methods", "public_send", "reduce", "reject", "remove_instance_variable", "respond_to?",
-                        "reverse_each", "select", "send", "singleton_class", "singleton_method", "singleton_methods",
-                        "size", "slice_after", "slice_before", "slice_when", "sort", "sort_by", "sum", "taint",
-                        "tainted?", "take", "take_while", "tally", "tap", "then", "to_a", "to_enum", "to_h", "to_s",
-                        "to_set", "trust", "uniq", "untaint", "untrust", "untrusted?", "values", "values_at",
-                        "yield_self", "zip"};
+                        "public_methods", "public_send", "remove_instance_variable", "respond_to?", "send",
+                        "singleton_class", "singleton_method", "singleton_methods", "taint", "tainted?", "tap", "then",
+                        "to_enum", "to_s", "trust", "untaint", "untrust", "untrusted?", "yield_self"};
 
         for (String w : reserved) {
             reservedNames.put(w, "member_" + w);

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubySymbolProvider.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubySymbolProvider.java
@@ -97,21 +97,30 @@ public class RubySymbolProvider implements SymbolProvider,
         return reservedNames.build();
     }
 
-    // Mark all instances methods of a class as reserved. Shape members are accessors of a class.
-    // Taken from "class Foo; end; Foo.new.methods.sort".
+    // Mark all instances methods of a struct class as reserved. Shape members are accessors of a class.
+    // Taken from "Foo = Struct.new(nil); Foo.new.methods.sort".
     private ReservedWords memberReservedNames() {
         ReservedWordsBuilder reservedNames = new ReservedWordsBuilder();
         String[] reserved =
-                {"!", "!=", "!~", "<=>", "==", "===", "=~", "__id__", "__send__", "class", "clone",
-                        "define_singleton_method", "display", "dup", "enum_for", "eql?", "equal?", "extend", "freeze",
-                        "frozen?", "hash", "inspect", "instance_eval", "instance_exec", "instance_of?",
-                        "instance_variable_defined?", "instance_variable_get", "instance_variable_set",
-                        "instance_variables", "is_a?", "itself", "kind_of?", "method", "methods", "nil?", "object_id",
+                {"!", "!=", "!~", "<=>", "==", "===", "=~", "[]", "[]=", "__id__", "__send__", "all?", "any?", "chain",
+                        "chunk", "chunk_while", "class", "clone", "collect", "collect_concat", "count", "cycle",
+                        "deconstruct", "deconstruct_keys", "define_singleton_method", "detect", "dig", "display",
+                        "drop", "drop_while", "dup", "each", "each_cons", "each_entry", "each_pair", "each_slice",
+                        "each_with_index", "each_with_object", "entries", "enum_for", "eql?", "equal?", "extend",
+                        "filter", "filter_map", "find", "find_all", "find_index", "first", "flat_map", "freeze",
+                        "frozen?", "grep", "grep_v", "group_by", "hash", "include?", "inject", "inspect",
+                        "instance_eval", "instance_exec", "instance_of?", "instance_variable_defined?",
+                        "instance_variable_get", "instance_variable_set", "instance_variables", "is_a?", "itself",
+                        "kind_of?", "lazy", "length", "map", "max", "max_by", "member?", "members", "method", "methods",
+                        "min", "min_by", "minmax", "minmax_by", "nil?", "none?", "object_id", "one?", "partition",
                         "pretty_inspect", "pretty_print", "pretty_print_cycle", "pretty_print_inspect",
                         "pretty_print_instance_variables", "private_methods", "protected_methods", "public_method",
-                        "public_methods", "public_send", "remove_instance_variable", "respond_to?", "send",
-                        "singleton_class", "singleton_method", "singleton_methods", "taint", "tainted?", "tap", "then",
-                        "to_enum", "to_s", "trust", "untaint", "untrust", "untrusted?", "yield_self"};
+                        "public_methods", "public_send", "reduce", "reject", "remove_instance_variable", "respond_to?",
+                        "reverse_each", "select", "send", "singleton_class", "singleton_method", "singleton_methods",
+                        "size", "slice_after", "slice_before", "slice_when", "sort", "sort_by", "sum", "taint",
+                        "tainted?", "take", "take_while", "tally", "tap", "then", "to_a", "to_enum", "to_h", "to_s",
+                        "to_set", "trust", "uniq", "untaint", "untrust", "untrusted?", "values", "values_at",
+                        "yield_self", "zip"};
 
         for (String w : reserved) {
             reservedNames.put(w, "member_" + w);


### PR DESCRIPTION
This change updates reserved words for all ruby keywords and for instance methods of a Ruby struct. This removes "name" and other CLASS methods.

There are different approaches we can take:

* Use classes instead of structs for types. Enumerable methods would not need to be reserved words. This approach involves a lot of change.
* (This PR) add enumerable as reserved words. V3 -> V4 migration is slightly more complex but allows for enumerable methods on Struct to be used without hinderance.
* Do nothing, always overwrite enumerable methods. V3 does this today, but we haven't had customer reachouts.