### PR TITLE
Add metadata to Hearth::Output and Errors, and return Hearth::Output on successful calls

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-codegen/projections/**/*.rb linguist-generated=true
+codegen/projections/**/*.rb* linguist-generated=true

--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ Hearth has a full suite of rspec tests which can be run from the hearth director
 #### Manual Testing
 The `sample-service` directory defines a rails service that can be run with `rails s`.  You can then test manually by adding hearth and the generated sdk client to your library path with:
 ```sh
-irb -I 'hearth/lib' -I 'sample_service/lib'
+irb -I 'hearth/lib' -I 'codegen/projections/high_score_service/lib'
 ```
 
 And test with:
 ```Ruby
-require 'sample_service'
+require 'high_score_service'
 
-c = SampleService::Client.new(endpoint: 'http://127.0.0.1:3000')
+c = HighScoreService::Client.new(endpoint: 'http://127.0.0.1:3000')
 c.get_high_score(id: '1')
 ```

--- a/codegen/projections/high_score_service/lib/high_score_service/client.rb
+++ b/codegen/projections/high_score_service/lib/high_score_service/client.rb
@@ -7,6 +7,8 @@
 #
 # WARNING ABOUT GENERATED CODE
 
+require_relative 'middleware/request_id'
+
 module HighScoreService
   # An API client for HighScoreService
   # See {#initialize} for a full list of supported configuration options
@@ -106,6 +108,7 @@ module HighScoreService
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 201, errors: [Errors::UnprocessableEntityError]),
         data_parser: Parsers::CreateHighScore
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -165,6 +168,7 @@ module HighScoreService
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::DeleteHighScore
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -230,6 +234,7 @@ module HighScoreService
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::GetHighScore
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -291,6 +296,7 @@ module HighScoreService
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::ListHighScores
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -363,6 +369,7 @@ module HighScoreService
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: [Errors::UnprocessableEntityError]),
         data_parser: Parsers::UpdateHighScore
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),

--- a/codegen/projections/high_score_service/lib/high_score_service/client.rb
+++ b/codegen/projections/high_score_service/lib/high_score_service/client.rb
@@ -105,7 +105,7 @@ module HighScoreService
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 201, errors: [Errors::UnprocessableEntityError]),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 201, errors: [Errors::UnprocessableEntityError]),
         data_parser: Parsers::CreateHighScore
       )
       stack.use(Middleware::RequestId)
@@ -165,7 +165,7 @@ module HighScoreService
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::DeleteHighScore
       )
       stack.use(Middleware::RequestId)
@@ -231,7 +231,7 @@ module HighScoreService
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::GetHighScore
       )
       stack.use(Middleware::RequestId)
@@ -293,7 +293,7 @@ module HighScoreService
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::ListHighScores
       )
       stack.use(Middleware::RequestId)
@@ -366,7 +366,7 @@ module HighScoreService
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: [Errors::UnprocessableEntityError]),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: [Errors::UnprocessableEntityError]),
         data_parser: Parsers::UpdateHighScore
       )
       stack.use(Middleware::RequestId)

--- a/codegen/projections/high_score_service/lib/high_score_service/client.rb
+++ b/codegen/projections/high_score_service/lib/high_score_service/client.rb
@@ -81,14 +81,14 @@ module HighScoreService
     #
     # @example Response structure
     #
-    #   resp #=> Types::CreateHighScoreOutput
-    #   resp.high_score #=> Types::HighScoreAttributes
-    #   resp.high_score.id #=> String
-    #   resp.high_score.game #=> String
-    #   resp.high_score.score #=> Integer
-    #   resp.high_score.created_at #=> Time
-    #   resp.high_score.updated_at #=> Time
-    #   resp.location #=> String
+    #   resp.data #=> Types::CreateHighScoreOutput
+    #   resp.data.high_score #=> Types::HighScoreAttributes
+    #   resp.data.high_score.id #=> String
+    #   resp.data.high_score.game #=> String
+    #   resp.data.high_score.score #=> Integer
+    #   resp.data.high_score.created_at #=> Time
+    #   resp.data.high_score.updated_at #=> Time
+    #   resp.data.location #=> String
     #
     def create_high_score(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -126,7 +126,7 @@ module HighScoreService
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # Delete a high score
@@ -147,7 +147,7 @@ module HighScoreService
     #
     # @example Response structure
     #
-    #   resp #=> Types::DeleteHighScoreOutput
+    #   resp.data #=> Types::DeleteHighScoreOutput
     #
     def delete_high_score(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -185,7 +185,7 @@ module HighScoreService
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # Get a high score
@@ -206,13 +206,13 @@ module HighScoreService
     #
     # @example Response structure
     #
-    #   resp #=> Types::GetHighScoreOutput
-    #   resp.high_score #=> Types::HighScoreAttributes
-    #   resp.high_score.id #=> String
-    #   resp.high_score.game #=> String
-    #   resp.high_score.score #=> Integer
-    #   resp.high_score.created_at #=> Time
-    #   resp.high_score.updated_at #=> Time
+    #   resp.data #=> Types::GetHighScoreOutput
+    #   resp.data.high_score #=> Types::HighScoreAttributes
+    #   resp.data.high_score.id #=> String
+    #   resp.data.high_score.game #=> String
+    #   resp.data.high_score.score #=> Integer
+    #   resp.data.high_score.created_at #=> Time
+    #   resp.data.high_score.updated_at #=> Time
     #
     def get_high_score(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -250,7 +250,7 @@ module HighScoreService
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # List all high scores
@@ -266,14 +266,14 @@ module HighScoreService
     #
     # @example Response structure
     #
-    #   resp #=> Types::ListHighScoresOutput
-    #   resp.high_scores #=> Array<HighScoreAttributes>
-    #   resp.high_scores[0] #=> Types::HighScoreAttributes
-    #   resp.high_scores[0].id #=> String
-    #   resp.high_scores[0].game #=> String
-    #   resp.high_scores[0].score #=> Integer
-    #   resp.high_scores[0].created_at #=> Time
-    #   resp.high_scores[0].updated_at #=> Time
+    #   resp.data #=> Types::ListHighScoresOutput
+    #   resp.data.high_scores #=> Array<HighScoreAttributes>
+    #   resp.data.high_scores[0] #=> Types::HighScoreAttributes
+    #   resp.data.high_scores[0].id #=> String
+    #   resp.data.high_scores[0].game #=> String
+    #   resp.data.high_scores[0].score #=> Integer
+    #   resp.data.high_scores[0].created_at #=> Time
+    #   resp.data.high_scores[0].updated_at #=> Time
     #
     def list_high_scores(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -311,7 +311,7 @@ module HighScoreService
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # Update a high score
@@ -339,13 +339,13 @@ module HighScoreService
     #
     # @example Response structure
     #
-    #   resp #=> Types::UpdateHighScoreOutput
-    #   resp.high_score #=> Types::HighScoreAttributes
-    #   resp.high_score.id #=> String
-    #   resp.high_score.game #=> String
-    #   resp.high_score.score #=> Integer
-    #   resp.high_score.created_at #=> Time
-    #   resp.high_score.updated_at #=> Time
+    #   resp.data #=> Types::UpdateHighScoreOutput
+    #   resp.data.high_score #=> Types::HighScoreAttributes
+    #   resp.data.high_score.id #=> String
+    #   resp.data.high_score.game #=> String
+    #   resp.data.high_score.score #=> Integer
+    #   resp.data.high_score.created_at #=> Time
+    #   resp.data.high_score.updated_at #=> Time
     #
     def update_high_score(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -383,7 +383,7 @@ module HighScoreService
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     private

--- a/codegen/projections/high_score_service/lib/high_score_service/errors.rb
+++ b/codegen/projections/high_score_service/lib/high_score_service/errors.rb
@@ -62,7 +62,15 @@ module HighScoreService
     end
 
     # Base class for all errors returned by this service
-    class ApiError < Hearth::HTTP::ApiError; end
+    class ApiError < Hearth::HTTP::ApiError
+      def initialize(request_id: nil, **kwargs)
+        @request_id = request_id
+        super(**kwargs)
+      end
+
+      # @return [String, nil] request_id
+      attr_reader :request_id
+    end
 
     # Base class for all errors returned where the client is at fault.
     # These are generally errors with 4XX HTTP status codes.
@@ -93,6 +101,7 @@ module HighScoreService
       #
       def initialize(http_resp:, **kwargs)
         @data = Parsers::UnprocessableEntityError.parse(http_resp)
+        kwargs[:request_id] = http_resp.headers['x-request-id']
         kwargs[:message] = @data.message if @data.respond_to?(:message)
 
         super(http_resp: http_resp, **kwargs)

--- a/codegen/projections/high_score_service/lib/high_score_service/errors.rb
+++ b/codegen/projections/high_score_service/lib/high_score_service/errors.rb
@@ -9,7 +9,6 @@
 
 module HighScoreService
   module Errors
-
     def self.error_code(http_resp)
       case http_resp.status
       when 300 then 'MultipleChoicesError'
@@ -62,15 +61,7 @@ module HighScoreService
     end
 
     # Base class for all errors returned by this service
-    class ApiError < Hearth::HTTP::ApiError
-      def initialize(request_id: nil, **kwargs)
-        @request_id = request_id
-        super(**kwargs)
-      end
-
-      # @return [String, nil] request_id
-      attr_reader :request_id
-    end
+    class ApiError < Hearth::HTTP::ApiError; end
 
     # Base class for all errors returned where the client is at fault.
     # These are generally errors with 4XX HTTP status codes.
@@ -101,7 +92,6 @@ module HighScoreService
       #
       def initialize(http_resp:, **kwargs)
         @data = Parsers::UnprocessableEntityError.parse(http_resp)
-        kwargs[:request_id] = http_resp.headers['x-request-id']
         kwargs[:message] = @data.message if @data.respond_to?(:message)
 
         super(http_resp: http_resp, **kwargs)

--- a/codegen/projections/high_score_service/lib/high_score_service/middleware/request_id.rb
+++ b/codegen/projections/high_score_service/lib/high_score_service/middleware/request_id.rb
@@ -1,14 +1,16 @@
-# A middleware that extracts a request id from a response and sets it
-# on the context.
-# @api private
-class RequestId
-  def initialize(app)
-    @app = app
-  end
+module Middleware
+  # A middleware that extracts a request id from a response and sets it
+  # on the context.
+  # @api private
+  class RequestId
+    def initialize(app)
+      @app = app
+    end
 
-  def call(input, context)
-    output = @app.call(input, context)
-    output.metadata[:request_id] = context.response.headers['x-request-id']
-    output
+    def call(input, context)
+      output = @app.call(input, context)
+      output.metadata[:request_id] = context.response.headers['x-request-id']
+      output
+    end
   end
 end

--- a/codegen/projections/high_score_service/lib/high_score_service/middleware/request_id.rb
+++ b/codegen/projections/high_score_service/lib/high_score_service/middleware/request_id.rb
@@ -1,7 +1,7 @@
 module HighScoreService
   module Middleware
     # A middleware that extracts a request id from a response and sets it
-    # on the context.
+    # on output's metadata.
     # @api private
     class RequestId
       def initialize(app, _ = {})

--- a/codegen/projections/high_score_service/lib/high_score_service/middleware/request_id.rb
+++ b/codegen/projections/high_score_service/lib/high_score_service/middleware/request_id.rb
@@ -1,16 +1,18 @@
-module Middleware
-  # A middleware that extracts a request id from a response and sets it
-  # on the context.
-  # @api private
-  class RequestId
-    def initialize(app)
-      @app = app
-    end
+module HighScoreService
+  module Middleware
+    # A middleware that extracts a request id from a response and sets it
+    # on the context.
+    # @api private
+    class RequestId
+      def initialize(app, _ = {})
+        @app = app
+      end
 
-    def call(input, context)
-      output = @app.call(input, context)
-      output.metadata[:request_id] = context.response.headers['x-request-id']
-      output
+      def call(input, context)
+        output = @app.call(input, context)
+        output.metadata[:request_id] = context.response.headers['x-request-id']
+        output
+      end
     end
   end
 end

--- a/codegen/projections/high_score_service/lib/high_score_service/middleware/request_id.rb
+++ b/codegen/projections/high_score_service/lib/high_score_service/middleware/request_id.rb
@@ -1,0 +1,14 @@
+# A middleware that extracts a request id from a response and sets it
+# on the context.
+# @api private
+class RequestId
+  def initialize(app)
+    @app = app
+  end
+
+  def call(input, context)
+    output = @app.call(input, context)
+    output.metadata[:request_id] = context.response.headers['x-request-id']
+    output
+  end
+end

--- a/codegen/projections/rails_json/lib/rails_json/client.rb
+++ b/codegen/projections/rails_json/lib/rails_json/client.rb
@@ -127,7 +127,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::AllQueryStringTypes
       )
       stack.use(Middleware::RequestId)
@@ -187,7 +187,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::ConstantAndVariableQueryString
       )
       stack.use(Middleware::RequestId)
@@ -247,7 +247,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::ConstantQueryString
       )
       stack.use(Middleware::RequestId)
@@ -314,7 +314,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::DocumentType
       )
       stack.use(Middleware::RequestId)
@@ -379,7 +379,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::DocumentTypeAsPayload
       )
       stack.use(Middleware::RequestId)
@@ -432,7 +432,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::EmptyOperation
       )
       stack.use(Middleware::RequestId)
@@ -485,7 +485,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::EndpointOperation
       )
       stack.use(Middleware::RequestId)
@@ -540,7 +540,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::EndpointWithHostLabelOperation
       )
       stack.use(Middleware::RequestId)
@@ -603,7 +603,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: [Errors::InvalidGreeting, Errors::ComplexError]),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: [Errors::InvalidGreeting, Errors::ComplexError]),
         data_parser: Parsers::GreetingWithErrors
       )
       stack.use(Middleware::RequestId)
@@ -666,7 +666,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::HttpPayloadTraits
       )
       stack.use(Middleware::RequestId)
@@ -727,7 +727,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::HttpPayloadTraitsWithMediaType
       )
       stack.use(Middleware::RequestId)
@@ -793,7 +793,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::HttpPayloadWithStructure
       )
       stack.use(Middleware::RequestId)
@@ -858,7 +858,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::HttpPrefixHeaders
       )
       stack.use(Middleware::RequestId)
@@ -915,7 +915,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::HttpPrefixHeadersInResponse
       )
       stack.use(Middleware::RequestId)
@@ -971,7 +971,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::HttpRequestWithFloatLabels
       )
       stack.use(Middleware::RequestId)
@@ -1027,7 +1027,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::HttpRequestWithGreedyLabelInPath
       )
       stack.use(Middleware::RequestId)
@@ -1098,7 +1098,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::HttpRequestWithLabels
       )
       stack.use(Middleware::RequestId)
@@ -1162,7 +1162,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::HttpRequestWithLabelsAndTimestampFormat
       )
       stack.use(Middleware::RequestId)
@@ -1216,7 +1216,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::HttpResponseCode
       )
       stack.use(Middleware::RequestId)
@@ -1274,7 +1274,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::IgnoreQueryParamsInResponse
       )
       stack.use(Middleware::RequestId)
@@ -1381,7 +1381,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::InputAndOutputWithHeaders
       )
       stack.use(Middleware::RequestId)
@@ -1458,7 +1458,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::JsonEnums
       )
       stack.use(Middleware::RequestId)
@@ -1562,7 +1562,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::JsonMaps
       )
       stack.use(Middleware::RequestId)
@@ -1640,7 +1640,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::JsonUnions
       )
       stack.use(Middleware::RequestId)
@@ -1801,7 +1801,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: [Errors::ErrorWithMembers, Errors::ErrorWithoutMembers]),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: [Errors::ErrorWithMembers, Errors::ErrorWithoutMembers]),
         data_parser: Parsers::KitchenSinkOperation
       )
       stack.use(Middleware::RequestId)
@@ -1859,7 +1859,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::MediaTypeHeader
       )
       stack.use(Middleware::RequestId)
@@ -1917,7 +1917,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::NestedAttributesOperation
       )
       stack.use(Middleware::RequestId)
@@ -1982,7 +1982,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::NullAndEmptyHeadersClient
       )
       stack.use(Middleware::RequestId)
@@ -2048,7 +2048,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::NullOperation
       )
       stack.use(Middleware::RequestId)
@@ -2106,7 +2106,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::OmitsNullSerializesEmptyString
       )
       stack.use(Middleware::RequestId)
@@ -2162,7 +2162,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::OperationWithOptionalInputOutput
       )
       stack.use(Middleware::RequestId)
@@ -2219,7 +2219,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::QueryIdempotencyTokenAutoFill
       )
       stack.use(Middleware::RequestId)
@@ -2279,7 +2279,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::QueryParamsAsStringListMap
       )
       stack.use(Middleware::RequestId)
@@ -2349,7 +2349,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::TimestampFormatHeaders
       )
       stack.use(Middleware::RequestId)
@@ -2409,7 +2409,7 @@ module RailsJson
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::Operation____789BadName
       )
       stack.use(Middleware::RequestId)

--- a/codegen/projections/rails_json/lib/rails_json/client.rb
+++ b/codegen/projections/rails_json/lib/rails_json/client.rb
@@ -110,7 +110,7 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::AllQueryStringTypesOutput
+    #   resp.data #=> Types::AllQueryStringTypesOutput
     #
     def all_query_string_types(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -148,7 +148,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # This example uses fixed query string params and variable query string params.
@@ -169,7 +169,7 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::ConstantAndVariableQueryStringOutput
+    #   resp.data #=> Types::ConstantAndVariableQueryStringOutput
     #
     def constant_and_variable_query_string(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -207,7 +207,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # This example uses a constant query string parameters and a label.
@@ -228,7 +228,7 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::ConstantQueryStringOutput
+    #   resp.data #=> Types::ConstantQueryStringOutput
     #
     def constant_query_string(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -266,7 +266,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # This example serializes a document as part of the payload.
@@ -292,9 +292,9 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::DocumentTypeOutput
-    #   resp.string_value #=> String
-    #   resp.document_value #=> Hash,Array,String,Boolean,Numeric
+    #   resp.data #=> Types::DocumentTypeOutput
+    #   resp.data.string_value #=> String
+    #   resp.data.document_value #=> Hash,Array,String,Boolean,Numeric
     #
     def document_type(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -332,7 +332,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # This example serializes a document as the entire HTTP payload.
@@ -357,8 +357,8 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::DocumentTypeAsPayloadOutput
-    #   resp.document_value #=> Hash,Array,String,Boolean,Numeric
+    #   resp.data #=> Types::DocumentTypeAsPayloadOutput
+    #   resp.data.document_value #=> Hash,Array,String,Boolean,Numeric
     #
     def document_type_as_payload(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -396,7 +396,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # @param [Hash] params
@@ -410,7 +410,7 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::EmptyOperationOutput
+    #   resp.data #=> Types::EmptyOperationOutput
     #
     def empty_operation(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -448,7 +448,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # @param [Hash] params
@@ -462,7 +462,7 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::EndpointOperationOutput
+    #   resp.data #=> Types::EndpointOperationOutput
     #
     def endpoint_operation(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -500,7 +500,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # @param [Hash] params
@@ -516,7 +516,7 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::EndpointWithHostLabelOperationOutput
+    #   resp.data #=> Types::EndpointWithHostLabelOperationOutput
     #
     def endpoint_with_host_label_operation(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -554,7 +554,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # This operation has three possible return values:
@@ -577,8 +577,8 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::GreetingWithErrorsOutput
-    #   resp.greeting #=> String
+    #   resp.data #=> Types::GreetingWithErrorsOutput
+    #   resp.data.greeting #=> String
     #
     def greeting_with_errors(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -616,7 +616,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # This examples serializes a blob shape in the payload.
@@ -638,9 +638,9 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::HttpPayloadTraitsOutput
-    #   resp.foo #=> String
-    #   resp.blob #=> String
+    #   resp.data #=> Types::HttpPayloadTraitsOutput
+    #   resp.data.foo #=> String
+    #   resp.data.blob #=> String
     #
     def http_payload_traits(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -678,7 +678,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # This examples uses a `@mediaType` trait on the payload to force a custom
@@ -698,9 +698,9 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::HttpPayloadTraitsWithMediaTypeOutput
-    #   resp.foo #=> String
-    #   resp.blob #=> String
+    #   resp.data #=> Types::HttpPayloadTraitsWithMediaTypeOutput
+    #   resp.data.foo #=> String
+    #   resp.data.blob #=> String
     #
     def http_payload_traits_with_media_type(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -738,7 +738,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # This examples serializes a structure in the payload.
@@ -762,10 +762,10 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::HttpPayloadWithStructureOutput
-    #   resp.nested #=> Types::NestedPayload
-    #   resp.nested.greeting #=> String
-    #   resp.nested.member_name #=> String
+    #   resp.data #=> Types::HttpPayloadWithStructureOutput
+    #   resp.data.nested #=> Types::NestedPayload
+    #   resp.data.nested.greeting #=> String
+    #   resp.data.nested.member_name #=> String
     #
     def http_payload_with_structure(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -803,7 +803,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # This examples adds headers to the input of a request and response by prefix.
@@ -826,10 +826,10 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::HttpPrefixHeadersOutput
-    #   resp.foo #=> String
-    #   resp.foo_map #=> Hash<String, String>
-    #   resp.foo_map['key'] #=> String
+    #   resp.data #=> Types::HttpPrefixHeadersOutput
+    #   resp.data.foo #=> String
+    #   resp.data.foo_map #=> Hash<String, String>
+    #   resp.data.foo_map['key'] #=> String
     #
     def http_prefix_headers(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -867,7 +867,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # Clients that perform this test extract all headers from the response.
@@ -883,9 +883,9 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::HttpPrefixHeadersInResponseOutput
-    #   resp.prefix_headers #=> Hash<String, String>
-    #   resp.prefix_headers['key'] #=> String
+    #   resp.data #=> Types::HttpPrefixHeadersInResponseOutput
+    #   resp.data.prefix_headers #=> Hash<String, String>
+    #   resp.data.prefix_headers['key'] #=> String
     #
     def http_prefix_headers_in_response(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -923,7 +923,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # @param [Hash] params
@@ -940,7 +940,7 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::HttpRequestWithFloatLabelsOutput
+    #   resp.data #=> Types::HttpRequestWithFloatLabelsOutput
     #
     def http_request_with_float_labels(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -978,7 +978,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # @param [Hash] params
@@ -995,7 +995,7 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::HttpRequestWithGreedyLabelInPathOutput
+    #   resp.data #=> Types::HttpRequestWithGreedyLabelInPathOutput
     #
     def http_request_with_greedy_label_in_path(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -1033,7 +1033,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # The example tests how requests are serialized when there's no input
@@ -1065,7 +1065,7 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::HttpRequestWithLabelsOutput
+    #   resp.data #=> Types::HttpRequestWithLabelsOutput
     #
     def http_request_with_labels(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -1103,7 +1103,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # The example tests how requests serialize different timestamp formats in the
@@ -1128,7 +1128,7 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::HttpRequestWithLabelsAndTimestampFormatOutput
+    #   resp.data #=> Types::HttpRequestWithLabelsAndTimestampFormatOutput
     #
     def http_request_with_labels_and_timestamp_format(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -1166,7 +1166,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # @param [Hash] params
@@ -1180,8 +1180,8 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::HttpResponseCodeOutput
-    #   resp.status #=> Integer
+    #   resp.data #=> Types::HttpResponseCodeOutput
+    #   resp.data.status #=> Integer
     #
     def http_response_code(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -1219,7 +1219,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # This example ensures that query string bound request parameters are
@@ -1237,8 +1237,8 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::IgnoreQueryParamsInResponseOutput
-    #   resp.baz #=> String
+    #   resp.data #=> Types::IgnoreQueryParamsInResponseOutput
+    #   resp.data.baz #=> String
     #
     def ignore_query_params_in_response(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -1276,7 +1276,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # The example tests how requests and responses are serialized when there is
@@ -1322,29 +1322,29 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::InputAndOutputWithHeadersOutput
-    #   resp.header_string #=> String
-    #   resp.header_byte #=> Integer
-    #   resp.header_short #=> Integer
-    #   resp.header_integer #=> Integer
-    #   resp.header_long #=> Integer
-    #   resp.header_float #=> Float
-    #   resp.header_double #=> Float
-    #   resp.header_true_bool #=> Boolean
-    #   resp.header_false_bool #=> Boolean
-    #   resp.header_string_list #=> Array<String>
-    #   resp.header_string_list[0] #=> String
-    #   resp.header_string_set #=> Set<String>
-    #   resp.header_string_set[0] #=> String
-    #   resp.header_integer_list #=> Array<Integer>
-    #   resp.header_integer_list[0] #=> Integer
-    #   resp.header_boolean_list #=> Array<Boolean>
-    #   resp.header_boolean_list[0] #=> Boolean
-    #   resp.header_timestamp_list #=> Array<Time>
-    #   resp.header_timestamp_list[0] #=> Time
-    #   resp.header_enum #=> String, one of Foo, Baz, Bar, 1, 0
-    #   resp.header_enum_list #=> Array<String>
-    #   resp.header_enum_list[0] #=> String, one of Foo, Baz, Bar, 1, 0
+    #   resp.data #=> Types::InputAndOutputWithHeadersOutput
+    #   resp.data.header_string #=> String
+    #   resp.data.header_byte #=> Integer
+    #   resp.data.header_short #=> Integer
+    #   resp.data.header_integer #=> Integer
+    #   resp.data.header_long #=> Integer
+    #   resp.data.header_float #=> Float
+    #   resp.data.header_double #=> Float
+    #   resp.data.header_true_bool #=> Boolean
+    #   resp.data.header_false_bool #=> Boolean
+    #   resp.data.header_string_list #=> Array<String>
+    #   resp.data.header_string_list[0] #=> String
+    #   resp.data.header_string_set #=> Set<String>
+    #   resp.data.header_string_set[0] #=> String
+    #   resp.data.header_integer_list #=> Array<Integer>
+    #   resp.data.header_integer_list[0] #=> Integer
+    #   resp.data.header_boolean_list #=> Array<Boolean>
+    #   resp.data.header_boolean_list[0] #=> Boolean
+    #   resp.data.header_timestamp_list #=> Array<Time>
+    #   resp.data.header_timestamp_list[0] #=> Time
+    #   resp.data.header_enum #=> String, one of Foo, Baz, Bar, 1, 0
+    #   resp.data.header_enum_list #=> Array<String>
+    #   resp.data.header_enum_list[0] #=> String, one of Foo, Baz, Bar, 1, 0
     #
     def input_and_output_with_headers(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -1382,7 +1382,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # This example serializes enums as top level properties, in lists, sets, and maps.
@@ -1411,16 +1411,16 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::JsonEnumsOutput
-    #   resp.foo_enum1 #=> String, one of Foo, Baz, Bar, 1, 0
-    #   resp.foo_enum2 #=> String, one of Foo, Baz, Bar, 1, 0
-    #   resp.foo_enum3 #=> String, one of Foo, Baz, Bar, 1, 0
-    #   resp.foo_enum_list #=> Array<String>
-    #   resp.foo_enum_list[0] #=> String, one of Foo, Baz, Bar, 1, 0
-    #   resp.foo_enum_set #=> Set<String>
-    #   resp.foo_enum_set[0] #=> String, one of Foo, Baz, Bar, 1, 0
-    #   resp.foo_enum_map #=> Hash<String, String>
-    #   resp.foo_enum_map['key'] #=> String, one of Foo, Baz, Bar, 1, 0
+    #   resp.data #=> Types::JsonEnumsOutput
+    #   resp.data.foo_enum1 #=> String, one of Foo, Baz, Bar, 1, 0
+    #   resp.data.foo_enum2 #=> String, one of Foo, Baz, Bar, 1, 0
+    #   resp.data.foo_enum3 #=> String, one of Foo, Baz, Bar, 1, 0
+    #   resp.data.foo_enum_list #=> Array<String>
+    #   resp.data.foo_enum_list[0] #=> String, one of Foo, Baz, Bar, 1, 0
+    #   resp.data.foo_enum_set #=> Set<String>
+    #   resp.data.foo_enum_set[0] #=> String, one of Foo, Baz, Bar, 1, 0
+    #   resp.data.foo_enum_map #=> Hash<String, String>
+    #   resp.data.foo_enum_map['key'] #=> String, one of Foo, Baz, Bar, 1, 0
     #
     def json_enums(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -1458,7 +1458,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # The example tests basic map serialization.
@@ -1503,27 +1503,27 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::JsonMapsOutput
-    #   resp.dense_struct_map #=> Hash<String, GreetingStruct>
-    #   resp.dense_struct_map['key'] #=> Types::GreetingStruct
-    #   resp.dense_struct_map['key'].hi #=> String
-    #   resp.sparse_struct_map #=> Hash<String, GreetingStruct>
-    #   resp.dense_number_map #=> Hash<String, Integer>
-    #   resp.dense_number_map['key'] #=> Integer
-    #   resp.dense_boolean_map #=> Hash<String, Boolean>
-    #   resp.dense_boolean_map['key'] #=> Boolean
-    #   resp.dense_string_map #=> Hash<String, String>
-    #   resp.dense_string_map['key'] #=> String
-    #   resp.sparse_number_map #=> Hash<String, Integer>
-    #   resp.sparse_number_map['key'] #=> Integer
-    #   resp.sparse_boolean_map #=> Hash<String, Boolean>
-    #   resp.sparse_boolean_map['key'] #=> Boolean
-    #   resp.sparse_string_map #=> Hash<String, String>
-    #   resp.sparse_string_map['key'] #=> String
-    #   resp.dense_set_map #=> Hash<String, Set<String>>
-    #   resp.dense_set_map['key'] #=> Set<String>
-    #   resp.dense_set_map['key'][0] #=> String
-    #   resp.sparse_set_map #=> Hash<String, Set<String>>
+    #   resp.data #=> Types::JsonMapsOutput
+    #   resp.data.dense_struct_map #=> Hash<String, GreetingStruct>
+    #   resp.data.dense_struct_map['key'] #=> Types::GreetingStruct
+    #   resp.data.dense_struct_map['key'].hi #=> String
+    #   resp.data.sparse_struct_map #=> Hash<String, GreetingStruct>
+    #   resp.data.dense_number_map #=> Hash<String, Integer>
+    #   resp.data.dense_number_map['key'] #=> Integer
+    #   resp.data.dense_boolean_map #=> Hash<String, Boolean>
+    #   resp.data.dense_boolean_map['key'] #=> Boolean
+    #   resp.data.dense_string_map #=> Hash<String, String>
+    #   resp.data.dense_string_map['key'] #=> String
+    #   resp.data.sparse_number_map #=> Hash<String, Integer>
+    #   resp.data.sparse_number_map['key'] #=> Integer
+    #   resp.data.sparse_boolean_map #=> Hash<String, Boolean>
+    #   resp.data.sparse_boolean_map['key'] #=> Boolean
+    #   resp.data.sparse_string_map #=> Hash<String, String>
+    #   resp.data.sparse_string_map['key'] #=> String
+    #   resp.data.dense_set_map #=> Hash<String, Set<String>>
+    #   resp.data.dense_set_map['key'] #=> Set<String>
+    #   resp.data.dense_set_map['key'][0] #=> String
+    #   resp.data.sparse_set_map #=> Hash<String, Set<String>>
     #
     def json_maps(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -1561,7 +1561,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # This operation uses unions for inputs and outputs.
@@ -1599,8 +1599,8 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::JsonUnionsOutput
-    #   resp.contents #=> MyUnion
+    #   resp.data #=> Types::JsonUnionsOutput
+    #   resp.data.contents #=> MyUnion
     #
     def json_unions(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -1638,7 +1638,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # @param [Hash] params
@@ -1700,67 +1700,67 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::KitchenSinkOperationOutput
-    #   resp.blob #=> String
-    #   resp.boolean #=> Boolean
-    #   resp.double #=> Float
-    #   resp.empty_struct #=> Types::EmptyStruct
-    #   resp.float #=> Float
-    #   resp.httpdate_timestamp #=> Time
-    #   resp.integer #=> Integer
-    #   resp.iso8601_timestamp #=> Time
-    #   resp.json_value #=> String
-    #   resp.list_of_lists #=> Array<Array<String>>
-    #   resp.list_of_lists[0] #=> Array<String>
-    #   resp.list_of_lists[0][0] #=> String
-    #   resp.list_of_maps_of_strings #=> Array<Hash<String, String>>
-    #   resp.list_of_maps_of_strings[0] #=> Hash<String, String>
-    #   resp.list_of_maps_of_strings[0]['key'] #=> String
-    #   resp.list_of_strings #=> Array<String>
-    #   resp.list_of_structs #=> Array<SimpleStruct>
-    #   resp.list_of_structs[0] #=> Types::SimpleStruct
-    #   resp.list_of_structs[0].value #=> String
-    #   resp.long #=> Integer
-    #   resp.map_of_lists_of_strings #=> Hash<String, Array<String>>
-    #   resp.map_of_maps #=> Hash<String, Hash<String, String>>
-    #   resp.map_of_strings #=> Hash<String, String>
-    #   resp.map_of_structs #=> Hash<String, SimpleStruct>
-    #   resp.recursive_list #=> Array<KitchenSink>
-    #   resp.recursive_list[0] #=> Types::KitchenSink
-    #   resp.recursive_list[0].blob #=> String
-    #   resp.recursive_list[0].boolean #=> Boolean
-    #   resp.recursive_list[0].double #=> Float
-    #   resp.recursive_list[0].empty_struct #=> Types::EmptyStruct
-    #   resp.recursive_list[0].float #=> Float
-    #   resp.recursive_list[0].httpdate_timestamp #=> Time
-    #   resp.recursive_list[0].integer #=> Integer
-    #   resp.recursive_list[0].iso8601_timestamp #=> Time
-    #   resp.recursive_list[0].json_value #=> String
-    #   resp.recursive_list[0].list_of_lists #=> Array<Array<String>>
-    #   resp.recursive_list[0].list_of_maps_of_strings #=> Array<Hash<String, String>>
-    #   resp.recursive_list[0].list_of_strings #=> Array<String>
-    #   resp.recursive_list[0].list_of_structs #=> Array<SimpleStruct>
-    #   resp.recursive_list[0].long #=> Integer
-    #   resp.recursive_list[0].map_of_lists_of_strings #=> Hash<String, Array<String>>
-    #   resp.recursive_list[0].map_of_maps #=> Hash<String, Hash<String, String>>
-    #   resp.recursive_list[0].map_of_strings #=> Hash<String, String>
-    #   resp.recursive_list[0].map_of_structs #=> Hash<String, SimpleStruct>
-    #   resp.recursive_list[0].recursive_list #=> Array<KitchenSink>
-    #   resp.recursive_list[0].recursive_map #=> Hash<String, KitchenSink>
-    #   resp.recursive_list[0].recursive_struct #=> Types::KitchenSink
-    #   resp.recursive_list[0].simple_struct #=> Types::SimpleStruct
-    #   resp.recursive_list[0].string #=> String
-    #   resp.recursive_list[0].struct_with_location_name #=> Types::StructWithLocationName
-    #   resp.recursive_list[0].struct_with_location_name.value #=> String
-    #   resp.recursive_list[0].timestamp #=> Time
-    #   resp.recursive_list[0].unix_timestamp #=> Time
-    #   resp.recursive_map #=> Hash<String, KitchenSink>
-    #   resp.recursive_struct #=> Types::KitchenSink
-    #   resp.simple_struct #=> Types::SimpleStruct
-    #   resp.string #=> String
-    #   resp.struct_with_location_name #=> Types::StructWithLocationName
-    #   resp.timestamp #=> Time
-    #   resp.unix_timestamp #=> Time
+    #   resp.data #=> Types::KitchenSinkOperationOutput
+    #   resp.data.blob #=> String
+    #   resp.data.boolean #=> Boolean
+    #   resp.data.double #=> Float
+    #   resp.data.empty_struct #=> Types::EmptyStruct
+    #   resp.data.float #=> Float
+    #   resp.data.httpdate_timestamp #=> Time
+    #   resp.data.integer #=> Integer
+    #   resp.data.iso8601_timestamp #=> Time
+    #   resp.data.json_value #=> String
+    #   resp.data.list_of_lists #=> Array<Array<String>>
+    #   resp.data.list_of_lists[0] #=> Array<String>
+    #   resp.data.list_of_lists[0][0] #=> String
+    #   resp.data.list_of_maps_of_strings #=> Array<Hash<String, String>>
+    #   resp.data.list_of_maps_of_strings[0] #=> Hash<String, String>
+    #   resp.data.list_of_maps_of_strings[0]['key'] #=> String
+    #   resp.data.list_of_strings #=> Array<String>
+    #   resp.data.list_of_structs #=> Array<SimpleStruct>
+    #   resp.data.list_of_structs[0] #=> Types::SimpleStruct
+    #   resp.data.list_of_structs[0].value #=> String
+    #   resp.data.long #=> Integer
+    #   resp.data.map_of_lists_of_strings #=> Hash<String, Array<String>>
+    #   resp.data.map_of_maps #=> Hash<String, Hash<String, String>>
+    #   resp.data.map_of_strings #=> Hash<String, String>
+    #   resp.data.map_of_structs #=> Hash<String, SimpleStruct>
+    #   resp.data.recursive_list #=> Array<KitchenSink>
+    #   resp.data.recursive_list[0] #=> Types::KitchenSink
+    #   resp.data.recursive_list[0].blob #=> String
+    #   resp.data.recursive_list[0].boolean #=> Boolean
+    #   resp.data.recursive_list[0].double #=> Float
+    #   resp.data.recursive_list[0].empty_struct #=> Types::EmptyStruct
+    #   resp.data.recursive_list[0].float #=> Float
+    #   resp.data.recursive_list[0].httpdate_timestamp #=> Time
+    #   resp.data.recursive_list[0].integer #=> Integer
+    #   resp.data.recursive_list[0].iso8601_timestamp #=> Time
+    #   resp.data.recursive_list[0].json_value #=> String
+    #   resp.data.recursive_list[0].list_of_lists #=> Array<Array<String>>
+    #   resp.data.recursive_list[0].list_of_maps_of_strings #=> Array<Hash<String, String>>
+    #   resp.data.recursive_list[0].list_of_strings #=> Array<String>
+    #   resp.data.recursive_list[0].list_of_structs #=> Array<SimpleStruct>
+    #   resp.data.recursive_list[0].long #=> Integer
+    #   resp.data.recursive_list[0].map_of_lists_of_strings #=> Hash<String, Array<String>>
+    #   resp.data.recursive_list[0].map_of_maps #=> Hash<String, Hash<String, String>>
+    #   resp.data.recursive_list[0].map_of_strings #=> Hash<String, String>
+    #   resp.data.recursive_list[0].map_of_structs #=> Hash<String, SimpleStruct>
+    #   resp.data.recursive_list[0].recursive_list #=> Array<KitchenSink>
+    #   resp.data.recursive_list[0].recursive_map #=> Hash<String, KitchenSink>
+    #   resp.data.recursive_list[0].recursive_struct #=> Types::KitchenSink
+    #   resp.data.recursive_list[0].simple_struct #=> Types::SimpleStruct
+    #   resp.data.recursive_list[0].string #=> String
+    #   resp.data.recursive_list[0].struct_with_location_name #=> Types::StructWithLocationName
+    #   resp.data.recursive_list[0].struct_with_location_name.value #=> String
+    #   resp.data.recursive_list[0].timestamp #=> Time
+    #   resp.data.recursive_list[0].unix_timestamp #=> Time
+    #   resp.data.recursive_map #=> Hash<String, KitchenSink>
+    #   resp.data.recursive_struct #=> Types::KitchenSink
+    #   resp.data.simple_struct #=> Types::SimpleStruct
+    #   resp.data.string #=> String
+    #   resp.data.struct_with_location_name #=> Types::StructWithLocationName
+    #   resp.data.timestamp #=> Time
+    #   resp.data.unix_timestamp #=> Time
     #
     def kitchen_sink_operation(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -1798,7 +1798,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # This example ensures that mediaType strings are base64 encoded in headers.
@@ -1816,8 +1816,8 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::MediaTypeHeaderOutput
-    #   resp.json #=> String
+    #   resp.data #=> Types::MediaTypeHeaderOutput
+    #   resp.data.json #=> String
     #
     def media_type_header(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -1855,7 +1855,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # @param [Hash] params
@@ -1873,8 +1873,8 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::NestedAttributesOperationOutput
-    #   resp.value #=> String
+    #   resp.data #=> Types::NestedAttributesOperationOutput
+    #   resp.data.value #=> String
     #
     def nested_attributes_operation(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -1912,7 +1912,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # Null and empty headers are not sent over the wire.
@@ -1934,11 +1934,11 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::NullAndEmptyHeadersClientOutput
-    #   resp.a #=> String
-    #   resp.b #=> String
-    #   resp.c #=> Array<String>
-    #   resp.c[0] #=> String
+    #   resp.data #=> Types::NullAndEmptyHeadersClientOutput
+    #   resp.data.a #=> String
+    #   resp.data.b #=> String
+    #   resp.data.c #=> Array<String>
+    #   resp.data.c[0] #=> String
     #
     def null_and_empty_headers_client(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -1976,7 +1976,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # @param [Hash] params
@@ -1998,12 +1998,12 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::NullOperationOutput
-    #   resp.string #=> String
-    #   resp.sparse_string_list #=> Array<String>
-    #   resp.sparse_string_list[0] #=> String
-    #   resp.sparse_string_map #=> Hash<String, String>
-    #   resp.sparse_string_map['key'] #=> String
+    #   resp.data #=> Types::NullOperationOutput
+    #   resp.data.string #=> String
+    #   resp.data.sparse_string_list #=> Array<String>
+    #   resp.data.sparse_string_list[0] #=> String
+    #   resp.data.sparse_string_map #=> Hash<String, String>
+    #   resp.data.sparse_string_map['key'] #=> String
     #
     def null_operation(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -2041,7 +2041,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # Omits null, but serializes empty string value.
@@ -2060,7 +2060,7 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::OmitsNullSerializesEmptyStringOutput
+    #   resp.data #=> Types::OmitsNullSerializesEmptyStringOutput
     #
     def omits_null_serializes_empty_string(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -2098,7 +2098,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # @param [Hash] params
@@ -2114,8 +2114,8 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::OperationWithOptionalInputOutputOutput
-    #   resp.value #=> String
+    #   resp.data #=> Types::OperationWithOptionalInputOutputOutput
+    #   resp.data.value #=> String
     #
     def operation_with_optional_input_output(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -2153,7 +2153,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # Automatically adds idempotency tokens.
@@ -2171,7 +2171,7 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::QueryIdempotencyTokenAutoFillOutput
+    #   resp.data #=> Types::QueryIdempotencyTokenAutoFillOutput
     #
     def query_idempotency_token_auto_fill(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -2209,7 +2209,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # @param [Hash] params
@@ -2230,7 +2230,7 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::QueryParamsAsStringListMapOutput
+    #   resp.data #=> Types::QueryParamsAsStringListMapOutput
     #
     def query_params_as_string_list_map(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -2268,7 +2268,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # This example tests how timestamp request and response headers are serialized.
@@ -2292,14 +2292,14 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::TimestampFormatHeadersOutput
-    #   resp.member_epoch_seconds #=> Time
-    #   resp.member_http_date #=> Time
-    #   resp.member_date_time #=> Time
-    #   resp.default_format #=> Time
-    #   resp.target_epoch_seconds #=> Time
-    #   resp.target_http_date #=> Time
-    #   resp.target_date_time #=> Time
+    #   resp.data #=> Types::TimestampFormatHeadersOutput
+    #   resp.data.member_epoch_seconds #=> Time
+    #   resp.data.member_http_date #=> Time
+    #   resp.data.member_date_time #=> Time
+    #   resp.data.default_format #=> Time
+    #   resp.data.target_epoch_seconds #=> Time
+    #   resp.data.target_http_date #=> Time
+    #   resp.data.target_date_time #=> Time
     #
     def timestamp_format_headers(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -2337,7 +2337,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # @param [Hash] params
@@ -2356,9 +2356,9 @@ module RailsJson
     #
     # @example Response structure
     #
-    #   resp #=> Types::Struct____789BadNameOutput
-    #   resp.member #=> Types::Struct____456efg
-    #   resp.member.member____123foo #=> String
+    #   resp.data #=> Types::Struct____789BadNameOutput
+    #   resp.data.member #=> Types::Struct____456efg
+    #   resp.data.member.member____123foo #=> String
     #
     def operation____789_bad_name(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -2396,7 +2396,7 @@ module RailsJson
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     private

--- a/codegen/projections/rails_json/lib/rails_json/client.rb
+++ b/codegen/projections/rails_json/lib/rails_json/client.rb
@@ -7,6 +7,8 @@
 #
 # WARNING ABOUT GENERATED CODE
 
+require_relative 'middleware/request_id'
+
 module RailsJson
   # An API client for RailsJson
   # See {#initialize} for a full list of supported configuration options
@@ -128,6 +130,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::AllQueryStringTypes
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -187,6 +190,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::ConstantAndVariableQueryString
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -246,6 +250,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::ConstantQueryString
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -312,6 +317,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::DocumentType
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -376,6 +382,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::DocumentTypeAsPayload
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -428,6 +435,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::EmptyOperation
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -480,6 +488,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::EndpointOperation
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -534,6 +543,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::EndpointWithHostLabelOperation
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -596,6 +606,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: [Errors::InvalidGreeting, Errors::ComplexError]),
         data_parser: Parsers::GreetingWithErrors
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -658,6 +669,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::HttpPayloadTraits
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -718,6 +730,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::HttpPayloadTraitsWithMediaType
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -783,6 +796,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::HttpPayloadWithStructure
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -847,6 +861,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::HttpPrefixHeaders
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -903,6 +918,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::HttpPrefixHeadersInResponse
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -958,6 +974,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::HttpRequestWithFloatLabels
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -1013,6 +1030,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::HttpRequestWithGreedyLabelInPath
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -1083,6 +1101,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::HttpRequestWithLabels
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -1146,6 +1165,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::HttpRequestWithLabelsAndTimestampFormat
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -1199,6 +1219,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::HttpResponseCode
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -1256,6 +1277,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::IgnoreQueryParamsInResponse
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -1362,6 +1384,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::InputAndOutputWithHeaders
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -1438,6 +1461,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::JsonEnums
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -1541,6 +1565,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::JsonMaps
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -1618,6 +1643,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::JsonUnions
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -1778,6 +1804,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: [Errors::ErrorWithMembers, Errors::ErrorWithoutMembers]),
         data_parser: Parsers::KitchenSinkOperation
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -1835,6 +1862,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::MediaTypeHeader
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -1892,6 +1920,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::NestedAttributesOperation
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -1956,6 +1985,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::NullAndEmptyHeadersClient
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -2021,6 +2051,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::NullOperation
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -2078,6 +2109,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::OmitsNullSerializesEmptyString
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -2133,6 +2165,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::OperationWithOptionalInputOutput
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -2189,6 +2222,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::QueryIdempotencyTokenAutoFill
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -2248,6 +2282,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::QueryParamsAsStringListMap
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -2317,6 +2352,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::TimestampFormatHeaders
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
@@ -2376,6 +2412,7 @@ module RailsJson
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
         data_parser: Parsers::Operation____789BadName
       )
+      stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: options.fetch(:stub_responses, @stub_responses),
         client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),

--- a/codegen/projections/rails_json/lib/rails_json/errors.rb
+++ b/codegen/projections/rails_json/lib/rails_json/errors.rb
@@ -15,7 +15,15 @@ module RailsJson
     end
 
     # Base class for all errors returned by this service
-    class ApiError < Hearth::HTTP::ApiError; end
+    class ApiError < Hearth::HTTP::ApiError
+      def initialize(request_id: nil, **kwargs)
+        @request_id = request_id
+        super(**kwargs)
+      end
+
+      # @return [String, nil] request_id
+      attr_reader :request_id
+    end
 
     # Base class for all errors returned where the client is at fault.
     # These are generally errors with 4XX HTTP status codes.
@@ -46,6 +54,7 @@ module RailsJson
       #
       def initialize(http_resp:, **kwargs)
         @data = Parsers::ComplexError.parse(http_resp)
+        kwargs[:request_id] = http_resp.headers['x-request-id']
         kwargs[:message] = @data.message if @data.respond_to?(:message)
 
         super(http_resp: http_resp, **kwargs)
@@ -65,6 +74,7 @@ module RailsJson
       #
       def initialize(http_resp:, **kwargs)
         @data = Parsers::ErrorWithMembers.parse(http_resp)
+        kwargs[:request_id] = http_resp.headers['x-request-id']
         kwargs[:message] = @data.message if @data.respond_to?(:message)
 
         super(http_resp: http_resp, **kwargs)
@@ -84,6 +94,7 @@ module RailsJson
       #
       def initialize(http_resp:, **kwargs)
         @data = Parsers::ErrorWithoutMembers.parse(http_resp)
+        kwargs[:request_id] = http_resp.headers['x-request-id']
         kwargs[:message] = @data.message if @data.respond_to?(:message)
 
         super(http_resp: http_resp, **kwargs)
@@ -103,6 +114,7 @@ module RailsJson
       #
       def initialize(http_resp:, **kwargs)
         @data = Parsers::InvalidGreeting.parse(http_resp)
+        kwargs[:request_id] = http_resp.headers['x-request-id']
         kwargs[:message] = @data.message if @data.respond_to?(:message)
 
         super(http_resp: http_resp, **kwargs)

--- a/codegen/projections/rails_json/lib/rails_json/errors.rb
+++ b/codegen/projections/rails_json/lib/rails_json/errors.rb
@@ -9,21 +9,12 @@
 
 module RailsJson
   module Errors
-
     def self.error_code(http_resp)
       http_resp.headers['x-smithy-rails-error']
     end
 
     # Base class for all errors returned by this service
-    class ApiError < Hearth::HTTP::ApiError
-      def initialize(request_id: nil, **kwargs)
-        @request_id = request_id
-        super(**kwargs)
-      end
-
-      # @return [String, nil] request_id
-      attr_reader :request_id
-    end
+    class ApiError < Hearth::HTTP::ApiError; end
 
     # Base class for all errors returned where the client is at fault.
     # These are generally errors with 4XX HTTP status codes.
@@ -54,7 +45,6 @@ module RailsJson
       #
       def initialize(http_resp:, **kwargs)
         @data = Parsers::ComplexError.parse(http_resp)
-        kwargs[:request_id] = http_resp.headers['x-request-id']
         kwargs[:message] = @data.message if @data.respond_to?(:message)
 
         super(http_resp: http_resp, **kwargs)
@@ -74,7 +64,6 @@ module RailsJson
       #
       def initialize(http_resp:, **kwargs)
         @data = Parsers::ErrorWithMembers.parse(http_resp)
-        kwargs[:request_id] = http_resp.headers['x-request-id']
         kwargs[:message] = @data.message if @data.respond_to?(:message)
 
         super(http_resp: http_resp, **kwargs)
@@ -94,7 +83,6 @@ module RailsJson
       #
       def initialize(http_resp:, **kwargs)
         @data = Parsers::ErrorWithoutMembers.parse(http_resp)
-        kwargs[:request_id] = http_resp.headers['x-request-id']
         kwargs[:message] = @data.message if @data.respond_to?(:message)
 
         super(http_resp: http_resp, **kwargs)
@@ -114,7 +102,6 @@ module RailsJson
       #
       def initialize(http_resp:, **kwargs)
         @data = Parsers::InvalidGreeting.parse(http_resp)
-        kwargs[:request_id] = http_resp.headers['x-request-id']
         kwargs[:message] = @data.message if @data.respond_to?(:message)
 
         super(http_resp: http_resp, **kwargs)

--- a/codegen/projections/rails_json/lib/rails_json/middleware/request_id.rb
+++ b/codegen/projections/rails_json/lib/rails_json/middleware/request_id.rb
@@ -1,14 +1,16 @@
-# A middleware that extracts a request id from a response and sets it
-# on the context.
-# @api private
-class RequestId
-  def initialize(app)
-    @app = app
-  end
+module Middleware
+  # A middleware that extracts a request id from a response and sets it
+  # on the context.
+  # @api private
+  class RequestId
+    def initialize(app)
+      @app = app
+    end
 
-  def call(input, context)
-    output = @app.call(input, context)
-    output.metadata[:request_id] = context.response.headers['x-request-id']
-    output
+    def call(input, context)
+      output = @app.call(input, context)
+      output.metadata[:request_id] = context.response.headers['x-request-id']
+      output
+    end
   end
 end

--- a/codegen/projections/rails_json/lib/rails_json/middleware/request_id.rb
+++ b/codegen/projections/rails_json/lib/rails_json/middleware/request_id.rb
@@ -1,16 +1,18 @@
-module Middleware
-  # A middleware that extracts a request id from a response and sets it
-  # on the context.
-  # @api private
-  class RequestId
-    def initialize(app)
-      @app = app
-    end
+module RailsJson
+  module Middleware
+    # A middleware that extracts a request id from a response and sets it
+    # on the context.
+    # @api private
+    class RequestId
+      def initialize(app, _ = {})
+        @app = app
+      end
 
-    def call(input, context)
-      output = @app.call(input, context)
-      output.metadata[:request_id] = context.response.headers['x-request-id']
-      output
+      def call(input, context)
+        output = @app.call(input, context)
+        output.metadata[:request_id] = context.response.headers['x-request-id']
+        output
+      end
     end
   end
 end

--- a/codegen/projections/rails_json/lib/rails_json/middleware/request_id.rb
+++ b/codegen/projections/rails_json/lib/rails_json/middleware/request_id.rb
@@ -1,0 +1,14 @@
+# A middleware that extracts a request id from a response and sets it
+# on the context.
+# @api private
+class RequestId
+  def initialize(app)
+    @app = app
+  end
+
+  def call(input, context)
+    output = @app.call(input, context)
+    output.metadata[:request_id] = context.response.headers['x-request-id']
+    output
+  end
+end

--- a/codegen/projections/rails_json/lib/rails_json/middleware/request_id.rb
+++ b/codegen/projections/rails_json/lib/rails_json/middleware/request_id.rb
@@ -1,7 +1,7 @@
 module RailsJson
   module Middleware
     # A middleware that extracts a request id from a response and sets it
-    # on the context.
+    # on output's metadata.
     # @api private
     class RequestId
       def initialize(app, _ = {})

--- a/codegen/projections/rails_json/spec/protocol_spec.rb
+++ b/codegen/projections/rails_json/spec/protocol_spec.rb
@@ -56,7 +56,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.operation____789_bad_name({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             member: {
               member____123foo: "foo value"
             }
@@ -79,7 +79,7 @@ module RailsJson
             }
           })
           output = client.operation____789_bad_name({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             member: {
               member____123foo: "foo value"
             }
@@ -398,7 +398,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.document_type({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             string_value: "string",
             document_value: {'foo' => 'bar'}
           })
@@ -418,7 +418,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.document_type({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             string_value: "string",
             document_value: 'hello'
           })
@@ -438,7 +438,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.document_type({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             string_value: "string",
             document_value: 10
           })
@@ -458,7 +458,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.document_type({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             string_value: "string",
             document_value: false
           })
@@ -481,7 +481,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.document_type({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             string_value: "string",
             document_value: [true, false]
           })
@@ -502,7 +502,7 @@ module RailsJson
             document_value: {'foo' => 'bar'}
           })
           output = client.document_type({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             string_value: "string",
             document_value: {'foo' => 'bar'}
           })
@@ -520,7 +520,7 @@ module RailsJson
             document_value: 'hello'
           })
           output = client.document_type({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             string_value: "string",
             document_value: 'hello'
           })
@@ -538,7 +538,7 @@ module RailsJson
             document_value: 10
           })
           output = client.document_type({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             string_value: "string",
             document_value: 10
           })
@@ -556,7 +556,7 @@ module RailsJson
             document_value: false
           })
           output = client.document_type({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             string_value: "string",
             document_value: false
           })
@@ -574,7 +574,7 @@ module RailsJson
             document_value: [true, false]
           })
           output = client.document_type({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             string_value: "string",
             document_value: [true, false]
           })
@@ -639,7 +639,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.document_type_as_payload({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             document_value: {'foo' => 'bar'}
           })
         end
@@ -655,7 +655,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.document_type_as_payload({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             document_value: 'hello'
           })
         end
@@ -674,7 +674,7 @@ module RailsJson
             document_value: {'foo' => 'bar'}
           })
           output = client.document_type_as_payload({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             document_value: {'foo' => 'bar'}
           })
         end
@@ -690,7 +690,7 @@ module RailsJson
             document_value: 'hello'
           })
           output = client.document_type_as_payload({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             document_value: 'hello'
           })
         end
@@ -716,7 +716,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.empty_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
 
           })
         end
@@ -737,7 +737,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.empty_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
 
           })
         end
@@ -757,7 +757,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.empty_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
 
           })
         end
@@ -779,7 +779,7 @@ module RailsJson
 
           })
           output = client.empty_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
 
           })
         end
@@ -798,7 +798,7 @@ module RailsJson
 
           })
           output = client.empty_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
 
           })
         end
@@ -818,7 +818,7 @@ module RailsJson
 
           })
           output = client.empty_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
 
           })
         end
@@ -1010,7 +1010,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.http_payload_traits({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             foo: "Foo",
             blob: 'blobby blob blob'
           })
@@ -1027,7 +1027,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.http_payload_traits({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             foo: "Foo"
           })
         end
@@ -1047,7 +1047,7 @@ module RailsJson
             blob: 'blobby blob blob'
           })
           output = client.http_payload_traits({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             foo: "Foo",
             blob: 'blobby blob blob'
           })
@@ -1064,7 +1064,7 @@ module RailsJson
             foo: "Foo"
           })
           output = client.http_payload_traits({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             foo: "Foo"
           })
         end
@@ -1109,7 +1109,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.http_payload_traits_with_media_type({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             foo: "Foo",
             blob: 'blobby blob blob'
           })
@@ -1130,7 +1130,7 @@ module RailsJson
             blob: 'blobby blob blob'
           })
           output = client.http_payload_traits_with_media_type({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             foo: "Foo",
             blob: 'blobby blob blob'
           })
@@ -1184,7 +1184,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.http_payload_with_structure({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             nested: {
               greeting: "hello",
               member_name: "Phreddy"
@@ -1209,7 +1209,7 @@ module RailsJson
             }
           })
           output = client.http_payload_with_structure({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             nested: {
               greeting: "hello",
               member_name: "Phreddy"
@@ -1278,7 +1278,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.http_prefix_headers({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             foo: "Foo",
             foo_map: {
               'Abc' => "Abc value",
@@ -1305,7 +1305,7 @@ module RailsJson
             }
           })
           output = client.http_prefix_headers({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             foo: "Foo",
             foo_map: {
               'Abc' => "Abc value",
@@ -1331,7 +1331,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.http_prefix_headers_in_response({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             prefix_headers: {
               'X-Foo' => "Foo",
               'Hello' => "Hello"
@@ -1356,7 +1356,7 @@ module RailsJson
             }
           })
           output = client.http_prefix_headers_in_response({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             prefix_headers: {
               'X-Foo' => "Foo",
               'Hello' => "Hello"
@@ -1550,7 +1550,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.http_response_code({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             status: 201
           })
         end
@@ -1567,7 +1567,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.http_response_code({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             status: 201
           })
         end
@@ -1590,7 +1590,7 @@ module RailsJson
             status: 201
           })
           output = client.http_response_code({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             status: 201
           })
         end
@@ -1608,7 +1608,7 @@ module RailsJson
             status: 201
           })
           output = client.http_response_code({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             status: 201
           })
         end
@@ -1634,7 +1634,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.ignore_query_params_in_response({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
 
           })
         end
@@ -1651,7 +1651,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.ignore_query_params_in_response({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
 
           })
         end
@@ -1673,7 +1673,7 @@ module RailsJson
 
           })
           output = client.ignore_query_params_in_response({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
 
           })
         end
@@ -1691,7 +1691,7 @@ module RailsJson
 
           })
           output = client.ignore_query_params_in_response({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
 
           })
         end
@@ -1816,7 +1816,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.input_and_output_with_headers({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             header_string: "Hello",
             header_string_list: [
               "a",
@@ -1842,7 +1842,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.input_and_output_with_headers({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             header_string_list: [
               "b,c",
               "\"def\"",
@@ -1862,7 +1862,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.input_and_output_with_headers({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             header_byte: 1,
             header_short: 123,
             header_integer: 123,
@@ -1888,7 +1888,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.input_and_output_with_headers({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             header_true_bool: true,
             header_false_bool: false,
             header_boolean_list: [
@@ -1910,7 +1910,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.input_and_output_with_headers({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             header_enum: "Foo",
             header_enum_list: [
               "Foo",
@@ -1944,7 +1944,7 @@ module RailsJson
             ]
           })
           output = client.input_and_output_with_headers({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             header_string: "Hello",
             header_string_list: [
               "a",
@@ -1974,7 +1974,7 @@ module RailsJson
             ]
           })
           output = client.input_and_output_with_headers({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             header_string_list: [
               "b,c",
               "\"def\"",
@@ -2004,7 +2004,7 @@ module RailsJson
             ]
           })
           output = client.input_and_output_with_headers({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             header_byte: 1,
             header_short: 123,
             header_integer: 123,
@@ -2036,7 +2036,7 @@ module RailsJson
             ]
           })
           output = client.input_and_output_with_headers({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             header_true_bool: true,
             header_false_bool: false,
             header_boolean_list: [
@@ -2063,7 +2063,7 @@ module RailsJson
             ]
           })
           output = client.input_and_output_with_headers({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             header_enum: "Foo",
             header_enum_list: [
               "Foo",
@@ -2157,7 +2157,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.json_enums({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             foo_enum1: "Foo",
             foo_enum2: "0",
             foo_enum3: "1",
@@ -2204,7 +2204,7 @@ module RailsJson
             }
           })
           output = client.json_enums({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             foo_enum1: "Foo",
             foo_enum2: "0",
             foo_enum3: "1",
@@ -2484,7 +2484,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.json_maps({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             dense_struct_map: {
               'foo' => {
                 hi: "there"
@@ -2528,7 +2528,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.json_maps({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             sparse_boolean_map: {
               'x' => nil
             },
@@ -2568,7 +2568,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.json_maps({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             dense_number_map: {
               'x' => 0
             },
@@ -2600,7 +2600,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.json_maps({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             sparse_set_map: {
               'x' => [
 
@@ -2629,7 +2629,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.json_maps({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             dense_set_map: {
               'x' => [
 
@@ -2659,7 +2659,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.json_maps({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             sparse_set_map: {
               'x' => [
 
@@ -2691,7 +2691,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.json_maps({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             dense_set_map: {
               'x' => [
 
@@ -2733,7 +2733,7 @@ module RailsJson
             }
           })
           output = client.json_maps({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             dense_struct_map: {
               'foo' => {
                 hi: "there"
@@ -2775,7 +2775,7 @@ module RailsJson
             }
           })
           output = client.json_maps({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             sparse_boolean_map: {
               'x' => nil
             },
@@ -2813,7 +2813,7 @@ module RailsJson
             }
           })
           output = client.json_maps({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             dense_number_map: {
               'x' => 0
             },
@@ -2848,7 +2848,7 @@ module RailsJson
             }
           })
           output = client.json_maps({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             sparse_set_map: {
               'x' => [
 
@@ -2880,7 +2880,7 @@ module RailsJson
             }
           })
           output = client.json_maps({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             dense_set_map: {
               'x' => [
 
@@ -2913,7 +2913,7 @@ module RailsJson
             }
           })
           output = client.json_maps({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             sparse_set_map: {
               'x' => [
 
@@ -2947,7 +2947,7 @@ module RailsJson
             }
           })
           output = client.json_maps({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             dense_set_map: {
               'x' => [
 
@@ -3205,7 +3205,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.json_unions({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             contents: {
               string_value: "foo"
             }
@@ -3227,7 +3227,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.json_unions({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             contents: {
               boolean_value: true
             }
@@ -3249,7 +3249,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.json_unions({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             contents: {
               number_value: 1
             }
@@ -3271,7 +3271,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.json_unions({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             contents: {
               blob_value: 'foo'
             }
@@ -3293,7 +3293,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.json_unions({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             contents: {
               timestamp_value: Time.at(1398796238)
             }
@@ -3315,7 +3315,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.json_unions({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             contents: {
               enum_value: "Foo"
             }
@@ -3337,7 +3337,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.json_unions({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             contents: {
               list_value: [
                 "foo",
@@ -3365,7 +3365,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.json_unions({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             contents: {
               map_value: {
                 'foo' => "bar",
@@ -3392,7 +3392,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.json_unions({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             contents: {
               structure_value: {
                 hi: "hello"
@@ -3417,7 +3417,7 @@ module RailsJson
             }
           })
           output = client.json_unions({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             contents: {
               string_value: "foo"
             }
@@ -3437,7 +3437,7 @@ module RailsJson
             }
           })
           output = client.json_unions({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             contents: {
               boolean_value: true
             }
@@ -3457,7 +3457,7 @@ module RailsJson
             }
           })
           output = client.json_unions({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             contents: {
               number_value: 1
             }
@@ -3477,7 +3477,7 @@ module RailsJson
             }
           })
           output = client.json_unions({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             contents: {
               blob_value: 'foo'
             }
@@ -3497,7 +3497,7 @@ module RailsJson
             }
           })
           output = client.json_unions({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             contents: {
               timestamp_value: Time.at(1398796238)
             }
@@ -3517,7 +3517,7 @@ module RailsJson
             }
           })
           output = client.json_unions({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             contents: {
               enum_value: "Foo"
             }
@@ -3540,7 +3540,7 @@ module RailsJson
             }
           })
           output = client.json_unions({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             contents: {
               list_value: [
                 "foo",
@@ -3566,7 +3566,7 @@ module RailsJson
             }
           })
           output = client.json_unions({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             contents: {
               map_value: {
                 'foo' => "bar",
@@ -3591,7 +3591,7 @@ module RailsJson
             }
           })
           output = client.json_unions({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             contents: {
               structure_value: {
                 hi: "hello"
@@ -4222,7 +4222,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
 
           })
         end
@@ -4238,7 +4238,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             string: "string-value"
           })
         end
@@ -4254,7 +4254,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             integer: 1234
           })
         end
@@ -4270,7 +4270,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             long: 1234567890123456789
           })
         end
@@ -4286,7 +4286,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             float: 1234.5
           })
         end
@@ -4302,7 +4302,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             double: 1.2345678912345679E8
           })
         end
@@ -4318,7 +4318,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             boolean: true
           })
         end
@@ -4334,7 +4334,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             boolean: false
           })
         end
@@ -4350,7 +4350,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             blob: 'binary-value'
           })
         end
@@ -4366,7 +4366,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             timestamp: Time.at(946845296)
           })
         end
@@ -4382,7 +4382,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             iso8601_timestamp: Time.at(946845296)
           })
         end
@@ -4398,7 +4398,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             httpdate_timestamp: Time.at(946845296)
           })
         end
@@ -4414,7 +4414,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             list_of_strings: [
               "abc",
               "mno",
@@ -4434,7 +4434,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             list_of_maps_of_strings: [
               {
                 'size' => "large"
@@ -4457,7 +4457,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             list_of_lists: [
               [
                 "abc",
@@ -4484,7 +4484,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             list_of_structs: [
               {
                 value: "value-1"
@@ -4507,7 +4507,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             recursive_list: [
               {
                 recursive_list: [
@@ -4535,7 +4535,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             map_of_strings: {
               'size' => "large",
               'color' => "red"
@@ -4554,7 +4554,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             map_of_lists_of_strings: {
               'sizes' => [
                 "large",
@@ -4579,7 +4579,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             map_of_maps: {
               'sizes' => {
                 'large' => "L",
@@ -4604,7 +4604,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             map_of_structs: {
               'size' => {
                 value: "small"
@@ -4627,7 +4627,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             recursive_map: {
               'key-1' => {
                 recursive_map: {
@@ -4655,7 +4655,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
 
           })
         end
@@ -4674,7 +4674,7 @@ module RailsJson
 
           })
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
 
           })
         end
@@ -4690,7 +4690,7 @@ module RailsJson
             string: "string-value"
           })
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             string: "string-value"
           })
         end
@@ -4706,7 +4706,7 @@ module RailsJson
             integer: 1234
           })
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             integer: 1234
           })
         end
@@ -4722,7 +4722,7 @@ module RailsJson
             long: 1234567890123456789
           })
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             long: 1234567890123456789
           })
         end
@@ -4738,7 +4738,7 @@ module RailsJson
             float: 1234.5
           })
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             float: 1234.5
           })
         end
@@ -4754,7 +4754,7 @@ module RailsJson
             double: 1.2345678912345679E8
           })
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             double: 1.2345678912345679E8
           })
         end
@@ -4770,7 +4770,7 @@ module RailsJson
             boolean: true
           })
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             boolean: true
           })
         end
@@ -4786,7 +4786,7 @@ module RailsJson
             boolean: false
           })
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             boolean: false
           })
         end
@@ -4802,7 +4802,7 @@ module RailsJson
             blob: 'binary-value'
           })
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             blob: 'binary-value'
           })
         end
@@ -4818,7 +4818,7 @@ module RailsJson
             timestamp: Time.at(946845296)
           })
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             timestamp: Time.at(946845296)
           })
         end
@@ -4834,7 +4834,7 @@ module RailsJson
             iso8601_timestamp: Time.at(946845296)
           })
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             iso8601_timestamp: Time.at(946845296)
           })
         end
@@ -4850,7 +4850,7 @@ module RailsJson
             httpdate_timestamp: Time.at(946845296)
           })
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             httpdate_timestamp: Time.at(946845296)
           })
         end
@@ -4870,7 +4870,7 @@ module RailsJson
             ]
           })
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             list_of_strings: [
               "abc",
               "mno",
@@ -4897,7 +4897,7 @@ module RailsJson
             ]
           })
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             list_of_maps_of_strings: [
               {
                 'size' => "large"
@@ -4931,7 +4931,7 @@ module RailsJson
             ]
           })
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             list_of_lists: [
               [
                 "abc",
@@ -4965,7 +4965,7 @@ module RailsJson
             ]
           })
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             list_of_structs: [
               {
                 value: "value-1"
@@ -5000,7 +5000,7 @@ module RailsJson
             ]
           })
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             recursive_list: [
               {
                 recursive_list: [
@@ -5031,7 +5031,7 @@ module RailsJson
             }
           })
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             map_of_strings: {
               'size' => "large",
               'color' => "red"
@@ -5059,7 +5059,7 @@ module RailsJson
             }
           })
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             map_of_lists_of_strings: {
               'sizes' => [
                 "large",
@@ -5093,7 +5093,7 @@ module RailsJson
             }
           })
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             map_of_maps: {
               'sizes' => {
                 'large' => "L",
@@ -5125,7 +5125,7 @@ module RailsJson
             }
           })
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             map_of_structs: {
               'size' => {
                 value: "small"
@@ -5160,7 +5160,7 @@ module RailsJson
             }
           })
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             recursive_map: {
               'key-1' => {
                 recursive_map: {
@@ -5188,7 +5188,7 @@ module RailsJson
 
           })
           output = client.kitchen_sink_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
 
           })
         end
@@ -5231,7 +5231,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.media_type_header({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             json: "true"
           })
         end
@@ -5250,7 +5250,7 @@ module RailsJson
             json: "true"
           })
           output = client.media_type_header({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             json: "true"
           })
         end
@@ -5395,7 +5395,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.null_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
 
           })
         end
@@ -5415,7 +5415,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.null_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             sparse_string_map: {
               'foo' => nil
             }
@@ -5437,7 +5437,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.null_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             sparse_string_list: [
               nil
             ]
@@ -5458,7 +5458,7 @@ module RailsJson
 
           })
           output = client.null_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
 
           })
         end
@@ -5476,7 +5476,7 @@ module RailsJson
             }
           })
           output = client.null_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             sparse_string_map: {
               'foo' => nil
             }
@@ -5496,7 +5496,7 @@ module RailsJson
             ]
           })
           output = client.null_operation({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             sparse_string_list: [
               nil
             ]
@@ -5717,7 +5717,7 @@ module RailsJson
           end
           middleware.remove_send.remove_build
           output = client.timestamp_format_headers({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             member_epoch_seconds: Time.at(1576540098),
             member_http_date: Time.at(1576540098),
             member_date_time: Time.at(1576540098),
@@ -5748,7 +5748,7 @@ module RailsJson
             target_date_time: Time.at(1576540098)
           })
           output = client.timestamp_format_headers({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             member_epoch_seconds: Time.at(1576540098),
             member_http_date: Time.at(1576540098),
             member_date_time: Time.at(1576540098),

--- a/codegen/projections/weather/lib/weather/client.rb
+++ b/codegen/projections/weather/lib/weather/client.rb
@@ -73,16 +73,16 @@ module Weather
     #
     # @example Response structure
     #
-    #   resp #=> Types::GetCityOutput
-    #   resp.member_name #=> String
-    #   resp.coordinates #=> Types::CityCoordinates
-    #   resp.coordinates.latitude #=> Float
-    #   resp.coordinates.longitude #=> Float
-    #   resp.city #=> Types::CitySummary
-    #   resp.city.city_id #=> String
-    #   resp.city.member_name #=> String
-    #   resp.city.number #=> String
-    #   resp.city.case #=> String
+    #   resp.data #=> Types::GetCityOutput
+    #   resp.data.member_name #=> String
+    #   resp.data.coordinates #=> Types::CityCoordinates
+    #   resp.data.coordinates.latitude #=> Float
+    #   resp.data.coordinates.longitude #=> Float
+    #   resp.data.city #=> Types::CitySummary
+    #   resp.data.city.city_id #=> String
+    #   resp.data.city.member_name #=> String
+    #   resp.data.city.number #=> String
+    #   resp.data.city.case #=> String
     #
     def get_city(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -120,7 +120,7 @@ module Weather
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # @param [Hash] params
@@ -136,9 +136,9 @@ module Weather
     #
     # @example Response structure
     #
-    #   resp #=> Types::GetCityAnnouncementsOutput
-    #   resp.last_updated #=> Time
-    #   resp.announcements #=> Announcements
+    #   resp.data #=> Types::GetCityAnnouncementsOutput
+    #   resp.data.last_updated #=> Time
+    #   resp.data.announcements #=> Announcements
     #
     def get_city_announcements(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -176,7 +176,7 @@ module Weather
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # @param [Hash] params
@@ -200,8 +200,8 @@ module Weather
     #
     # @example Response structure
     #
-    #   resp #=> Types::GetCityImageOutput
-    #   resp.image #=> String
+    #   resp.data #=> Types::GetCityImageOutput
+    #   resp.data.image #=> String
     #
     def get_city_image(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -239,7 +239,7 @@ module Weather
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # @param [Hash] params
@@ -253,8 +253,8 @@ module Weather
     #
     # @example Response structure
     #
-    #   resp #=> Types::GetCurrentTimeOutput
-    #   resp.time #=> Time
+    #   resp.data #=> Types::GetCurrentTimeOutput
+    #   resp.data.time #=> Time
     #
     def get_current_time(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -292,7 +292,7 @@ module Weather
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # @param [Hash] params
@@ -308,9 +308,9 @@ module Weather
     #
     # @example Response structure
     #
-    #   resp #=> Types::GetForecastOutput
-    #   resp.chance_of_rain #=> Float
-    #   resp.precipitation #=> Precipitation
+    #   resp.data #=> Types::GetForecastOutput
+    #   resp.data.chance_of_rain #=> Float
+    #   resp.data.precipitation #=> Precipitation
     #
     def get_forecast(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -348,7 +348,7 @@ module Weather
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # @param [Hash] params
@@ -371,21 +371,21 @@ module Weather
     #
     # @example Response structure
     #
-    #   resp #=> Types::ListCitiesOutput
-    #   resp.next_token #=> String
-    #   resp.some_enum #=> String, one of YES, NO
-    #   resp.a_string #=> String
-    #   resp.default_bool #=> Boolean
-    #   resp.boxed_bool #=> Boolean
-    #   resp.default_number #=> Integer
-    #   resp.boxed_number #=> Integer
-    #   resp.items #=> Array<CitySummary>
-    #   resp.items[0] #=> Types::CitySummary
-    #   resp.items[0].city_id #=> String
-    #   resp.items[0].member_name #=> String
-    #   resp.items[0].number #=> String
-    #   resp.items[0].case #=> String
-    #   resp.sparse_items #=> Array<CitySummary>
+    #   resp.data #=> Types::ListCitiesOutput
+    #   resp.data.next_token #=> String
+    #   resp.data.some_enum #=> String, one of YES, NO
+    #   resp.data.a_string #=> String
+    #   resp.data.default_bool #=> Boolean
+    #   resp.data.boxed_bool #=> Boolean
+    #   resp.data.default_number #=> Integer
+    #   resp.data.boxed_number #=> Integer
+    #   resp.data.items #=> Array<CitySummary>
+    #   resp.data.items[0] #=> Types::CitySummary
+    #   resp.data.items[0].city_id #=> String
+    #   resp.data.items[0].member_name #=> String
+    #   resp.data.items[0].number #=> String
+    #   resp.data.items[0].case #=> String
+    #   resp.data.sparse_items #=> Array<CitySummary>
     #
     def list_cities(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -423,7 +423,7 @@ module Weather
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # @param [Hash] params
@@ -442,10 +442,10 @@ module Weather
     #
     # @example Response structure
     #
-    #   resp #=> Types::Struct____789BadNameOutput
-    #   resp.member____123abc #=> String
-    #   resp.member #=> Types::Struct____456efg
-    #   resp.member.member____123foo #=> String
+    #   resp.data #=> Types::Struct____789BadNameOutput
+    #   resp.data.member____123abc #=> String
+    #   resp.data.member #=> Types::Struct____456efg
+    #   resp.data.member.member____123foo #=> String
     #
     def operation____789_bad_name(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -483,7 +483,7 @@ module Weather
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     private

--- a/codegen/projections/weather/lib/weather/client.rb
+++ b/codegen/projections/weather/lib/weather/client.rb
@@ -97,7 +97,7 @@ module Weather
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: [Errors::NoSuchResource]),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: [Errors::NoSuchResource]),
         data_parser: Parsers::GetCity
       )
       stack.use(Hearth::Middleware::Send,
@@ -153,7 +153,7 @@ module Weather
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: [Errors::NoSuchResource]),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: [Errors::NoSuchResource]),
         data_parser: Parsers::GetCityAnnouncements
       )
       stack.use(Hearth::Middleware::Send,
@@ -216,7 +216,7 @@ module Weather
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: [Errors::NoSuchResource]),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: [Errors::NoSuchResource]),
         data_parser: Parsers::GetCityImage
       )
       stack.use(Hearth::Middleware::Send,
@@ -269,7 +269,7 @@ module Weather
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::GetCurrentTime
       )
       stack.use(Hearth::Middleware::Send,
@@ -325,7 +325,7 @@ module Weather
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::GetForecast
       )
       stack.use(Hearth::Middleware::Send,
@@ -400,7 +400,7 @@ module Weather
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::ListCities
       )
       stack.use(Hearth::Middleware::Send,
@@ -460,7 +460,7 @@ module Weather
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: [Errors::NoSuchResource]),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: [Errors::NoSuchResource]),
         data_parser: Parsers::Operation____789BadName
       )
       stack.use(Hearth::Middleware::Send,

--- a/codegen/projections/weather/lib/weather/errors.rb
+++ b/codegen/projections/weather/lib/weather/errors.rb
@@ -9,21 +9,12 @@
 
 module Weather
   module Errors
-
     def self.error_code(http_resp)
       http_resp.headers['x-smithy-error']
     end
 
     # Base class for all errors returned by this service
-    class ApiError < Hearth::HTTP::ApiError
-      def initialize(request_id: nil, **kwargs)
-        @request_id = request_id
-        super(**kwargs)
-      end
-
-      # @return [String, nil] request_id
-      attr_reader :request_id
-    end
+    class ApiError < Hearth::HTTP::ApiError; end
 
     # Base class for all errors returned where the client is at fault.
     # These are generally errors with 4XX HTTP status codes.
@@ -54,7 +45,6 @@ module Weather
       #
       def initialize(http_resp:, **kwargs)
         @data = Parsers::NoSuchResource.parse(http_resp)
-        kwargs[:request_id] = http_resp.headers['x-request-id']
         kwargs[:message] = @data.message if @data.respond_to?(:message)
 
         super(http_resp: http_resp, **kwargs)

--- a/codegen/projections/weather/lib/weather/errors.rb
+++ b/codegen/projections/weather/lib/weather/errors.rb
@@ -15,7 +15,15 @@ module Weather
     end
 
     # Base class for all errors returned by this service
-    class ApiError < Hearth::HTTP::ApiError; end
+    class ApiError < Hearth::HTTP::ApiError
+      def initialize(request_id: nil, **kwargs)
+        @request_id = request_id
+        super(**kwargs)
+      end
+
+      # @return [String, nil] request_id
+      attr_reader :request_id
+    end
 
     # Base class for all errors returned where the client is at fault.
     # These are generally errors with 4XX HTTP status codes.
@@ -46,6 +54,7 @@ module Weather
       #
       def initialize(http_resp:, **kwargs)
         @data = Parsers::NoSuchResource.parse(http_resp)
+        kwargs[:request_id] = http_resp.headers['x-request-id']
         kwargs[:message] = @data.message if @data.respond_to?(:message)
 
         super(http_resp: http_resp, **kwargs)

--- a/codegen/projections/weather/sig/weather/errors.rbs
+++ b/codegen/projections/weather/sig/weather/errors.rbs
@@ -13,6 +13,9 @@ module Weather
     def self.error_code: (untyped http_resp) -> untyped
 
     class ApiError < Hearth::HTTP::ApiError
+    def initialize: (request_id: untyped request_id, **untyped kwargs) -> void
+
+    attr_reader request_id: untyped
     end
 
     class ApiClientError < ApiError

--- a/codegen/projections/weather/spec/protocol_spec.rb
+++ b/codegen/projections/weather/spec/protocol_spec.rb
@@ -91,7 +91,7 @@ module Weather
           end
           middleware.remove_send.remove_build
           output = client.get_city({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             member_name: "Seattle",
             coordinates: {
               latitude: 12.34,
@@ -130,7 +130,7 @@ module Weather
             }
           })
           output = client.get_city({}, middleware: middleware)
-          expect(output.to_h).to eq({
+          expect(output.data.to_h).to eq({
             member_name: "Seattle",
             coordinates: {
               latitude: 12.34,

--- a/codegen/projections/white_label/lib/white_label/client.rb
+++ b/codegen/projections/white_label/lib/white_label/client.rb
@@ -147,20 +147,20 @@ module WhiteLabel
     #
     # @example Response structure
     #
-    #   resp #=> Types::KitchenSinkOutput
-    #   resp.string #=> String
-    #   resp.struct #=> Types::Struct
-    #   resp.struct.value #=> String
-    #   resp.document #=> Hash,Array,String,Boolean,Numeric
-    #   resp.list_of_strings #=> Array<String>
-    #   resp.list_of_strings[0] #=> String
-    #   resp.list_of_structs #=> Array<Struct>
-    #   resp.map_of_strings #=> Hash<String, String>
-    #   resp.map_of_strings['key'] #=> String
-    #   resp.map_of_structs #=> Hash<String, Struct>
-    #   resp.set_of_strings #=> Set<String>
-    #   resp.set_of_strings[0] #=> String
-    #   resp.union #=> Union
+    #   resp.data #=> Types::KitchenSinkOutput
+    #   resp.data.string #=> String
+    #   resp.data.struct #=> Types::Struct
+    #   resp.data.struct.value #=> String
+    #   resp.data.document #=> Hash,Array,String,Boolean,Numeric
+    #   resp.data.list_of_strings #=> Array<String>
+    #   resp.data.list_of_strings[0] #=> String
+    #   resp.data.list_of_structs #=> Array<Struct>
+    #   resp.data.map_of_strings #=> Hash<String, String>
+    #   resp.data.map_of_strings['key'] #=> String
+    #   resp.data.map_of_structs #=> Hash<String, Struct>
+    #   resp.data.set_of_strings #=> Set<String>
+    #   resp.data.set_of_strings[0] #=> String
+    #   resp.data.union #=> Union
     #
     # @example Test input and output
     #
@@ -303,7 +303,7 @@ module WhiteLabel
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # @param [Hash] params
@@ -319,10 +319,10 @@ module WhiteLabel
     #
     # @example Response structure
     #
-    #   resp #=> Types::PaginatorsTestOperationOutput
-    #   resp.next_token #=> String
-    #   resp.items #=> Array<String>
-    #   resp.items[0] #=> String
+    #   resp.data #=> Types::PaginatorsTestOperationOutput
+    #   resp.data.next_token #=> String
+    #   resp.data.items #=> Array<String>
+    #   resp.data.items[0] #=> String
     #
     def paginators_test(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -360,7 +360,7 @@ module WhiteLabel
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # @param [Hash] params
@@ -376,10 +376,10 @@ module WhiteLabel
     #
     # @example Response structure
     #
-    #   resp #=> Types::PaginatorsTestWithItemsOutput
-    #   resp.next_token #=> String
-    #   resp.items #=> Array<String>
-    #   resp.items[0] #=> String
+    #   resp.data #=> Types::PaginatorsTestWithItemsOutput
+    #   resp.data.next_token #=> String
+    #   resp.data.items #=> Array<String>
+    #   resp.data.items[0] #=> String
     #
     def paginators_test_with_items(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -417,7 +417,7 @@ module WhiteLabel
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # @param [Hash] params
@@ -433,8 +433,8 @@ module WhiteLabel
     #
     # @example Response structure
     #
-    #   resp #=> Types::WaitersTestOutput
-    #   resp.status #=> String
+    #   resp.data #=> Types::WaitersTestOutput
+    #   resp.data.status #=> String
     #
     def waiters_test(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -472,7 +472,7 @@ module WhiteLabel
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     # @param [Hash] params
@@ -488,11 +488,11 @@ module WhiteLabel
     #
     # @example Response structure
     #
-    #   resp #=> Types::Struct____PaginatorsTestWithBadNamesOutput
-    #   resp.member____wrapper #=> Types::ResultWrapper
-    #   resp.member____wrapper.member____123next_token #=> String
-    #   resp.member____items #=> Array<String>
-    #   resp.member____items[0] #=> String
+    #   resp.data #=> Types::Struct____PaginatorsTestWithBadNamesOutput
+    #   resp.data.member____wrapper #=> Types::ResultWrapper
+    #   resp.data.member____wrapper.member____123next_token #=> String
+    #   resp.data.member____items #=> Array<String>
+    #   resp.data.member____items[0] #=> String
     #
     def operation____paginators_test_with_bad_names(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -530,7 +530,7 @@ module WhiteLabel
         )
       )
       raise resp.error if resp.error
-      resp.data
+      resp
     end
 
     private

--- a/codegen/projections/white_label/lib/white_label/client.rb
+++ b/codegen/projections/white_label/lib/white_label/client.rb
@@ -280,7 +280,7 @@ module WhiteLabel
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: [Errors::ClientError, Errors::ServerError]),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: [Errors::ClientError, Errors::ServerError]),
         data_parser: Parsers::KitchenSink
       )
       stack.use(Hearth::Middleware::Send,
@@ -337,7 +337,7 @@ module WhiteLabel
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::PaginatorsTest
       )
       stack.use(Hearth::Middleware::Send,
@@ -394,7 +394,7 @@ module WhiteLabel
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::PaginatorsTestWithItems
       )
       stack.use(Hearth::Middleware::Send,
@@ -449,7 +449,7 @@ module WhiteLabel
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::WaitersTest
       )
       stack.use(Hearth::Middleware::Send,
@@ -507,7 +507,7 @@ module WhiteLabel
       )
       stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, error_code_fn: Errors.method(:error_code), success_status: 200, errors: []),
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::Operation____PaginatorsTestWithBadNames
       )
       stack.use(Hearth::Middleware::Send,

--- a/codegen/projections/white_label/lib/white_label/errors.rb
+++ b/codegen/projections/white_label/lib/white_label/errors.rb
@@ -9,21 +9,12 @@
 
 module WhiteLabel
   module Errors
-
     def self.error_code(http_resp)
       http_resp.headers['x-smithy-error']
     end
 
     # Base class for all errors returned by this service
-    class ApiError < Hearth::HTTP::ApiError
-      def initialize(request_id: nil, **kwargs)
-        @request_id = request_id
-        super(**kwargs)
-      end
-
-      # @return [String, nil] request_id
-      attr_reader :request_id
-    end
+    class ApiError < Hearth::HTTP::ApiError; end
 
     # Base class for all errors returned where the client is at fault.
     # These are generally errors with 4XX HTTP status codes.
@@ -54,7 +45,6 @@ module WhiteLabel
       #
       def initialize(http_resp:, **kwargs)
         @data = Parsers::ClientError.parse(http_resp)
-        kwargs[:request_id] = http_resp.headers['x-request-id']
         kwargs[:message] = @data.message if @data.respond_to?(:message)
 
         super(http_resp: http_resp, **kwargs)
@@ -74,7 +64,6 @@ module WhiteLabel
       #
       def initialize(http_resp:, **kwargs)
         @data = Parsers::ServerError.parse(http_resp)
-        kwargs[:request_id] = http_resp.headers['x-request-id']
         kwargs[:message] = @data.message if @data.respond_to?(:message)
 
         super(http_resp: http_resp, **kwargs)

--- a/codegen/projections/white_label/lib/white_label/errors.rb
+++ b/codegen/projections/white_label/lib/white_label/errors.rb
@@ -15,7 +15,15 @@ module WhiteLabel
     end
 
     # Base class for all errors returned by this service
-    class ApiError < Hearth::HTTP::ApiError; end
+    class ApiError < Hearth::HTTP::ApiError
+      def initialize(request_id: nil, **kwargs)
+        @request_id = request_id
+        super(**kwargs)
+      end
+
+      # @return [String, nil] request_id
+      attr_reader :request_id
+    end
 
     # Base class for all errors returned where the client is at fault.
     # These are generally errors with 4XX HTTP status codes.
@@ -46,6 +54,7 @@ module WhiteLabel
       #
       def initialize(http_resp:, **kwargs)
         @data = Parsers::ClientError.parse(http_resp)
+        kwargs[:request_id] = http_resp.headers['x-request-id']
         kwargs[:message] = @data.message if @data.respond_to?(:message)
 
         super(http_resp: http_resp, **kwargs)
@@ -65,6 +74,7 @@ module WhiteLabel
       #
       def initialize(http_resp:, **kwargs)
         @data = Parsers::ServerError.parse(http_resp)
+        kwargs[:request_id] = http_resp.headers['x-request-id']
         kwargs[:message] = @data.message if @data.respond_to?(:message)
 
         super(http_resp: http_resp, **kwargs)

--- a/codegen/projections/white_label/sig/white_label/errors.rbs
+++ b/codegen/projections/white_label/sig/white_label/errors.rbs
@@ -13,6 +13,9 @@ module WhiteLabel
     def self.error_code: (untyped http_resp) -> untyped
 
     class ApiError < Hearth::HTTP::ApiError
+    def initialize: (request_id: untyped request_id, **untyped kwargs) -> void
+
+    attr_reader request_id: untyped
     end
 
     class ApiClientError < ApiError

--- a/codegen/smithy-ruby-codegen-test/integration-specs/errors_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/errors_spec.rb
@@ -10,6 +10,17 @@ module WhiteLabel
         error = ApiError.new(http_resp: http_resp, error_code: 'error')
         expect(error).to be_a(Hearth::HTTP::ApiError)
       end
+
+      it 'stores a request_id' do
+        http_resp = Hearth::HTTP::Response.new
+        error = ApiError.new(
+          http_resp: http_resp,
+          request_id: '123',
+          error_code: 'error',
+          message: 'error message'
+        )
+        expect(error.request_id).to eq('123')
+      end
     end
 
     describe ApiClientError do

--- a/codegen/smithy-ruby-codegen-test/integration-specs/errors_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/errors_spec.rb
@@ -7,26 +7,15 @@ module WhiteLabel
     describe ApiError do
       it 'inherits the base protocol api error' do
         http_resp = Hearth::HTTP::Response.new
-        error = ApiError.new(http_resp: http_resp, error_code: 'error')
+        error = ApiError.new(http_resp: http_resp, metadata: {}, error_code: 'error')
         expect(error).to be_a(Hearth::HTTP::ApiError)
-      end
-
-      it 'stores a request_id' do
-        http_resp = Hearth::HTTP::Response.new
-        error = ApiError.new(
-          http_resp: http_resp,
-          request_id: '123',
-          error_code: 'error',
-          message: 'error message'
-        )
-        expect(error.request_id).to eq('123')
       end
     end
 
     describe ApiClientError do
       it 'inherits the base client api error' do
         http_resp = Hearth::HTTP::Response.new
-        error = ApiClientError.new(http_resp: http_resp, error_code: 'error')
+        error = ApiClientError.new(http_resp: http_resp, metadata: {}, error_code: 'error')
         expect(error).to be_a(ApiError)
       end
     end
@@ -34,7 +23,7 @@ module WhiteLabel
     describe ApiServerError do
       it 'inherits the base client api error' do
         http_resp = Hearth::HTTP::Response.new
-        error = ApiServerError.new(http_resp: http_resp, error_code: 'error')
+        error = ApiServerError.new(http_resp: http_resp, metadata: {}, error_code: 'error')
         expect(error).to be_a(ApiError)
       end
     end
@@ -42,7 +31,12 @@ module WhiteLabel
     describe ApiRedirectError do
       it 'inherits the base client api error' do
         http_resp = Hearth::HTTP::Response.new
-        error = ApiRedirectError.new(location: nil, http_resp: http_resp, error_code: 'error')
+        error = ApiRedirectError.new(
+          location: nil,
+          http_resp: http_resp,
+          metadata: {},
+          error_code: 'error'
+        )
         expect(error).to be_a(ApiError)
       end
 
@@ -52,6 +46,7 @@ module WhiteLabel
           http_resp: http_resp,
           location: 'location',
           error_code: 'error',
+          metadata: {},
           message: 'error message'
         )
         expect(error.location).to eq('location')
@@ -64,7 +59,7 @@ module WhiteLabel
         data = Types::ClientError.new(message: 'error message')
         # don't test fakeProtocol parsers
         expect(Parsers::ClientError).to receive(:parse).with(http_resp).and_return(data)
-        error = ClientError.new(http_resp: http_resp, error_code: 'error')
+        error = ClientError.new(http_resp: http_resp, metadata: {}, error_code: 'error')
         expect(error.data).to eq(data)
         expect(error).to be_a(ApiClientError)
         expect(error.message).to eq('error message')
@@ -77,7 +72,7 @@ module WhiteLabel
         data = Types::ServerError.new
         # don't test fakeProtocol parsers
         expect(Parsers::ServerError).to receive(:parse).with(http_resp).and_return(data)
-        error = ServerError.new(http_resp: http_resp, error_code: 'error')
+        error = ServerError.new(http_resp: http_resp, metadata: {}, error_code: 'error')
         expect(error.data).to eq(data)
         expect(error).to be_a(ApiServerError)
         expect(error.message).to eq("WhiteLabel::Errors::ServerError")

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/ApplicationTransport.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/ApplicationTransport.java
@@ -126,7 +126,7 @@ public final class ApplicationTransport {
             List<Middleware> middleware = new ArrayList();
             middleware.add((new Middleware.Builder())
                     .klass("Hearth::HTTP::Middleware::ContentLength")
-                    .step(MiddlewareStackStep.BUILD)
+                    .step(MiddlewareStackStep.SERIALIZE)
                     .build()
             );
 

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/ApplicationTransport.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/ApplicationTransport.java
@@ -126,7 +126,7 @@ public final class ApplicationTransport {
             List<Middleware> middleware = new ArrayList();
             middleware.add((new Middleware.Builder())
                     .klass("Hearth::HTTP::Middleware::ContentLength")
-                    .step(MiddlewareStackStep.SERIALIZE)
+                    .step(MiddlewareStackStep.BUILD)
                     .build()
             );
 

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/ApplicationTransport.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/ApplicationTransport.java
@@ -151,11 +151,8 @@ public final class ApplicationTransport {
                                         Collectors.joining(", "));
                         params.put("error_parser",
                                 "Hearth::HTTP::ErrorParser.new("
-                                        + "error_module: Errors, error_code_fn: "
-                                        + "Errors.method(:error_code), "
-                                        + "success_status: "
-                                        + successCode + ", errors: [" + errors + "]"
-                                        + ")"
+                                        + "error_module: Errors, success_status: " + successCode
+                                        + ", errors: [" + errors + "]" + ")"
                         );
                         return params;
                     })

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ClientGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ClientGenerator.java
@@ -275,7 +275,7 @@ public class ClientGenerator {
                 .closeBlock(")")
                 .closeBlock(")")
                 .write("raise resp.error if resp.error")
-                .write("resp.data")
+                .write("resp")
                 .closeBlock("end");
         LOGGER.finer("Generated client operation method " + operationName);
     }

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ErrorsGeneratorBase.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ErrorsGeneratorBase.java
@@ -70,7 +70,7 @@ public abstract class ErrorsGeneratorBase {
                 .writePreamble()
                 .openBlock("module $L", settings.getModule())
                 .openBlock("module Errors")
-                .openBlock("def self.error_code(http_resp)")
+                .openBlock("def self.error_code(resp)")
                 .call(() -> renderErrorCodeBody())
                 .closeBlock("end")
                 .call(() -> renderBaseErrors())
@@ -147,13 +147,17 @@ public abstract class ErrorsGeneratorBase {
      * Called to render the error_code method body.
      * <p>
      * errors.rb defines a self.error_code(resp) method that should
-     * return the protocol specific error code from the response or nil
-     * if no error code is found.
+     * return the protocol specific error code (as a string) from the
+     * response, or nil if no error code is found. The error code is
+     * used to find and raise a generated error with the same name.
+     *
+     * For example, an error code of 'FooError' will attempt to raise
+     * the Service::Errors::FooError error.
      */
     public abstract void renderErrorCodeBody();
 
     public void renderRbsErrorCode() {
-        rbsWriter.write("def self.error_code: (untyped http_resp) -> untyped");
+        rbsWriter.write("def self.error_code: (untyped resp) -> untyped");
     }
 
     protected List<Shape> getErrorShapes() {

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ErrorsGeneratorBase.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ErrorsGeneratorBase.java
@@ -105,7 +105,15 @@ public abstract class ErrorsGeneratorBase {
     private void renderBaseErrors() {
         writer
                 .write("\n# Base class for all errors returned by this service")
-                .write("class ApiError < Hearth::HTTP::ApiError; end")
+                .openBlock("class ApiError < Hearth::HTTP::ApiError")
+                .openBlock("def initialize(request_id: nil, **kwargs)")
+                .write("@request_id = request_id")
+                .write("super(**kwargs)")
+                .closeBlock("end")
+                .write("")
+                .write("# @return [String, nil] request_id")
+                .write("attr_reader :request_id")
+                .closeBlock("end")
                 .write("\n# Base class for all errors returned where the client is at fault.")
                 .write("# These are generally errors with 4XX HTTP status codes.")
                 .write("class ApiClientError < ApiError; end")
@@ -129,6 +137,8 @@ public abstract class ErrorsGeneratorBase {
     private void renderRbsBaseErrors() {
         rbsWriter
                 .write("\nclass ApiError < Hearth::HTTP::ApiError")
+                .write("def initialize: (request_id: untyped request_id, **untyped kwargs) -> void\n")
+                .write("attr_reader request_id: untyped")
                 .write("end")
                 .write("\nclass ApiClientError < ApiError")
                 .write("end")
@@ -205,6 +215,7 @@ public abstract class ErrorsGeneratorBase {
         writer
                 .openBlock("def initialize(http_resp:, **kwargs)")
                 .write("@data = Parsers::$L.parse(http_resp)", errorName)
+                .write("kwargs[:request_id] = http_resp.headers['x-request-id']")
                 .write("kwargs[:message] = @data.message if @data.respond_to?(:message)\n")
                 .write("super(http_resp: http_resp, **kwargs)")
                 .closeBlock("end")

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/HttpProtocolTestGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/HttpProtocolTestGenerator.java
@@ -125,7 +125,7 @@ public class HttpProtocolTestGenerator {
                     .call(() -> renderResponseMiddleware(testCase))
                     .write("middleware.remove_send.remove_build")
                     .write("output = client.$L({}, middleware: middleware)", operationName)
-                    .write("expect(output.to_h).to eq($L)",
+                    .write("expect(output.data.to_h).to eq($L)",
                             getRubyHashFromParams(outputShape, testCase.getParams()))
                     .closeBlock("end");
             LOGGER.finer(

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/HttpProtocolTestGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/HttpProtocolTestGenerator.java
@@ -157,7 +157,7 @@ public class HttpProtocolTestGenerator {
                             getRubyHashFromParams(outputShape, testCase.getParams()))
                     .write("output = client.$L({}, middleware: middleware)", operationName)
                     // Note: This part is not required, but its an additional check on parsers
-                    .write("expect(output.to_h).to eq($L)",
+                    .write("expect(output.data.to_h).to eq($L)",
                             getRubyHashFromParams(outputShape, testCase.getParams()))
                     .closeBlock("end");
             LOGGER.finer("Generated protocol response stubber test for operation " + operationName + " test: "

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/docs/ResponseExampleGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/docs/ResponseExampleGenerator.java
@@ -55,7 +55,7 @@ public class ResponseExampleGenerator {
     public String generate() {
         Shape operationOutput = model.expectShape(operation.getOutputShape());
 
-        operationOutput.accept(new ResponseMember("resp", visited));
+        operationOutput.accept(new ResponseMember("resp.data", visited));
 
         return writer.toString();
     }

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/middleware/MiddlewareStackStep.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/middleware/MiddlewareStackStep.java
@@ -27,7 +27,7 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
 public enum MiddlewareStackStep {
     INITIALIZE,
     SERIALIZE,
-    VALIDATE,
+    BUILD,
     RETRY,
     FINALIZE,
     DESERIALIZE,
@@ -42,8 +42,8 @@ public enum MiddlewareStackStep {
                 return "Retry";
             case SERIALIZE:
                 return "Serialize";
-            case VALIDATE:
-                return "Validate";
+            case BUILD:
+                return "Build";
             case DESERIALIZE:
                 return "Deserialize";
             case FINALIZE:

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/middleware/MiddlewareStackStep.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/middleware/MiddlewareStackStep.java
@@ -27,7 +27,7 @@ import software.amazon.smithy.utils.SmithyUnstableApi;
 public enum MiddlewareStackStep {
     INITIALIZE,
     SERIALIZE,
-    BUILD,
+    VALIDATE,
     RETRY,
     FINALIZE,
     DESERIALIZE,
@@ -42,8 +42,8 @@ public enum MiddlewareStackStep {
                 return "Retry";
             case SERIALIZE:
                 return "Serialize";
-            case BUILD:
-                return "Build";
+            case VALIDATE:
+                return "Validate";
             case DESERIALIZE:
                 return "Deserialize";
             case FINALIZE:

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/test/protocol/fakeprotocol/generators/ErrorsGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/test/protocol/fakeprotocol/generators/ErrorsGenerator.java
@@ -25,6 +25,6 @@ public class ErrorsGenerator extends ErrorsGeneratorBase {
     }
 
     public void renderErrorCodeBody() {
-        writer.write("http_resp.headers['x-smithy-error']");
+        writer.write("resp.headers['x-smithy-error']");
     }
 }

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/test/protocol/fakeprotocol/generators/ErrorsGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/test/protocol/fakeprotocol/generators/ErrorsGenerator.java
@@ -24,10 +24,7 @@ public class ErrorsGenerator extends ErrorsGeneratorBase {
         super(context);
     }
 
-    public void renderErrorCode() {
-        writer
-                .openBlock("def self.error_code(http_resp)")
-                .write("http_resp.headers['x-smithy-error']")
-                .closeBlock("end");
+    public void renderErrorCodeBody() {
+        writer.write("http_resp.headers['x-smithy-error']");
     }
 }

--- a/codegen/smithy-ruby-rails-codegen-test/integration-specs/request_id_spec.rb
+++ b/codegen/smithy-ruby-rails-codegen-test/integration-specs/request_id_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_json'
+
+module RailsJson
+  describe Client do
+    let(:endpoint) { 'http://127.0.0.1' }
+    let(:client) { Client.new(stub_responses: true, endpoint: endpoint) }
+
+    context 'success' do
+      it 'puts request_id onto output metadata' do
+        middleware = Hearth::MiddlewareBuilder.around_send do |app, input, context|
+          response = context.response
+          response.status = 200
+          response.headers = Hearth::HTTP::Headers.new(headers: { 'x-request-id' => '123' })
+          response.body = StringIO.new('{}')
+          Hearth::Output.new
+        end
+        middleware.remove_send.remove_build
+        output = client.empty_operation({}, middleware: middleware)
+        expect(output.metadata[:request_id]).to eq('123')
+      end
+    end
+
+    context 'error' do
+      it 'puts request_id onto error metadata' do
+        middleware = Hearth::MiddlewareBuilder.around_send do |app, input, context|
+          response = context.response
+          response.status = 400
+          response.headers = Hearth::HTTP::Headers.new(
+            headers: { 'x-smithy-rails-error' => 'InvalidGreeting', 'x-request-id' => '123' }
+          )
+          response.body = StringIO.new('{}')
+          Hearth::Output.new
+        end
+        middleware.remove_send.remove_build
+        begin
+          client.greeting_with_errors({}, middleware: middleware)
+        rescue Errors::InvalidGreeting => e
+          expect(e.metadata[:request_id]).to eq('123')
+        end
+      end
+    end
+
+  end
+end

--- a/codegen/smithy-ruby-rails-codegen-test/integration-specs/stubs_spec.rb
+++ b/codegen/smithy-ruby-rails-codegen-test/integration-specs/stubs_spec.rb
@@ -8,7 +8,7 @@ module RailsJson
       let(:client) { RailsJson::Client.new(stub_responses: true, endpoint: 'https://example.com')}
 
       it 'returns a default with recursive values' do
-        resp = client.kitchen_sink_operation()
+        resp = client.kitchen_sink_operation().data
 
         expect(resp.blob).to eq('blob')
         expect(resp.boolean).to eq(false)
@@ -50,7 +50,7 @@ module RailsJson
                                 recursive_map: { 'test_key' => { blob: 'blob 2' } }
                               }
         )
-        resp = client.kitchen_sink_operation()
+        resp = client.kitchen_sink_operation().data
 
         expect(resp.blob).to eq('my blob')
         expect(resp.boolean).to eq(true)
@@ -61,7 +61,7 @@ module RailsJson
 
       it 'stubs an empty body when given nil' do
         client.stub_responses(:kitchen_sink_operation, { })
-        resp = client.kitchen_sink_operation()
+        resp = client.kitchen_sink_operation().data
 
         expect(resp.blob).to be_nil
         expect(resp.boolean).to be_nil

--- a/codegen/smithy-ruby-rails-codegen-test/integration-specs/stubs_spec.rb
+++ b/codegen/smithy-ruby-rails-codegen-test/integration-specs/stubs_spec.rb
@@ -8,65 +8,67 @@ module RailsJson
       let(:client) { RailsJson::Client.new(stub_responses: true, endpoint: 'https://example.com')}
 
       it 'returns a default with recursive values' do
-        resp = client.kitchen_sink_operation().data
+        resp = client.kitchen_sink_operation()
 
-        expect(resp.blob).to eq('blob')
-        expect(resp.boolean).to eq(false)
-        expect(resp.double).to eq(1.0)
-        expect(resp.empty_struct.to_h).to eq({})
+        expect(resp.data.blob).to eq('blob')
+        expect(resp.data.boolean).to eq(false)
+        expect(resp.data.double).to eq(1.0)
+        expect(resp.data.empty_struct.to_h).to eq({})
 
-        expect(resp.httpdate_timestamp).to be_within(1).of(Time.now)
-        expect(resp.iso8601_timestamp).to be_within(1).of(Time.now)
-        expect(resp.timestamp).to be_within(1).of(Time.now)
-        expect(resp.unix_timestamp).to be_within(1).of(Time.now)
+        expect(resp.data.httpdate_timestamp).to be_within(1).of(Time.now)
+        expect(resp.data.iso8601_timestamp).to be_within(1).of(Time.now)
+        expect(resp.data.timestamp).to be_within(1).of(Time.now)
+        expect(resp.data.unix_timestamp).to be_within(1).of(Time.now)
 
-        expect(resp.json_value).to eq('json_value')
-        expect(resp.list_of_lists).to eq([["member"]])
-        expect(resp.list_of_maps_of_strings).to eq([{"test_key"=>"value"}])
-        expect(resp.to_h[:map_of_structs]).to eq({"test_key"=>{value: "value"}})
+        expect(resp.data.json_value).to eq('json_value')
+        expect(resp.data.list_of_lists).to eq([["member"]])
+        expect(resp.data.list_of_maps_of_strings).to eq([{"test_key"=>"value"}])
+        expect(resp.data.to_h[:map_of_structs]).to eq({"test_key"=>{value: "value"}})
 
-        expect(resp.simple_struct).to be_a(Types::SimpleStruct)
-        expect(resp.simple_struct.value).to eq('value')
+        expect(resp.data.simple_struct).to be_a(Types::SimpleStruct)
+        expect(resp.data.simple_struct.value).to eq('value')
 
-        expect(resp.recursive_struct).to be_a(Types::KitchenSink)
-        expect(resp.recursive_struct.blob).to eq('blob')
-        expect(resp.recursive_struct.recursive_struct).to be_nil
+        expect(resp.data.recursive_struct).to be_a(Types::KitchenSink)
+        expect(resp.data.recursive_struct.blob).to eq('blob')
+        expect(resp.data.recursive_struct.recursive_struct).to be_nil
 
-        expect(resp.recursive_map["test_key"]).to be_a(Types::KitchenSink)
-        expect(resp.recursive_map["test_key"].blob).to eq('blob')
-        expect(resp.recursive_map["test_key"].recursive_struct).to be_nil
+        expect(resp.data.recursive_map["test_key"]).to be_a(Types::KitchenSink)
+        expect(resp.data.recursive_map["test_key"].blob).to eq('blob')
+        expect(resp.data.recursive_map["test_key"].recursive_struct).to be_nil
 
-        expect(resp.struct_with_location_name).to be_a(Types::StructWithLocationName)
-        expect(resp.struct_with_location_name.value).to eq('value')
+        expect(resp.data.struct_with_location_name).to be_a(Types::StructWithLocationName)
+        expect(resp.data.struct_with_location_name.value).to eq('value')
       end
 
       it 'returns the stubbed values' do
         t = Time.now.utc
-        client.stub_responses(:kitchen_sink_operation,
-                              { blob: 'my blob',
-                                boolean: true,
-                                timestamp: t,
-                                simple_struct: {value: 'my value'},
-                                recursive_map: { 'test_key' => { blob: 'blob 2' } }
-                              }
+        client.stub_responses(
+          :kitchen_sink_operation,
+          {
+            blob: 'my blob',
+            boolean: true,
+            timestamp: t,
+            simple_struct: {value: 'my value'},
+            recursive_map: { 'test_key' => { blob: 'blob 2' } }
+          }
         )
-        resp = client.kitchen_sink_operation().data
+        resp = client.kitchen_sink_operation()
 
-        expect(resp.blob).to eq('my blob')
-        expect(resp.boolean).to eq(true)
-        expect(resp.timestamp).to be_within(1).of(t)
-        expect(resp.simple_struct.to_h).to eq({value: 'my value'})
-        expect(resp.to_h[:recursive_map]).to eq({ 'test_key' => { blob: 'blob 2' } })
+        expect(resp.data.blob).to eq('my blob')
+        expect(resp.data.boolean).to eq(true)
+        expect(resp.data.timestamp).to be_within(1).of(t)
+        expect(resp.data.simple_struct.to_h).to eq({value: 'my value'})
+        expect(resp.data.to_h[:recursive_map]).to eq({ 'test_key' => { blob: 'blob 2' } })
       end
 
       it 'stubs an empty body when given nil' do
-        client.stub_responses(:kitchen_sink_operation, { })
-        resp = client.kitchen_sink_operation().data
+        client.stub_responses(:kitchen_sink_operation, {})
+        resp = client.kitchen_sink_operation()
 
-        expect(resp.blob).to be_nil
-        expect(resp.boolean).to be_nil
-        expect(resp.simple_struct).to be_nil
-        expect(resp.recursive_map).to be_nil
+        expect(resp.data.blob).to be_nil
+        expect(resp.data.boolean).to be_nil
+        expect(resp.data.simple_struct).to be_nil
+        expect(resp.data.recursive_map).to be_nil
       end
     end
   end

--- a/codegen/smithy-ruby-rails-codegen/middleware/request_id.rb
+++ b/codegen/smithy-ruby-rails-codegen/middleware/request_id.rb
@@ -1,14 +1,16 @@
-# A middleware that extracts a request id from a response and sets it
-# on the context.
-# @api private
-class RequestId
-  def initialize(app)
-    @app = app
-  end
+module Middleware
+  # A middleware that extracts a request id from a response and sets it
+  # on the context.
+  # @api private
+  class RequestId
+    def initialize(app)
+      @app = app
+    end
 
-  def call(input, context)
-    output = @app.call(input, context)
-    output.metadata[:request_id] = context.response.headers['x-request-id']
-    output
+    def call(input, context)
+      output = @app.call(input, context)
+      output.metadata[:request_id] = context.response.headers['x-request-id']
+      output
+    end
   end
 end

--- a/codegen/smithy-ruby-rails-codegen/middleware/request_id.rb
+++ b/codegen/smithy-ruby-rails-codegen/middleware/request_id.rb
@@ -3,7 +3,7 @@ module Middleware
   # on the context.
   # @api private
   class RequestId
-    def initialize(app)
+    def initialize(app, _ = {})
       @app = app
     end
 

--- a/codegen/smithy-ruby-rails-codegen/middleware/request_id.rb
+++ b/codegen/smithy-ruby-rails-codegen/middleware/request_id.rb
@@ -1,0 +1,14 @@
+# A middleware that extracts a request id from a response and sets it
+# on the context.
+# @api private
+class RequestId
+  def initialize(app)
+    @app = app
+  end
+
+  def call(input, context)
+    output = @app.call(input, context)
+    output.metadata[:request_id] = context.response.headers['x-request-id']
+    output
+  end
+end

--- a/codegen/smithy-ruby-rails-codegen/middleware/request_id.rb
+++ b/codegen/smithy-ruby-rails-codegen/middleware/request_id.rb
@@ -1,6 +1,6 @@
 module Middleware
   # A middleware that extracts a request id from a response and sets it
-  # on the context.
+  # on output's metadata.
   # @api private
   class RequestId
     def initialize(app, _ = {})

--- a/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/integrations/RailsIntegration.java
+++ b/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/integrations/RailsIntegration.java
@@ -17,8 +17,12 @@ package software.amazon.smithy.ruby.codegen.integrations;
 
 import java.util.Arrays;
 import java.util.List;
+import software.amazon.smithy.ruby.codegen.GenerationContext;
 import software.amazon.smithy.ruby.codegen.ProtocolGenerator;
 import software.amazon.smithy.ruby.codegen.RubyIntegration;
+import software.amazon.smithy.ruby.codegen.middleware.Middleware;
+import software.amazon.smithy.ruby.codegen.middleware.MiddlewareBuilder;
+import software.amazon.smithy.ruby.codegen.middleware.MiddlewareStackStep;
 import software.amazon.smithy.ruby.codegen.protocol.railsjson.RailsJsonGenerator;
 
 // Provide support for generating SDKs for Rails (RailsJson)
@@ -27,5 +31,17 @@ public class RailsIntegration implements RubyIntegration {
     @Override
     public List<ProtocolGenerator> getProtocolGenerators() {
         return Arrays.asList(new RailsJsonGenerator());
+    }
+
+    @Override
+    public void modifyClientMiddleware(MiddlewareBuilder middlewareBuilder, GenerationContext context) {
+        System.out.println("Working Directory = " + System.getProperty("user.dir"));
+
+        Middleware requestId = (new Middleware.Builder())
+                .klass("Middleware::RequestId")
+                .step(MiddlewareStackStep.DESERIALIZE)
+                .rubySource("smithy-ruby-rails-codegen/middleware/request_id.rb")
+                .build();
+        middlewareBuilder.register(requestId);
     }
 }

--- a/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/integrations/RailsIntegration.java
+++ b/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/integrations/RailsIntegration.java
@@ -35,8 +35,6 @@ public class RailsIntegration implements RubyIntegration {
 
     @Override
     public void modifyClientMiddleware(MiddlewareBuilder middlewareBuilder, GenerationContext context) {
-        System.out.println("Working Directory = " + System.getProperty("user.dir"));
-
         Middleware requestId = (new Middleware.Builder())
                 .klass("Middleware::RequestId")
                 .step(MiddlewareStackStep.DESERIALIZE)

--- a/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/protocol/railsjson/generators/ErrorsGenerator.java
+++ b/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/protocol/railsjson/generators/ErrorsGenerator.java
@@ -25,19 +25,15 @@ public class ErrorsGenerator extends ErrorsGeneratorBase {
         super(context);
     }
 
-    public void renderErrorCode() {
+    public void renderErrorCodeBody() {
         RailsJsonTrait railsJsonTrait = context.service().getTrait(RailsJsonTrait.class).get();
         String errorLocation = railsJsonTrait.getErrorLocation().orElse("status_code");
-
-        writer.openBlock("def self.error_code(http_resp)");
 
         if (errorLocation.equals("header")) {
             renderErrorCodeFromHeader();
         } else if (errorLocation.equals("status_code")) {
             renderErrorCodeFromStatusCode();
         }
-
-        writer.closeBlock("end");
     }
 
     private void renderErrorCodeFromHeader() {

--- a/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/protocol/railsjson/generators/ErrorsGenerator.java
+++ b/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/protocol/railsjson/generators/ErrorsGenerator.java
@@ -37,13 +37,13 @@ public class ErrorsGenerator extends ErrorsGeneratorBase {
     }
 
     private void renderErrorCodeFromHeader() {
-        writer.write("http_resp.headers['x-smithy-rails-error']");
+        writer.write("resp.headers['x-smithy-rails-error']");
     }
 
     // See https://github.com/rails/rails/blob/2dfd4fcd73ae7c4b40114f2447c7ef9d4c0790b4/guides/source/layouts_and_rendering.md?plain=1#L363-L408
     private void renderErrorCodeFromStatusCode() {
         writer
-                .write("case http_resp.status")
+                .write("case resp.status")
                 // 3xx errors
                 .write("when 300 then 'MultipleChoicesError'")
                 .write("when 301 then 'MovedPermanentlyError'")

--- a/hearth/lib/hearth/api_error.rb
+++ b/hearth/lib/hearth/api_error.rb
@@ -4,12 +4,16 @@ module Hearth
   # Base class for errors returned from an API. This excludes networking
   # errors and errors generated on the client-side.
   class ApiError < StandardError
-    def initialize(error_code:, message: nil)
+    def initialize(error_code:, metadata:, message: nil)
       @error_code = error_code
+      @metadata = metadata
       super(message)
     end
 
     # @return [String]
     attr_reader :error_code
+
+    # @return [Hash]
+    attr_reader :metadata
   end
 end

--- a/hearth/lib/hearth/http/api_error.rb
+++ b/hearth/lib/hearth/http/api_error.rb
@@ -9,7 +9,6 @@ module Hearth
         @http_status = http_resp.status
         @http_headers = http_resp.headers
         @http_body = http_resp.body
-        @request_id = http_resp.headers['x-request-id']
         super(**kwargs)
       end
 
@@ -21,9 +20,6 @@ module Hearth
 
       # @return [String]
       attr_reader :http_body
-
-      # @return [String]
-      attr_reader :request_id
     end
   end
 end

--- a/hearth/lib/hearth/http/error_parser.rb
+++ b/hearth/lib/hearth/http/error_parser.rb
@@ -19,7 +19,8 @@ module Hearth
 
       # @param [Module] error_module The code generated Errors module.
       #   Must contain service specific implementations of
-      #   ApiRedirectError, ApiClientError, and ApiServerError
+      #   ApiRedirectError, ApiClientError, and ApiServerError, and it
+      #   must have defined a `self.error_code(http_resp)` method.
       #
       # @param [Integer] success_status The status code of a
       #   successful response as defined by the model for
@@ -39,6 +40,7 @@ module Hearth
       # Parse and return the error if the response is not successful.
       #
       # @param [Response] response The HTTP response
+      # @param [Hash] metadata The metadata from {Hearth::Output}
       def parse(response, metadata)
         create_error(response, metadata) if error?(response)
       end

--- a/hearth/lib/hearth/middleware/parse.rb
+++ b/hearth/lib/hearth/middleware/parse.rb
@@ -23,19 +23,19 @@ module Hearth
       # @return [Output]
       def call(input, context)
         output = @app.call(input, context)
-        parse_error(context.response, output) unless output.error
-        parse_data(context.response, output) unless output.error
+        parse_error(context, output) unless output.error
+        parse_data(context, output) unless output.error
         output
       end
 
       private
 
-      def parse_error(response, output)
-        output.error = @error_parser.parse(response)
+      def parse_error(context, output)
+        output.error = @error_parser.parse(context.response, output.metadata)
       end
 
-      def parse_data(response, output)
-        output.data = @data_parser.parse(response)
+      def parse_data(context, output)
+        output.data = @data_parser.parse(context.response)
       end
     end
   end

--- a/hearth/lib/hearth/output.rb
+++ b/hearth/lib/hearth/output.rb
@@ -2,13 +2,14 @@
 
 module Hearth
   # A wrapper class that contains an error or data from the response.
-  # @api private
   class Output
     # @param [StandardError] error The error class to be raised.
     # @param [Struct] data The data returned by a client.
-    def initialize(error: nil, data: nil)
+    # @param [Hash] metadata Response metadata set by client middleware.
+    def initialize(error: nil, data: nil, metadata: {})
       @error = error
       @data = data
+      @metadata = metadata
     end
 
     # @return [StandardError, nil]
@@ -16,5 +17,8 @@ module Hearth
 
     # @return [Struct, nil]
     attr_accessor :data
+
+    # @return [Hash, nil]
+    attr_accessor :metadata
   end
 end

--- a/hearth/sig/lib/hearth/output.rbs
+++ b/hearth/sig/lib/hearth/output.rbs
@@ -1,0 +1,18 @@
+module Hearth
+  # A wrapper class that contains an error or data from the response.
+  class Output
+    # @param [StandardError] error The error class to be raised.
+    # @param [Struct] data The data returned by a client.
+    # @param [Hash] metadata Response metadata set by client middleware.
+    def initialize: (?error: untyped? error, ?data: untyped? data, ?metadata: ::Hash[untyped, untyped] metadata) -> void
+
+    # @return [StandardError, nil]
+    attr_accessor error: untyped
+
+    # @return [Struct, nil]
+    attr_accessor data: untyped
+
+    # @return [Hash, nil]
+    attr_accessor metadata: untyped
+  end
+end

--- a/hearth/spec/hearth/api_error_spec.rb
+++ b/hearth/spec/hearth/api_error_spec.rb
@@ -3,11 +3,13 @@
 module Hearth
   describe ApiError do
     let(:error_code) { 'error_code' }
+    let(:metadata) { { key: 'value' } }
     let(:message) { 'message' }
 
     subject do
       ApiError.new(
         error_code: error_code,
+        metadata: metadata,
         message: message
       )
     end
@@ -18,6 +20,18 @@ module Hearth
 
     it 'raises with the message' do
       expect { raise subject }.to raise_error(ApiError, message)
+    end
+
+    describe '#error_code' do
+      it 'returns the error code' do
+        expect(subject.error_code).to eq(error_code)
+      end
+    end
+
+    describe '#metadata' do
+      it 'returns the metadata' do
+        expect(subject.metadata).to eq(metadata)
+      end
     end
   end
 end

--- a/hearth/spec/hearth/http/api_error_spec.rb
+++ b/hearth/spec/hearth/http/api_error_spec.rb
@@ -4,12 +4,8 @@ module Hearth
   module HTTP
     describe ApiError do
       let(:http_status) { 404 }
-      let(:http_headers) do
-        Headers.new(headers: { 'x-request-id' => request_id })
-      end
-      let(:request_id) { '123' }
+      let(:http_headers) { Headers.new }
       let(:http_body) { 'body' }
-
       let(:http_resp) do
         Response.new(
           status: http_status,
@@ -17,13 +13,13 @@ module Hearth
           body: http_body
         )
       end
-      let(:error_code) { 'error_code' }
       let(:message) { 'message' }
 
       subject do
         ApiError.new(
           http_resp: http_resp,
-          error_code: error_code,
+          error_code: 'error_code',
+          metadata: {},
           message: message
         )
       end
@@ -32,8 +28,22 @@ module Hearth
         expect(subject).to be_a Hearth::ApiError
       end
 
-      it 'raises with the message' do
-        expect { raise subject }.to raise_error(ApiError, message)
+      describe '#http_status' do
+        it 'returns the http status' do
+          expect(subject.http_status).to eq(http_status)
+        end
+      end
+
+      describe '#http_headers' do
+        it 'returns the http headers' do
+          expect(subject.http_headers).to eq(http_headers)
+        end
+      end
+
+      describe '#http_body' do
+        it 'returns the http body' do
+          expect(subject.http_body).to eq(http_body)
+        end
       end
     end
   end

--- a/hearth/spec/hearth/http/error_parser_spec.rb
+++ b/hearth/spec/hearth/http/error_parser_spec.rb
@@ -4,6 +4,7 @@ module Hearth
   module HTTP
     module TestErrors
       def self.error_code(http_resp)
+        http_resp # satisfy rubocop
         nil
       end
 
@@ -85,7 +86,10 @@ module Hearth
         end
 
         context 'error code on response' do
-          before { allow(TestErrors).to receive(:error_code).and_return('TestModeledError') }
+          before do
+            allow(TestErrors).to receive(:error_code)
+              .with(http_resp).and_return('TestModeledError')
+          end
 
           context 'error response: 2XX with error code' do
             let(:resp_status) { 200 }

--- a/hearth/spec/hearth/http/error_parser_spec.rb
+++ b/hearth/spec/hearth/http/error_parser_spec.rb
@@ -3,8 +3,7 @@
 module Hearth
   module HTTP
     module TestErrors
-      def self.error_code(http_resp)
-        http_resp # satisfy rubocop
+      def self.error_code(_http_resp)
         nil
       end
 

--- a/hearth/spec/hearth/http/error_parser_spec.rb
+++ b/hearth/spec/hearth/http/error_parser_spec.rb
@@ -3,6 +3,10 @@
 module Hearth
   module HTTP
     module TestErrors
+      def self.error_code(http_resp)
+        nil
+      end
+
       class ApiError < Hearth::HTTP::ApiError; end
 
       class ApiRedirectError < ApiError
@@ -23,29 +27,26 @@ module Hearth
       let(:error_module) { TestErrors }
       let(:success_status) { 200 }
       let(:errors) { [TestErrors::TestModeledError] }
-      let(:error_code_fn) { proc {} }
 
       let(:resp_status) { 200 }
       let(:http_resp) { Response.new(status: resp_status) }
+      let(:metadata) { { key: 'value' } }
 
       subject do
         Hearth::HTTP::ErrorParser.new(
           error_module: error_module,
           success_status: success_status,
-          errors: errors,
-          error_code_fn: error_code_fn
+          errors: errors
         )
       end
 
       describe '#parse' do
         context 'no error code' do
-          let(:error_code_fn) { proc {} }
-
           context 'successful response: non-2XX success code matches' do
             let(:success_status) { 303 }
             let(:resp_status) { success_status }
             it 'does not return an error' do
-              error = subject.parse(http_resp)
+              error = subject.parse(http_resp, metadata)
               expect(error).to be_nil
             end
           end
@@ -53,7 +54,7 @@ module Hearth
           context 'successful response: 2XX code, no success_status' do
             let(:resp_status) { 201 }
             it 'does not return an error' do
-              error = subject.parse(http_resp)
+              error = subject.parse(http_resp, metadata)
               expect(error).to be_nil
             end
           end
@@ -61,7 +62,7 @@ module Hearth
           context 'error response: 3XX code' do
             let(:resp_status) { 300 }
             it 'returns an APIRedirectError' do
-              error = subject.parse(http_resp)
+              error = subject.parse(http_resp, metadata)
               expect(error).to be_a(TestErrors::ApiRedirectError)
             end
           end
@@ -69,7 +70,7 @@ module Hearth
           context 'error response: 4XX code' do
             let(:resp_status) { 400 }
             it 'returns an APIClientError' do
-              error = subject.parse(http_resp)
+              error = subject.parse(http_resp, metadata)
               expect(error).to be_a(TestErrors::ApiClientError)
             end
           end
@@ -77,20 +78,20 @@ module Hearth
           context 'error response: 5XX code' do
             let(:resp_status) { 500 }
             it 'returns an APIServerError' do
-              error = subject.parse(http_resp)
+              error = subject.parse(http_resp, metadata)
               expect(error).to be_a(TestErrors::ApiServerError)
             end
           end
         end
 
         context 'error code on response' do
-          let(:error_code_fn) { proc { 'TestModeledError' } }
+          before { allow(TestErrors).to receive(:error_code).and_return('TestModeledError') }
 
           context 'error response: 2XX with error code' do
             let(:resp_status) { 200 }
 
             it 'returns the modeled error' do
-              error = subject.parse(http_resp)
+              error = subject.parse(http_resp, metadata)
               expect(error).to be_a(TestErrors::TestModeledError)
             end
 
@@ -98,7 +99,7 @@ module Hearth
               let(:errors) { [] }
 
               it 'returns the generic APIError' do
-                error = subject.parse(http_resp)
+                error = subject.parse(http_resp, metadata)
                 expect(error).to be_a(TestErrors::ApiError)
               end
             end
@@ -108,7 +109,7 @@ module Hearth
             let(:resp_status) { 400 }
 
             it 'returns the modeled error' do
-              error = subject.parse(http_resp)
+              error = subject.parse(http_resp, metadata)
               expect(error).to be_a(TestErrors::TestModeledError)
             end
           end

--- a/hearth/spec/hearth/middleware/parse_spec.rb
+++ b/hearth/spec/hearth/middleware/parse_spec.rb
@@ -16,8 +16,9 @@ module Hearth
       end
 
       describe '#call' do
+        let(:metadata) { { key: 'value' } }
         let(:input) { double('input') }
-        let(:output) { Output.new }
+        let(:output) { Output.new(metadata: metadata) }
         let(:request) { double('request') }
         let(:response) { double('response') }
         let(:context) do
@@ -31,7 +32,8 @@ module Hearth
           expect(app).to receive(:call)
             .with(input, context).ordered
 
-          expect(error_parser).to receive(:parse).with(response).ordered
+          expect(error_parser).to receive(:parse)
+            .with(response, metadata).ordered
           expect(data_parser).to receive(:parse).with(response).ordered
 
           resp = subject.call(input, context)
@@ -43,6 +45,7 @@ module Hearth
           let(:error) do
             Hearth::ApiError.new(
               error_code: 'error_code',
+              metadata: metadata,
               message: 'error'
             )
           end
@@ -51,7 +54,7 @@ module Hearth
             expect(app).to receive(:call)
               .with(input, context).and_return(output).ordered
             expect(error_parser).to receive(:parse)
-              .with(response).ordered.and_return(error)
+              .with(response, metadata).ordered.and_return(error)
             expect(data_parser).not_to receive(:parse)
 
             resp = subject.call(input, context)
@@ -66,7 +69,8 @@ module Hearth
           it 'parses the data' do
             expect(app).to receive(:call)
               .with(input, context).ordered
-            expect(error_parser).to receive(:parse).with(response).ordered
+            expect(error_parser).to receive(:parse)
+              .with(response, metadata).ordered
             expect(data_parser).to receive(:parse)
               .with(response).and_return(data)
 

--- a/hearth/spec/hearth/output_spec.rb
+++ b/hearth/spec/hearth/output_spec.rb
@@ -4,14 +4,22 @@ module Hearth
   describe Output do
     let(:error) { StandardError.new }
     let(:data) { double('Struct') }
+    let(:metadata) { {} }
 
-    subject { Output.new(error: error, data: data) }
+    subject { Output.new(error: error, data: data, metadata: metadata) }
 
     describe '#initialize' do
       it 'sets empty defaults' do
         output = Output.new
         expect(output.error).to be_nil
         expect(output.data).to be_nil
+        expect(output.metadata).to eq({})
+      end
+
+      it 'uses provided values' do
+        expect(subject.error).to eq(error)
+        expect(subject.data).to eq(data)
+        expect(subject.metadata).to eq(metadata)
       end
     end
   end

--- a/hearth/spec/hearth/waiters/poller_spec.rb
+++ b/hearth/spec/hearth/waiters/poller_spec.rb
@@ -34,6 +34,7 @@ module Hearth
       let(:error) do
         Hearth::ApiError.new(
           error_code: 'SomeError',
+          metadata: {},
           message: 'error'
         )
       end

--- a/hearth/spec/hearth/waiters/waiter_spec.rb
+++ b/hearth/spec/hearth/waiters/waiter_spec.rb
@@ -21,6 +21,7 @@ module Hearth
       let(:error) do
         Hearth::ApiError.new(
           error_code: 'SomeError',
+          metadata: {},
           message: 'error'
         )
       end


### PR DESCRIPTION
Breaking change.

Return Hearth::Output from operations, instead of the output structure. This is similar to V3 (without delegation however).

This allows middleware to set context values and have it be accessible to users.