### PR TITLE
Add support for Streaming

### DIFF
--- a/codegen/projections/high_score_service/lib/high_score_service/client.rb
+++ b/codegen/projections/high_score_service/lib/high_score_service/client.rb
@@ -95,6 +95,7 @@ module HighScoreService
     def create_high_score(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::CreateHighScoreInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::CreateHighScoreInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -121,7 +122,7 @@ module HighScoreService
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :create_high_score
@@ -154,6 +155,7 @@ module HighScoreService
     def delete_high_score(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::DeleteHighScoreInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::DeleteHighScoreInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -180,7 +182,7 @@ module HighScoreService
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :delete_high_score
@@ -219,6 +221,7 @@ module HighScoreService
     def get_high_score(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::GetHighScoreInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::GetHighScoreInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -245,7 +248,7 @@ module HighScoreService
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :get_high_score
@@ -280,6 +283,7 @@ module HighScoreService
     def list_high_scores(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::ListHighScoresInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::ListHighScoresInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -306,7 +310,7 @@ module HighScoreService
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :list_high_scores
@@ -352,6 +356,7 @@ module HighScoreService
     def update_high_score(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::UpdateHighScoreInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::UpdateHighScoreInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -378,7 +383,7 @@ module HighScoreService
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :update_high_score

--- a/codegen/projections/rails_json/lib/rails_json/builders.rb
+++ b/codegen/projections/rails_json/lib/rails_json/builders.rb
@@ -1145,6 +1145,18 @@ module RailsJson
       end
     end
 
+    # Operation Builder for StreamingOperation
+    class StreamingOperation
+      def self.build(http_req, input:)
+        http_req.http_method = 'POST'
+        http_req.append_path('/streamingoperation')
+        params = Hearth::Query::ParamList.new
+        http_req.append_query_params(params)
+        http_req.headers['Content-Type'] = 'application/octet-stream'
+        http_req.body = StringIO.new(input[:output] || '')
+      end
+    end
+
     # Operation Builder for TimestampFormatHeaders
     class TimestampFormatHeaders
       def self.build(http_req, input:)

--- a/codegen/projections/rails_json/lib/rails_json/builders.rb
+++ b/codegen/projections/rails_json/lib/rails_json/builders.rb
@@ -1153,7 +1153,7 @@ module RailsJson
         params = Hearth::Query::ParamList.new
         http_req.append_query_params(params)
         http_req.body = input[:output]
-        http_req.headers['Content-Type'] = 'chunked'
+        http_req.headers['Transfer-Encoding'] = 'chunked'
       end
     end
 

--- a/codegen/projections/rails_json/lib/rails_json/builders.rb
+++ b/codegen/projections/rails_json/lib/rails_json/builders.rb
@@ -1152,8 +1152,8 @@ module RailsJson
         http_req.append_path('/streamingoperation')
         params = Hearth::Query::ParamList.new
         http_req.append_query_params(params)
-        http_req.headers['Content-Type'] = 'application/octet-stream'
-        http_req.body = StringIO.new(input[:output] || '')
+        http_req.body = input[:output]
+        http_req.headers['Content-Type'] = 'chunked'
       end
     end
 

--- a/codegen/projections/rails_json/lib/rails_json/client.rb
+++ b/codegen/projections/rails_json/lib/rails_json/client.rb
@@ -2341,7 +2341,6 @@ module RailsJson
       stack.use(Hearth::Middleware::Build,
         builder: Builders::StreamingOperation
       )
-      stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::StreamingOperation

--- a/codegen/projections/rails_json/lib/rails_json/client.rb
+++ b/codegen/projections/rails_json/lib/rails_json/client.rb
@@ -117,6 +117,7 @@ module RailsJson
     def all_query_string_types(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::AllQueryStringTypesInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::AllQueryStringTypesInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -143,7 +144,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :all_query_string_types
@@ -176,6 +177,7 @@ module RailsJson
     def constant_and_variable_query_string(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::ConstantAndVariableQueryStringInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::ConstantAndVariableQueryStringInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -202,7 +204,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :constant_and_variable_query_string
@@ -235,6 +237,7 @@ module RailsJson
     def constant_query_string(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::ConstantQueryStringInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::ConstantQueryStringInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -261,7 +264,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :constant_query_string
@@ -301,6 +304,7 @@ module RailsJson
     def document_type(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::DocumentTypeInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::DocumentTypeInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -327,7 +331,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :document_type
@@ -365,6 +369,7 @@ module RailsJson
     def document_type_as_payload(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::DocumentTypeAsPayloadInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::DocumentTypeAsPayloadInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -391,7 +396,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :document_type_as_payload
@@ -417,6 +422,7 @@ module RailsJson
     def empty_operation(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::EmptyOperationInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::EmptyOperationInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -443,7 +449,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :empty_operation
@@ -469,6 +475,7 @@ module RailsJson
     def endpoint_operation(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::EndpointOperationInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::EndpointOperationInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -499,7 +506,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :endpoint_operation
@@ -527,6 +534,7 @@ module RailsJson
     def endpoint_with_host_label_operation(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::EndpointWithHostLabelOperationInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::EndpointWithHostLabelOperationInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -557,7 +565,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :endpoint_with_host_label_operation
@@ -593,6 +601,7 @@ module RailsJson
     def greeting_with_errors(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::GreetingWithErrorsInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::GreetingWithErrorsInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -619,7 +628,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :greeting_with_errors
@@ -655,6 +664,7 @@ module RailsJson
     def http_payload_traits(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::HttpPayloadTraitsInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::HttpPayloadTraitsInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -681,7 +691,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :http_payload_traits
@@ -715,6 +725,7 @@ module RailsJson
     def http_payload_traits_with_media_type(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::HttpPayloadTraitsWithMediaTypeInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::HttpPayloadTraitsWithMediaTypeInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -741,7 +752,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :http_payload_traits_with_media_type
@@ -780,6 +791,7 @@ module RailsJson
     def http_payload_with_structure(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::HttpPayloadWithStructureInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::HttpPayloadWithStructureInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -806,7 +818,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :http_payload_with_structure
@@ -844,6 +856,7 @@ module RailsJson
     def http_prefix_headers(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::HttpPrefixHeadersInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::HttpPrefixHeadersInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -870,7 +883,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :http_prefix_headers
@@ -900,6 +913,7 @@ module RailsJson
     def http_prefix_headers_in_response(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::HttpPrefixHeadersInResponseInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::HttpPrefixHeadersInResponseInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -926,7 +940,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :http_prefix_headers_in_response
@@ -955,6 +969,7 @@ module RailsJson
     def http_request_with_float_labels(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::HttpRequestWithFloatLabelsInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::HttpRequestWithFloatLabelsInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -981,7 +996,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :http_request_with_float_labels
@@ -1010,6 +1025,7 @@ module RailsJson
     def http_request_with_greedy_label_in_path(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::HttpRequestWithGreedyLabelInPathInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::HttpRequestWithGreedyLabelInPathInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -1036,7 +1052,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :http_request_with_greedy_label_in_path
@@ -1080,6 +1096,7 @@ module RailsJson
     def http_request_with_labels(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::HttpRequestWithLabelsInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::HttpRequestWithLabelsInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -1106,7 +1123,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :http_request_with_labels
@@ -1143,6 +1160,7 @@ module RailsJson
     def http_request_with_labels_and_timestamp_format(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::HttpRequestWithLabelsAndTimestampFormatInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::HttpRequestWithLabelsAndTimestampFormatInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -1169,7 +1187,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :http_request_with_labels_and_timestamp_format
@@ -1196,6 +1214,7 @@ module RailsJson
     def http_response_code(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::HttpResponseCodeInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::HttpResponseCodeInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -1222,7 +1241,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :http_response_code
@@ -1253,6 +1272,7 @@ module RailsJson
     def ignore_query_params_in_response(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::IgnoreQueryParamsInResponseInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::IgnoreQueryParamsInResponseInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -1279,7 +1299,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :ignore_query_params_in_response
@@ -1359,6 +1379,7 @@ module RailsJson
     def input_and_output_with_headers(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::InputAndOutputWithHeadersInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::InputAndOutputWithHeadersInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -1385,7 +1406,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :input_and_output_with_headers
@@ -1435,6 +1456,7 @@ module RailsJson
     def json_enums(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::JsonEnumsInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::JsonEnumsInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -1461,7 +1483,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :json_enums
@@ -1538,6 +1560,7 @@ module RailsJson
     def json_maps(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::JsonMapsInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::JsonMapsInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -1564,7 +1587,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :json_maps
@@ -1615,6 +1638,7 @@ module RailsJson
     def json_unions(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::JsonUnionsInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::JsonUnionsInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -1641,7 +1665,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :json_unions
@@ -1775,6 +1799,7 @@ module RailsJson
     def kitchen_sink_operation(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::KitchenSinkOperationInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::KitchenSinkOperationInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -1801,7 +1826,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :kitchen_sink_operation
@@ -1832,6 +1857,7 @@ module RailsJson
     def media_type_header(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::MediaTypeHeaderInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::MediaTypeHeaderInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -1858,7 +1884,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :media_type_header
@@ -1889,6 +1915,7 @@ module RailsJson
     def nested_attributes_operation(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::NestedAttributesOperationInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::NestedAttributesOperationInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -1915,7 +1942,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :nested_attributes_operation
@@ -1953,6 +1980,7 @@ module RailsJson
     def null_and_empty_headers_client(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::NullAndEmptyHeadersClientInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::NullAndEmptyHeadersClientInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -1979,7 +2007,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :null_and_empty_headers_client
@@ -2018,6 +2046,7 @@ module RailsJson
     def null_operation(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::NullOperationInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::NullOperationInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -2044,7 +2073,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :null_operation
@@ -2075,6 +2104,7 @@ module RailsJson
     def omits_null_serializes_empty_string(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::OmitsNullSerializesEmptyStringInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::OmitsNullSerializesEmptyStringInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -2101,7 +2131,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :omits_null_serializes_empty_string
@@ -2130,6 +2160,7 @@ module RailsJson
     def operation_with_optional_input_output(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::OperationWithOptionalInputOutputInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::OperationWithOptionalInputOutputInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -2156,7 +2187,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :operation_with_optional_input_output
@@ -2186,6 +2217,7 @@ module RailsJson
     def query_idempotency_token_auto_fill(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::QueryIdempotencyTokenAutoFillInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::QueryIdempotencyTokenAutoFillInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -2212,7 +2244,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :query_idempotency_token_auto_fill
@@ -2245,6 +2277,7 @@ module RailsJson
     def query_params_as_string_list_map(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::QueryParamsAsStringListMapInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::QueryParamsAsStringListMapInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -2271,10 +2304,66 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :query_params_as_string_list_map
+        )
+      )
+      raise resp.error if resp.error
+      resp
+    end
+
+    # @param [Hash] params
+    #   See {Types::StreamingOperationInput}.
+    #
+    # @return [Types::StreamingOperationOutput]
+    #
+    # @example Request syntax with placeholder values
+    #
+    #   resp = client.streaming_operation(
+    #     output: 'output'
+    #   )
+    #
+    # @example Response structure
+    #
+    #   resp.data #=> Types::StreamingOperationOutput
+    #   resp.data.output #=> String
+    #
+    def streaming_operation(params = {}, options = {}, &block)
+      stack = Hearth::MiddlewareStack.new
+      input = Params::StreamingOperationInput.build(params)
+      response_body = output_stream(options, &block)
+      stack.use(Hearth::Middleware::Validate,
+        validator: Validators::StreamingOperationInput,
+        validate_input: options.fetch(:validate_input, @validate_input)
+      )
+      stack.use(Hearth::Middleware::Build,
+        builder: Builders::StreamingOperation
+      )
+      stack.use(Hearth::HTTP::Middleware::ContentLength)
+      stack.use(Hearth::Middleware::Parse,
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
+        data_parser: Parsers::StreamingOperation
+      )
+      stack.use(Middleware::RequestId)
+      stack.use(Hearth::Middleware::Send,
+        stub_responses: options.fetch(:stub_responses, @stub_responses),
+        client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
+        stub_class: Stubs::StreamingOperation,
+        params_class: Params::StreamingOperationOutput,
+        stubs: options.fetch(:stubs, @stubs)
+      )
+      apply_middleware(stack, options[:middleware])
+
+      resp = stack.run(
+        input: input,
+        context: Hearth::Context.new(
+          request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
+          response: Hearth::HTTP::Response.new(body: response_body),
+          params: params,
+          logger: @logger,
+          operation_name: :streaming_operation
         )
       )
       raise resp.error if resp.error
@@ -2314,6 +2403,7 @@ module RailsJson
     def timestamp_format_headers(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::TimestampFormatHeadersInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::TimestampFormatHeadersInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -2340,7 +2430,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :timestamp_format_headers
@@ -2373,6 +2463,7 @@ module RailsJson
     def operation____789_bad_name(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::Struct____789BadNameInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::Struct____789BadNameInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -2399,7 +2490,7 @@ module RailsJson
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :operation____789_bad_name

--- a/codegen/projections/rails_json/lib/rails_json/params.rb
+++ b/codegen/projections/rails_json/lib/rails_json/params.rb
@@ -1229,6 +1229,24 @@ module RailsJson
       end
     end
 
+    module StreamingOperationInput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::StreamingOperationInput, context: context)
+        type = Types::StreamingOperationInput.new
+        type.output = params[:output]
+        type
+      end
+    end
+
+    module StreamingOperationOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::StreamingOperationOutput, context: context)
+        type = Types::StreamingOperationOutput.new
+        type.output = params[:output]
+        type
+      end
+    end
+
     module StringList
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Array, context: context)

--- a/codegen/projections/rails_json/lib/rails_json/params.rb
+++ b/codegen/projections/rails_json/lib/rails_json/params.rb
@@ -1233,7 +1233,11 @@ module RailsJson
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::StreamingOperationInput, context: context)
         type = Types::StreamingOperationInput.new
-        type.output = params[:output]
+        io = params[:output] || StringIO.new
+        unless io.respond_to?(:read) || io.respond_to?(:readpartial)
+          io = StringIO.new(io)
+        end
+        type.output = io
         type
       end
     end
@@ -1242,7 +1246,11 @@ module RailsJson
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::StreamingOperationOutput, context: context)
         type = Types::StreamingOperationOutput.new
-        type.output = params[:output]
+        io = params[:output] || StringIO.new
+        unless io.respond_to?(:read) || io.respond_to?(:readpartial)
+          io = StringIO.new(io)
+        end
+        type.output = io
         type
       end
     end

--- a/codegen/projections/rails_json/lib/rails_json/parsers.rb
+++ b/codegen/projections/rails_json/lib/rails_json/parsers.rb
@@ -869,6 +869,15 @@ module RailsJson
       end
     end
 
+    # Operation Parser for StreamingOperation
+    class StreamingOperation
+      def self.parse(http_resp)
+        data = Types::StreamingOperationOutput.new
+        data.output = http_resp.body
+        data
+      end
+    end
+
     # Operation Parser for TimestampFormatHeaders
     class TimestampFormatHeaders
       def self.parse(http_resp)

--- a/codegen/projections/rails_json/lib/rails_json/stubs.rb
+++ b/codegen/projections/rails_json/lib/rails_json/stubs.rb
@@ -1487,8 +1487,8 @@ module RailsJson
       def self.stub(http_resp, stub:)
         data = {}
         http_resp.status = 200
-        http_resp.headers['Content-Type'] = 'application/octet-stream'
-        http_resp.body = StringIO.new(stub[:output] || '')
+        stub_io = stub[:output] === String ? StringIO.new(stub[:output]) : stub[:output]
+        IO.copy_stream(stub_io, http_resp.body)
       end
     end
 

--- a/codegen/projections/rails_json/lib/rails_json/stubs.rb
+++ b/codegen/projections/rails_json/lib/rails_json/stubs.rb
@@ -1487,7 +1487,8 @@ module RailsJson
       def self.stub(http_resp, stub:)
         data = {}
         http_resp.status = 200
-        stub_io = String === stub[:output] ? StringIO.new(stub[:output]) : stub[:output]
+        stub_io = stub[:output] || ''
+        stub_io = String === stub_io ? StringIO.new(stub_io) : stub_io
         IO.copy_stream(stub_io, http_resp.body)
       end
     end

--- a/codegen/projections/rails_json/lib/rails_json/stubs.rb
+++ b/codegen/projections/rails_json/lib/rails_json/stubs.rb
@@ -1487,7 +1487,7 @@ module RailsJson
       def self.stub(http_resp, stub:)
         data = {}
         http_resp.status = 200
-        stub_io = stub[:output] === String ? StringIO.new(stub[:output]) : stub[:output]
+        stub_io = String === stub[:output] ? StringIO.new(stub[:output]) : stub[:output]
         IO.copy_stream(stub_io, http_resp.body)
       end
     end

--- a/codegen/projections/rails_json/lib/rails_json/stubs.rb
+++ b/codegen/projections/rails_json/lib/rails_json/stubs.rb
@@ -1476,6 +1476,22 @@ module RailsJson
       end
     end
 
+    # Operation Stubber for StreamingOperation
+    class StreamingOperation
+      def self.default(visited=[])
+        {
+          output: 'output',
+        }
+      end
+
+      def self.stub(http_resp, stub:)
+        data = {}
+        http_resp.status = 200
+        http_resp.headers['Content-Type'] = 'application/octet-stream'
+        http_resp.body = StringIO.new(stub[:output] || '')
+      end
+    end
+
     # Operation Stubber for TimestampFormatHeaders
     class TimestampFormatHeaders
       def self.default(visited=[])

--- a/codegen/projections/rails_json/lib/rails_json/stubs.rb
+++ b/codegen/projections/rails_json/lib/rails_json/stubs.rb
@@ -1487,9 +1487,7 @@ module RailsJson
       def self.stub(http_resp, stub:)
         data = {}
         http_resp.status = 200
-        stub_io = stub[:output] || ''
-        stub_io = String === stub_io ? StringIO.new(stub_io) : stub_io
-        IO.copy_stream(stub_io, http_resp.body)
+        IO.copy_stream(stub[:output], http_resp.body)
       end
     end
 

--- a/codegen/projections/rails_json/lib/rails_json/types.rb
+++ b/codegen/projections/rails_json/lib/rails_json/types.rb
@@ -1847,6 +1847,28 @@ module RailsJson
       include Hearth::Structure
     end
 
+    # @!attribute output
+    #
+    #   @return [String]
+    #
+    StreamingOperationInput = ::Struct.new(
+      :output,
+      keyword_init: true
+    ) do
+      include Hearth::Structure
+    end
+
+    # @!attribute output
+    #
+    #   @return [String]
+    #
+    StreamingOperationOutput = ::Struct.new(
+      :output,
+      keyword_init: true
+    ) do
+      include Hearth::Structure
+    end
+
     # @!attribute value
     #
     #   @return [String]

--- a/codegen/projections/rails_json/lib/rails_json/validators.rb
+++ b/codegen/projections/rails_json/lib/rails_json/validators.rb
@@ -1084,14 +1084,18 @@ module RailsJson
     class StreamingOperationInput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::StreamingOperationInput, context: context)
-        Hearth::Validator.validate!(input[:output], ::String, context: "#{context}[:output]")
+        unless input[:output].respond_to?(:read) || input[:output].respond_to?(:readpartial)
+          raise ArgumentError, "Expected #{context} to be an IO like object, got #{input[:output].class}"
+        end
       end
     end
 
     class StreamingOperationOutput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::StreamingOperationOutput, context: context)
-        Hearth::Validator.validate!(input[:output], ::String, context: "#{context}[:output]")
+        unless input[:output].respond_to?(:read) || input[:output].respond_to?(:readpartial)
+          raise ArgumentError, "Expected #{context} to be an IO like object, got #{input[:output].class}"
+        end
       end
     end
 

--- a/codegen/projections/rails_json/lib/rails_json/validators.rb
+++ b/codegen/projections/rails_json/lib/rails_json/validators.rb
@@ -1081,6 +1081,20 @@ module RailsJson
       end
     end
 
+    class StreamingOperationInput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::StreamingOperationInput, context: context)
+        Hearth::Validator.validate!(input[:output], ::String, context: "#{context}[:output]")
+      end
+    end
+
+    class StreamingOperationOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::StreamingOperationOutput, context: context)
+        Hearth::Validator.validate!(input[:output], ::String, context: "#{context}[:output]")
+      end
+    end
+
     class StringList
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, ::Array, context: context)

--- a/codegen/projections/rails_json/sig/rails_json/client.rbs
+++ b/codegen/projections/rails_json/sig/rails_json/client.rbs
@@ -47,6 +47,7 @@ module RailsJson
     def operation_with_optional_input_output: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
     def query_idempotency_token_auto_fill: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
     def query_params_as_string_list_map: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
+    def streaming_operation: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
     def timestamp_format_headers: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
     def operation____789_bad_name: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
 

--- a/codegen/projections/rails_json/sig/rails_json/types.rbs
+++ b/codegen/projections/rails_json/sig/rails_json/types.rbs
@@ -204,6 +204,10 @@ module RailsJson
 
     SimpleStruct: untyped
 
+    StreamingOperationInput: untyped
+
+    StreamingOperationOutput: untyped
+
     StructWithLocationName: untyped
 
     TimestampFormatHeadersInput: untyped

--- a/codegen/projections/rails_json/spec/protocol_spec.rb
+++ b/codegen/projections/rails_json/spec/protocol_spec.rb
@@ -5676,6 +5676,10 @@ module RailsJson
 
     end
 
+    describe '#streaming_operation' do
+
+    end
+
     describe '#timestamp_format_headers' do
 
       describe 'requests' do

--- a/codegen/projections/weather/lib/weather/builders.rb
+++ b/codegen/projections/weather/lib/weather/builders.rb
@@ -18,12 +18,6 @@ module Weather
       end
     end
 
-    # Operation Builder for GetCityAnnouncements
-    class GetCityAnnouncements
-      def self.build(http_req, input:)
-      end
-    end
-
     # Operation Builder for GetCityImage
     class GetCityImage
       def self.build(http_req, input:)

--- a/codegen/projections/weather/lib/weather/client.rb
+++ b/codegen/projections/weather/lib/weather/client.rb
@@ -87,6 +87,7 @@ module Weather
     def get_city(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::GetCityInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::GetCityInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -112,7 +113,7 @@ module Weather
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :get_city
@@ -142,6 +143,7 @@ module Weather
     def get_city_announcements(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::GetCityAnnouncementsInput.build(params)
+      response_body = output_stream(options, &block)
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::GetCityAnnouncementsInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -167,7 +169,7 @@ module Weather
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :get_city_announcements
@@ -204,6 +206,7 @@ module Weather
     def get_city_image(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::GetCityImageInput.build(params)
+      response_body = output_stream(options, &block)
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::GetCityImageInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -229,7 +232,7 @@ module Weather
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :get_city_image
@@ -256,6 +259,7 @@ module Weather
     def get_current_time(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::GetCurrentTimeInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::GetCurrentTimeInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -281,7 +285,7 @@ module Weather
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :get_current_time
@@ -311,6 +315,7 @@ module Weather
     def get_forecast(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::GetForecastInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::GetForecastInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -336,7 +341,7 @@ module Weather
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :get_forecast
@@ -385,6 +390,7 @@ module Weather
     def list_cities(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::ListCitiesInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::ListCitiesInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -410,7 +416,7 @@ module Weather
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :list_cities
@@ -444,6 +450,7 @@ module Weather
     def operation____789_bad_name(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::Struct____789BadNameInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::Struct____789BadNameInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -469,7 +476,7 @@ module Weather
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :operation____789_bad_name

--- a/codegen/projections/weather/lib/weather/client.rb
+++ b/codegen/projections/weather/lib/weather/client.rb
@@ -124,62 +124,6 @@ module Weather
     end
 
     # @param [Hash] params
-    #   See {Types::GetCityAnnouncementsInput}.
-    #
-    # @return [Types::GetCityAnnouncementsOutput]
-    #
-    # @example Request syntax with placeholder values
-    #
-    #   resp = client.get_city_announcements(
-    #     city_id: 'cityId' # required
-    #   )
-    #
-    # @example Response structure
-    #
-    #   resp.data #=> Types::GetCityAnnouncementsOutput
-    #   resp.data.last_updated #=> Time
-    #   resp.data.announcements #=> Announcements
-    #
-    def get_city_announcements(params = {}, options = {}, &block)
-      stack = Hearth::MiddlewareStack.new
-      input = Params::GetCityAnnouncementsInput.build(params)
-      response_body = output_stream(options, &block)
-      stack.use(Hearth::Middleware::Validate,
-        validator: Validators::GetCityAnnouncementsInput,
-        validate_input: options.fetch(:validate_input, @validate_input)
-      )
-      stack.use(Hearth::Middleware::Build,
-        builder: Builders::GetCityAnnouncements
-      )
-      stack.use(Hearth::HTTP::Middleware::ContentLength)
-      stack.use(Hearth::Middleware::Parse,
-        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: [Errors::NoSuchResource]),
-        data_parser: Parsers::GetCityAnnouncements
-      )
-      stack.use(Hearth::Middleware::Send,
-        stub_responses: options.fetch(:stub_responses, @stub_responses),
-        client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
-        stub_class: Stubs::GetCityAnnouncements,
-        params_class: Params::GetCityAnnouncementsOutput,
-        stubs: options.fetch(:stubs, @stubs)
-      )
-      apply_middleware(stack, options[:middleware])
-
-      resp = stack.run(
-        input: input,
-        context: Hearth::Context.new(
-          request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: response_body),
-          params: params,
-          logger: @logger,
-          operation_name: :get_city_announcements
-        )
-      )
-      raise resp.error if resp.error
-      resp
-    end
-
-    # @param [Hash] params
     #   See {Types::GetCityImageInput}.
     #
     # @return [Types::GetCityImageOutput]

--- a/codegen/projections/weather/lib/weather/params.rb
+++ b/codegen/projections/weather/lib/weather/params.rb
@@ -127,7 +127,11 @@ module Weather
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::GetCityImageOutput, context: context)
         type = Types::GetCityImageOutput.new
-        type.image = params[:image]
+        io = params[:image] || StringIO.new
+        unless io.respond_to?(:read) || io.respond_to?(:readpartial)
+          io = StringIO.new(io)
+        end
+        type.image = io
         type
       end
     end

--- a/codegen/projections/weather/lib/weather/parsers.rb
+++ b/codegen/projections/weather/lib/weather/parsers.rb
@@ -34,22 +34,6 @@ module Weather
       end
     end
 
-    # Operation Parser for GetCityAnnouncements
-    class GetCityAnnouncements
-      def self.parse(http_resp)
-        data = Types::GetCityAnnouncementsOutput.new
-        data.last_updated = Time.parse(http_resp.headers['x-last-updated']) if http_resp.headers['x-last-updated']
-        data.announcements = http_resp.body
-        data
-      end
-    end
-
-    class Announcements
-    end
-
-    class Message
-    end
-
     # Operation Parser for GetCityImage
     class GetCityImage
       def self.parse(http_resp)

--- a/codegen/projections/weather/lib/weather/parsers.rb
+++ b/codegen/projections/weather/lib/weather/parsers.rb
@@ -39,6 +39,7 @@ module Weather
       def self.parse(http_resp)
         data = Types::GetCityAnnouncementsOutput.new
         data.last_updated = Time.parse(http_resp.headers['x-last-updated']) if http_resp.headers['x-last-updated']
+        data.announcements = http_resp.body
         data
       end
     end
@@ -53,6 +54,7 @@ module Weather
     class GetCityImage
       def self.parse(http_resp)
         data = Types::GetCityImageOutput.new
+        data.image = http_resp.body
         data
       end
     end

--- a/codegen/projections/weather/lib/weather/stubs.rb
+++ b/codegen/projections/weather/lib/weather/stubs.rb
@@ -67,9 +67,7 @@ module Weather
         data = {}
         http_resp.status = 200
         http_resp.headers['x-last-updated'] = Hearth::TimeHelper.to_date_time(stub[:last_updated]) unless stub[:last_updated].nil?
-        stub_io = stub[:announcements] || ''
-        stub_io = String === stub_io ? StringIO.new(stub_io) : stub_io
-        IO.copy_stream(stub_io, http_resp.body)
+        IO.copy_stream(stub[:announcements], http_resp.body)
       end
     end
 
@@ -109,9 +107,7 @@ module Weather
       def self.stub(http_resp, stub:)
         data = {}
         http_resp.status = 200
-        stub_io = stub[:image] || ''
-        stub_io = String === stub_io ? StringIO.new(stub_io) : stub_io
-        IO.copy_stream(stub_io, http_resp.body)
+        IO.copy_stream(stub[:image], http_resp.body)
       end
     end
 

--- a/codegen/projections/weather/lib/weather/stubs.rb
+++ b/codegen/projections/weather/lib/weather/stubs.rb
@@ -67,7 +67,8 @@ module Weather
         data = {}
         http_resp.status = 200
         http_resp.headers['x-last-updated'] = Hearth::TimeHelper.to_date_time(stub[:last_updated]) unless stub[:last_updated].nil?
-        stub_io = String === stub[:announcements] ? StringIO.new(stub[:announcements]) : stub[:announcements]
+        stub_io = stub[:announcements] || ''
+        stub_io = String === stub_io ? StringIO.new(stub_io) : stub_io
         IO.copy_stream(stub_io, http_resp.body)
       end
     end
@@ -108,7 +109,8 @@ module Weather
       def self.stub(http_resp, stub:)
         data = {}
         http_resp.status = 200
-        stub_io = String === stub[:image] ? StringIO.new(stub[:image]) : stub[:image]
+        stub_io = stub[:image] || ''
+        stub_io = String === stub_io ? StringIO.new(stub_io) : stub_io
         IO.copy_stream(stub_io, http_resp.body)
       end
     end

--- a/codegen/projections/weather/lib/weather/stubs.rb
+++ b/codegen/projections/weather/lib/weather/stubs.rb
@@ -67,6 +67,8 @@ module Weather
         data = {}
         http_resp.status = 200
         http_resp.headers['x-last-updated'] = Hearth::TimeHelper.to_date_time(stub[:last_updated]) unless stub[:last_updated].nil?
+        stub_io = stub[:announcements] === String ? StringIO.new(stub[:announcements]) : stub[:announcements]
+        IO.copy_stream(stub_io, http_resp.body)
       end
     end
 
@@ -106,6 +108,8 @@ module Weather
       def self.stub(http_resp, stub:)
         data = {}
         http_resp.status = 200
+        stub_io = stub[:image] === String ? StringIO.new(stub[:image]) : stub[:image]
+        IO.copy_stream(stub_io, http_resp.body)
       end
     end
 

--- a/codegen/projections/weather/lib/weather/stubs.rb
+++ b/codegen/projections/weather/lib/weather/stubs.rb
@@ -67,7 +67,7 @@ module Weather
         data = {}
         http_resp.status = 200
         http_resp.headers['x-last-updated'] = Hearth::TimeHelper.to_date_time(stub[:last_updated]) unless stub[:last_updated].nil?
-        stub_io = stub[:announcements] === String ? StringIO.new(stub[:announcements]) : stub[:announcements]
+        stub_io = String === stub[:announcements] ? StringIO.new(stub[:announcements]) : stub[:announcements]
         IO.copy_stream(stub_io, http_resp.body)
       end
     end
@@ -108,7 +108,7 @@ module Weather
       def self.stub(http_resp, stub:)
         data = {}
         http_resp.status = 200
-        stub_io = stub[:image] === String ? StringIO.new(stub[:image]) : stub[:image]
+        stub_io = String === stub[:image] ? StringIO.new(stub[:image]) : stub[:image]
         IO.copy_stream(stub_io, http_resp.body)
       end
     end

--- a/codegen/projections/weather/lib/weather/validators.rb
+++ b/codegen/projections/weather/lib/weather/validators.rb
@@ -114,7 +114,9 @@ module Weather
     class GetCityImageOutput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::GetCityImageOutput, context: context)
-        Hearth::Validator.validate!(input[:image], ::String, context: "#{context}[:image]")
+        unless input[:image].respond_to?(:read) || input[:image].respond_to?(:readpartial)
+          raise ArgumentError, "Expected #{context} to be an IO like object, got #{input[:image].class}"
+        end
       end
     end
 

--- a/codegen/projections/white_label/lib/white_label/builders.rb
+++ b/codegen/projections/white_label/lib/white_label/builders.rb
@@ -67,6 +67,8 @@ module WhiteLabel
     # Operation Builder for StreamingOperation
     class StreamingOperation
       def self.build(http_req, input:)
+        http_req.body = input[:stream]
+        http_req.headers['Content-Type'] = 'chunked'
       end
     end
 

--- a/codegen/projections/white_label/lib/white_label/builders.rb
+++ b/codegen/projections/white_label/lib/white_label/builders.rb
@@ -72,6 +72,14 @@ module WhiteLabel
       end
     end
 
+    # Operation Builder for StreamingWithLength
+    class StreamingWithLength
+      def self.build(http_req, input:)
+        http_req.body = input[:stream]
+        http_req.headers['Content-Type'] = 'chunked'
+      end
+    end
+
     # Operation Builder for WaitersTest
     class WaitersTest
       def self.build(http_req, input:)

--- a/codegen/projections/white_label/lib/white_label/builders.rb
+++ b/codegen/projections/white_label/lib/white_label/builders.rb
@@ -64,6 +64,12 @@ module WhiteLabel
       end
     end
 
+    # Operation Builder for StreamingOperation
+    class StreamingOperation
+      def self.build(http_req, input:)
+      end
+    end
+
     # Operation Builder for WaitersTest
     class WaitersTest
       def self.build(http_req, input:)

--- a/codegen/projections/white_label/lib/white_label/builders.rb
+++ b/codegen/projections/white_label/lib/white_label/builders.rb
@@ -68,7 +68,7 @@ module WhiteLabel
     class StreamingOperation
       def self.build(http_req, input:)
         http_req.body = input[:stream]
-        http_req.headers['Content-Type'] = 'chunked'
+        http_req.headers['Transfer-Encoding'] = 'chunked'
       end
     end
 
@@ -76,7 +76,6 @@ module WhiteLabel
     class StreamingWithLength
       def self.build(http_req, input:)
         http_req.body = input[:stream]
-        http_req.headers['Content-Type'] = 'chunked'
       end
     end
 

--- a/codegen/projections/white_label/lib/white_label/client.rb
+++ b/codegen/projections/white_label/lib/white_label/client.rb
@@ -482,6 +482,61 @@ module WhiteLabel
     end
 
     # @param [Hash] params
+    #   See {Types::StreamingOperationInput}.
+    #
+    # @return [Types::StreamingOperationOutput]
+    #
+    # @example Request syntax with placeholder values
+    #
+    #   resp = client.streaming_operation(
+    #     output: 'output'
+    #   )
+    #
+    # @example Response structure
+    #
+    #   resp.data #=> Types::StreamingOperationOutput
+    #   resp.data.output #=> String
+    #
+    def streaming_operation(params = {}, options = {}, &block)
+      stack = Hearth::MiddlewareStack.new
+      input = Params::StreamingOperationInput.build(params)
+      response_body = output_stream(options, &block)
+      stack.use(Hearth::Middleware::Validate,
+        validator: Validators::StreamingOperationInput,
+        validate_input: options.fetch(:validate_input, @validate_input)
+      )
+      stack.use(Hearth::Middleware::Build,
+        builder: Builders::StreamingOperation
+      )
+      stack.use(Hearth::HTTP::Middleware::ContentLength)
+      stack.use(Hearth::Middleware::Parse,
+        error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
+        data_parser: Parsers::StreamingOperation
+      )
+      stack.use(Hearth::Middleware::Send,
+        stub_responses: options.fetch(:stub_responses, @stub_responses),
+        client: Hearth::HTTP::Client.new(logger: @logger, http_wire_trace: options.fetch(:http_wire_trace, @http_wire_trace)),
+        stub_class: Stubs::StreamingOperation,
+        params_class: Params::StreamingOperationOutput,
+        stubs: options.fetch(:stubs, @stubs)
+      )
+      apply_middleware(stack, options[:middleware])
+
+      resp = stack.run(
+        input: input,
+        context: Hearth::Context.new(
+          request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
+          response: Hearth::HTTP::Response.new(body: response_body),
+          params: params,
+          logger: @logger,
+          operation_name: :streaming_operation
+        )
+      )
+      raise resp.error if resp.error
+      resp
+    end
+
+    # @param [Hash] params
     #   See {Types::WaitersTestInput}.
     #
     # @return [Types::WaitersTestOutput]

--- a/codegen/projections/white_label/lib/white_label/client.rb
+++ b/codegen/projections/white_label/lib/white_label/client.rb
@@ -103,6 +103,7 @@ module WhiteLabel
     def defaults_test(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::DefaultsTestInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::DefaultsTestInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -128,7 +129,7 @@ module WhiteLabel
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :defaults_test
@@ -330,6 +331,7 @@ module WhiteLabel
     def kitchen_sink(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::KitchenSinkInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::KitchenSinkInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -355,7 +357,7 @@ module WhiteLabel
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :kitchen_sink
@@ -386,6 +388,7 @@ module WhiteLabel
     def paginators_test(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::PaginatorsTestOperationInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::PaginatorsTestOperationInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -411,7 +414,7 @@ module WhiteLabel
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :paginators_test
@@ -442,6 +445,7 @@ module WhiteLabel
     def paginators_test_with_items(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::PaginatorsTestWithItemsInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::PaginatorsTestWithItemsInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -467,7 +471,7 @@ module WhiteLabel
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :paginators_test_with_items
@@ -496,6 +500,7 @@ module WhiteLabel
     def waiters_test(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::WaitersTestInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::WaitersTestInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -521,7 +526,7 @@ module WhiteLabel
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :waiters_test
@@ -553,6 +558,7 @@ module WhiteLabel
     def operation____paginators_test_with_bad_names(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
       input = Params::Struct____PaginatorsTestWithBadNamesInput.build(params)
+      response_body = StringIO.new
       stack.use(Hearth::Middleware::Validate,
         validator: Validators::Struct____PaginatorsTestWithBadNamesInput,
         validate_input: options.fetch(:validate_input, @validate_input)
@@ -578,7 +584,7 @@ module WhiteLabel
         input: input,
         context: Hearth::Context.new(
           request: Hearth::HTTP::Request.new(url: options.fetch(:endpoint, @endpoint)),
-          response: Hearth::HTTP::Response.new(body: output_stream(options, &block)),
+          response: Hearth::HTTP::Response.new(body: response_body),
           params: params,
           logger: @logger,
           operation_name: :operation____paginators_test_with_bad_names

--- a/codegen/projections/white_label/lib/white_label/client.rb
+++ b/codegen/projections/white_label/lib/white_label/client.rb
@@ -508,7 +508,6 @@ module WhiteLabel
       stack.use(Hearth::Middleware::Build,
         builder: Builders::StreamingOperation
       )
-      stack.use(Hearth::HTTP::Middleware::ContentLength)
       stack.use(Hearth::Middleware::Parse,
         error_parser: Hearth::HTTP::ErrorParser.new(error_module: Errors, success_status: 200, errors: []),
         data_parser: Parsers::StreamingOperation

--- a/codegen/projections/white_label/lib/white_label/client.rb
+++ b/codegen/projections/white_label/lib/white_label/client.rb
@@ -489,13 +489,13 @@ module WhiteLabel
     # @example Request syntax with placeholder values
     #
     #   resp = client.streaming_operation(
-    #     output: 'output'
+    #     stream: 'stream'
     #   )
     #
     # @example Response structure
     #
     #   resp.data #=> Types::StreamingOperationOutput
-    #   resp.data.output #=> String
+    #   resp.data.stream #=> String
     #
     def streaming_operation(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new

--- a/codegen/projections/white_label/lib/white_label/params.rb
+++ b/codegen/projections/white_label/lib/white_label/params.rb
@@ -226,6 +226,27 @@ module WhiteLabel
       end
     end
 
+    module StreamingWithLengthInput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::StreamingWithLengthInput, context: context)
+        type = Types::StreamingWithLengthInput.new
+        io = params[:stream] || StringIO.new
+        unless io.respond_to?(:read) || io.respond_to?(:readpartial)
+          io = StringIO.new(io)
+        end
+        type.stream = io
+        type
+      end
+    end
+
+    module StreamingWithLengthOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::StreamingWithLengthOutput, context: context)
+        type = Types::StreamingWithLengthOutput.new
+        type
+      end
+    end
+
     module Struct
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::Struct, context: context)

--- a/codegen/projections/white_label/lib/white_label/params.rb
+++ b/codegen/projections/white_label/lib/white_label/params.rb
@@ -204,7 +204,11 @@ module WhiteLabel
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::StreamingOperationInput, context: context)
         type = Types::StreamingOperationInput.new
-        type.output = params[:output]
+        io = params[:stream] || StringIO.new
+        unless io.respond_to?(:read) || io.respond_to?(:readpartial)
+          io = StringIO.new(io)
+        end
+        type.stream = io
         type
       end
     end
@@ -213,7 +217,11 @@ module WhiteLabel
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::StreamingOperationOutput, context: context)
         type = Types::StreamingOperationOutput.new
-        type.output = params[:output]
+        io = params[:stream] || StringIO.new
+        unless io.respond_to?(:read) || io.respond_to?(:readpartial)
+          io = StringIO.new(io)
+        end
+        type.stream = io
         type
       end
     end

--- a/codegen/projections/white_label/lib/white_label/params.rb
+++ b/codegen/projections/white_label/lib/white_label/params.rb
@@ -200,6 +200,24 @@ module WhiteLabel
       end
     end
 
+    module StreamingOperationInput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::StreamingOperationInput, context: context)
+        type = Types::StreamingOperationInput.new
+        type.output = params[:output]
+        type
+      end
+    end
+
+    module StreamingOperationOutput
+      def self.build(params, context: '')
+        Hearth::Validator.validate!(params, ::Hash, Types::StreamingOperationOutput, context: context)
+        type = Types::StreamingOperationOutput.new
+        type.output = params[:output]
+        type
+      end
+    end
+
     module Struct
       def self.build(params, context: '')
         Hearth::Validator.validate!(params, ::Hash, Types::Struct, context: context)

--- a/codegen/projections/white_label/lib/white_label/parsers.rb
+++ b/codegen/projections/white_label/lib/white_label/parsers.rb
@@ -93,6 +93,14 @@ module WhiteLabel
       end
     end
 
+    # Operation Parser for StreamingWithLength
+    class StreamingWithLength
+      def self.parse(http_resp)
+        data = Types::StreamingWithLengthOutput.new
+        data
+      end
+    end
+
     # Operation Parser for WaitersTest
     class WaitersTest
       def self.parse(http_resp)

--- a/codegen/projections/white_label/lib/white_label/parsers.rb
+++ b/codegen/projections/white_label/lib/white_label/parsers.rb
@@ -88,7 +88,7 @@ module WhiteLabel
     class StreamingOperation
       def self.parse(http_resp)
         data = Types::StreamingOperationOutput.new
-        data.output = http_resp.body
+        data.stream = http_resp.body
         data
       end
     end

--- a/codegen/projections/white_label/lib/white_label/parsers.rb
+++ b/codegen/projections/white_label/lib/white_label/parsers.rb
@@ -88,6 +88,7 @@ module WhiteLabel
     class StreamingOperation
       def self.parse(http_resp)
         data = Types::StreamingOperationOutput.new
+        data.output = http_resp.body
         data
       end
     end

--- a/codegen/projections/white_label/lib/white_label/parsers.rb
+++ b/codegen/projections/white_label/lib/white_label/parsers.rb
@@ -84,6 +84,14 @@ module WhiteLabel
       end
     end
 
+    # Operation Parser for StreamingOperation
+    class StreamingOperation
+      def self.parse(http_resp)
+        data = Types::StreamingOperationOutput.new
+        data
+      end
+    end
+
     # Operation Parser for WaitersTest
     class WaitersTest
       def self.parse(http_resp)

--- a/codegen/projections/white_label/lib/white_label/stubs.rb
+++ b/codegen/projections/white_label/lib/white_label/stubs.rb
@@ -184,6 +184,19 @@ module WhiteLabel
       end
     end
 
+    # Operation Stubber for StreamingOperation
+    class StreamingOperation
+      def self.default(visited=[])
+        {
+          output: 'output',
+        }
+      end
+
+      def self.stub(http_resp, stub:)
+        data = {}
+      end
+    end
+
     # Operation Stubber for WaitersTest
     class WaitersTest
       def self.default(visited=[])

--- a/codegen/projections/white_label/lib/white_label/stubs.rb
+++ b/codegen/projections/white_label/lib/white_label/stubs.rb
@@ -194,6 +194,8 @@ module WhiteLabel
 
       def self.stub(http_resp, stub:)
         data = {}
+        stub_io = stub[:output] === String ? StringIO.new(stub[:output]) : stub[:output]
+        IO.copy_stream(stub_io, http_resp.body)
       end
     end
 

--- a/codegen/projections/white_label/lib/white_label/stubs.rb
+++ b/codegen/projections/white_label/lib/white_label/stubs.rb
@@ -194,7 +194,7 @@ module WhiteLabel
 
       def self.stub(http_resp, stub:)
         data = {}
-        stub_io = stub[:output] === String ? StringIO.new(stub[:output]) : stub[:output]
+        stub_io = String === stub[:output] ? StringIO.new(stub[:output]) : stub[:output]
         IO.copy_stream(stub_io, http_resp.body)
       end
     end

--- a/codegen/projections/white_label/lib/white_label/stubs.rb
+++ b/codegen/projections/white_label/lib/white_label/stubs.rb
@@ -194,7 +194,8 @@ module WhiteLabel
 
       def self.stub(http_resp, stub:)
         data = {}
-        stub_io = String === stub[:output] ? StringIO.new(stub[:output]) : stub[:output]
+        stub_io = stub[:output] || ''
+        stub_io = String === stub_io ? StringIO.new(stub_io) : stub_io
         IO.copy_stream(stub_io, http_resp.body)
       end
     end

--- a/codegen/projections/white_label/lib/white_label/stubs.rb
+++ b/codegen/projections/white_label/lib/white_label/stubs.rb
@@ -188,15 +188,13 @@ module WhiteLabel
     class StreamingOperation
       def self.default(visited=[])
         {
-          output: 'output',
+          stream: 'stream',
         }
       end
 
       def self.stub(http_resp, stub:)
         data = {}
-        stub_io = stub[:output] || ''
-        stub_io = String === stub_io ? StringIO.new(stub_io) : stub_io
-        IO.copy_stream(stub_io, http_resp.body)
+        IO.copy_stream(stub[:stream], http_resp.body)
       end
     end
 

--- a/codegen/projections/white_label/lib/white_label/stubs.rb
+++ b/codegen/projections/white_label/lib/white_label/stubs.rb
@@ -198,6 +198,18 @@ module WhiteLabel
       end
     end
 
+    # Operation Stubber for StreamingWithLength
+    class StreamingWithLength
+      def self.default(visited=[])
+        {
+        }
+      end
+
+      def self.stub(http_resp, stub:)
+        data = {}
+      end
+    end
+
     # Operation Stubber for WaitersTest
     class WaitersTest
       def self.default(visited=[])

--- a/codegen/projections/white_label/lib/white_label/types.rb
+++ b/codegen/projections/white_label/lib/white_label/types.rb
@@ -427,23 +427,23 @@ module WhiteLabel
       include Hearth::Structure
     end
 
-    # @!attribute output
+    # @!attribute stream
     #
     #   @return [String]
     #
     StreamingOperationInput = ::Struct.new(
-      :output,
+      :stream,
       keyword_init: true
     ) do
       include Hearth::Structure
     end
 
-    # @!attribute output
+    # @!attribute stream
     #
     #   @return [String]
     #
     StreamingOperationOutput = ::Struct.new(
-      :output,
+      :stream,
       keyword_init: true
     ) do
       include Hearth::Structure

--- a/codegen/projections/white_label/lib/white_label/types.rb
+++ b/codegen/projections/white_label/lib/white_label/types.rb
@@ -427,6 +427,28 @@ module WhiteLabel
       include Hearth::Structure
     end
 
+    # @!attribute output
+    #
+    #   @return [String]
+    #
+    StreamingOperationInput = ::Struct.new(
+      :output,
+      keyword_init: true
+    ) do
+      include Hearth::Structure
+    end
+
+    # @!attribute output
+    #
+    #   @return [String]
+    #
+    StreamingOperationOutput = ::Struct.new(
+      :output,
+      keyword_init: true
+    ) do
+      include Hearth::Structure
+    end
+
     # This docstring should be different than KitchenSink struct member.
     #
     # @deprecated

--- a/codegen/projections/white_label/lib/white_label/types.rb
+++ b/codegen/projections/white_label/lib/white_label/types.rb
@@ -449,6 +449,24 @@ module WhiteLabel
       include Hearth::Structure
     end
 
+    # @!attribute stream
+    #
+    #   @return [String]
+    #
+    StreamingWithLengthInput = ::Struct.new(
+      :stream,
+      keyword_init: true
+    ) do
+      include Hearth::Structure
+    end
+
+    StreamingWithLengthOutput = ::Struct.new(
+      nil,
+      keyword_init: true
+    ) do
+      include Hearth::Structure
+    end
+
     # This docstring should be different than KitchenSink struct member.
     #
     # @deprecated

--- a/codegen/projections/white_label/lib/white_label/validators.rb
+++ b/codegen/projections/white_label/lib/white_label/validators.rb
@@ -185,14 +185,18 @@ module WhiteLabel
     class StreamingOperationInput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::StreamingOperationInput, context: context)
-        Hearth::Validator.validate!(input[:output], ::String, context: "#{context}[:output]")
+        unless input[:stream].respond_to?(:read) || input[:stream].respond_to?(:readpartial)
+          raise ArgumentError, "Expected #{context} to be an IO like object, got #{input[:stream].class}"
+        end
       end
     end
 
     class StreamingOperationOutput
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::StreamingOperationOutput, context: context)
-        Hearth::Validator.validate!(input[:output], ::String, context: "#{context}[:output]")
+        unless input[:stream].respond_to?(:read) || input[:stream].respond_to?(:readpartial)
+          raise ArgumentError, "Expected #{context} to be an IO like object, got #{input[:stream].class}"
+        end
       end
     end
 

--- a/codegen/projections/white_label/lib/white_label/validators.rb
+++ b/codegen/projections/white_label/lib/white_label/validators.rb
@@ -182,6 +182,20 @@ module WhiteLabel
       end
     end
 
+    class StreamingOperationInput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::StreamingOperationInput, context: context)
+        Hearth::Validator.validate!(input[:output], ::String, context: "#{context}[:output]")
+      end
+    end
+
+    class StreamingOperationOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::StreamingOperationOutput, context: context)
+        Hearth::Validator.validate!(input[:output], ::String, context: "#{context}[:output]")
+      end
+    end
+
     class Struct
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::Struct, context: context)

--- a/codegen/projections/white_label/lib/white_label/validators.rb
+++ b/codegen/projections/white_label/lib/white_label/validators.rb
@@ -200,6 +200,25 @@ module WhiteLabel
       end
     end
 
+    class StreamingWithLengthInput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::StreamingWithLengthInput, context: context)
+        unless input[:stream].respond_to?(:read) || input[:stream].respond_to?(:readpartial)
+          raise ArgumentError, "Expected #{context} to be an IO like object, got #{input[:stream].class}"
+        end
+
+        unless input[:stream].respond_to?(:size)
+          raise ArgumentError, "Expected #{context} to respond_to(:size)"
+        end
+      end
+    end
+
+    class StreamingWithLengthOutput
+      def self.validate!(input, context:)
+        Hearth::Validator.validate!(input, Types::StreamingWithLengthOutput, context: context)
+      end
+    end
+
     class Struct
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::Struct, context: context)

--- a/codegen/projections/white_label/sig/white_label/client.rbs
+++ b/codegen/projections/white_label/sig/white_label/client.rbs
@@ -19,6 +19,7 @@ module WhiteLabel
     def paginators_test: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
     def paginators_test_with_items: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
     def streaming_operation: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
+    def streaming_with_length: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
     def waiters_test: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
     def operation____paginators_test_with_bad_names: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
 

--- a/codegen/projections/white_label/sig/white_label/client.rbs
+++ b/codegen/projections/white_label/sig/white_label/client.rbs
@@ -18,6 +18,7 @@ module WhiteLabel
     def kitchen_sink: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
     def paginators_test: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
     def paginators_test_with_items: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
+    def streaming_operation: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
     def waiters_test: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
     def operation____paginators_test_with_bad_names: (?::Hash[untyped, untyped] params, ?::Hash[untyped, untyped] options){ () -> untyped } -> untyped
 

--- a/codegen/projections/white_label/sig/white_label/types.rbs
+++ b/codegen/projections/white_label/sig/white_label/types.rbs
@@ -32,6 +32,10 @@ module WhiteLabel
 
     ServerError: untyped
 
+    StreamingOperationInput: untyped
+
+    StreamingOperationOutput: untyped
+
     Struct: untyped
 
     class Union < Hearth::Union

--- a/codegen/projections/white_label/sig/white_label/types.rbs
+++ b/codegen/projections/white_label/sig/white_label/types.rbs
@@ -36,6 +36,10 @@ module WhiteLabel
 
     StreamingOperationOutput: untyped
 
+    StreamingWithLengthInput: untyped
+
+    StreamingWithLengthOutput: untyped
+
     Struct: untyped
 
     class Union < Hearth::Union

--- a/codegen/projections/white_label/spec/client_spec.rb
+++ b/codegen/projections/white_label/spec/client_spec.rb
@@ -83,37 +83,5 @@ module WhiteLabel
         client.kitchen_sink
       end
     end
-
-    describe '#streaming_operation' do
-      context 'block is provided' do
-        let(:block_io) { double("BlockIO") }
-        it 'creates and uses a blockIO as the body' do
-          client = Client.new(stub_responses: true)
-
-          expect(Hearth::BlockIO).to receive(:new).and_return(block_io)
-
-          expect(Hearth::HTTP::Response)
-            .to receive(:new)
-                  .with(hash_including(body: block_io))
-                  .and_call_original
-
-          client.streaming_operation { |resp| resp }
-        end
-      end
-
-      context 'output_stream is set' do
-        let(:output_stream) { double("OutputStream") }
-        it 'uses the output_stream as the body' do
-          client = Client.new(stub_responses: true)
-
-          expect(Hearth::HTTP::Response)
-            .to receive(:new)
-                  .with(hash_including(body: output_stream))
-                  .and_call_original
-
-          client.streaming_operation({}, output_stream: output_stream)
-        end
-      end
-    end
   end
 end

--- a/codegen/projections/white_label/spec/client_spec.rb
+++ b/codegen/projections/white_label/spec/client_spec.rb
@@ -82,7 +82,9 @@ module WhiteLabel
 
         client.kitchen_sink
       end
+    end
 
+    describe '#streaming_operation' do
       context 'block is provided' do
         let(:block_io) { double("BlockIO") }
         it 'creates and uses a blockIO as the body' do
@@ -95,7 +97,7 @@ module WhiteLabel
                   .with(hash_including(body: block_io))
                   .and_call_original
 
-          client.kitchen_sink { |resp| resp }
+          client.streaming_operation { |resp| resp }
         end
       end
 
@@ -109,7 +111,7 @@ module WhiteLabel
                   .with(hash_including(body: output_stream))
                   .and_call_original
 
-          client.kitchen_sink({}, output_stream: output_stream)
+          client.streaming_operation({}, output_stream: output_stream)
         end
       end
     end

--- a/codegen/projections/white_label/spec/errors_spec.rb
+++ b/codegen/projections/white_label/spec/errors_spec.rb
@@ -64,6 +64,13 @@ module WhiteLabel
         expect(error).to be_a(ApiClientError)
         expect(error.message).to eq('error message')
       end
+
+      it 'is retryable without throttling' do
+        http_resp = Hearth::HTTP::Response.new
+        error = ClientError.new(http_resp: http_resp, metadata: {}, error_code: 'error')
+        expect(error.retryable?).to be true
+        expect(error.throttling?).to be false
+      end
     end
 
     describe ServerError do
@@ -76,6 +83,13 @@ module WhiteLabel
         expect(error.data).to eq(data)
         expect(error).to be_a(ApiServerError)
         expect(error.message).to eq("WhiteLabel::Errors::ServerError")
+      end
+
+      it 'is retryable with throttling' do
+        http_resp = Hearth::HTTP::Response.new
+        error = ServerError.new(http_resp: http_resp, metadata: {}, error_code: 'error')
+        expect(error.retryable?).to be true
+        expect(error.throttling?).to be true
       end
     end
   end

--- a/codegen/projections/white_label/spec/params_spec.rb
+++ b/codegen/projections/white_label/spec/params_spec.rb
@@ -159,5 +159,29 @@ module WhiteLabel
           .to raise_error(ArgumentError, /Expected params to have one of/)
       end
     end
+
+    describe StreamingOperationInput do
+
+      it 'converts a string to StringIO' do
+        data = StreamingOperationInput.build({stream: 'string'}, context: 'params')
+        expect(data).to be_a(Types::StreamingOperationInput)
+        expect(data.stream).to be_a(StringIO)
+        expect(data.stream.read).to eq('string')
+      end
+
+      it 'converts a nil to an empty StringIO' do
+        data = StreamingOperationInput.build({stream: nil}, context: 'params')
+        expect(data).to be_a(Types::StreamingOperationInput)
+        expect(data.stream).to be_a(StringIO)
+        expect(data.stream.read).to eq('')
+      end
+
+      it 'does not convert a readable, io like object' do
+        stream = double("stream", read: 'chunk')
+        data = StreamingOperationInput.build({stream: stream}, context: 'params')
+        expect(data).to be_a(Types::StreamingOperationInput)
+        expect(data.stream).to be(stream)
+      end
+    end
   end
 end

--- a/codegen/projections/white_label/spec/protocol_spec.rb
+++ b/codegen/projections/white_label/spec/protocol_spec.rb
@@ -37,6 +37,10 @@ module WhiteLabel
 
     end
 
+    describe '#streaming_operation' do
+
+    end
+
     describe '#waiters_test' do
 
     end

--- a/codegen/projections/white_label/spec/protocol_spec.rb
+++ b/codegen/projections/white_label/spec/protocol_spec.rb
@@ -41,6 +41,10 @@ module WhiteLabel
 
     end
 
+    describe '#streaming_with_length' do
+
+    end
+
     describe '#waiters_test' do
 
     end

--- a/codegen/projections/white_label/spec/types_spec.rb
+++ b/codegen/projections/white_label/spec/types_spec.rb
@@ -60,7 +60,6 @@ module WhiteLabel
     end
 
     describe DefaultsTestInput do
-      subject { DefaultsTestInput.new }
 
       it 'has a default value for default_number' do
         expect(subject.default_number).to be 0

--- a/codegen/projections/white_label/spec/validators_spec.rb
+++ b/codegen/projections/white_label/spec/validators_spec.rb
@@ -223,7 +223,7 @@ module WhiteLabel
       it 'validates responds_to(:size)' do
         stream = double("stream", read: 'data')
         expect { StreamingWithLengthInput.validate!(Types::StreamingWithLengthInput.new(stream: stream), context: 'input') }
-          .to raise_error(ArgumentError, "Expected input to be an IO like object, got String")
+          .to raise_error(ArgumentError, "Expected input to respond_to(:size)")
       end
     end
   end

--- a/codegen/projections/white_label/spec/validators_spec.rb
+++ b/codegen/projections/white_label/spec/validators_spec.rb
@@ -218,5 +218,13 @@ module WhiteLabel
           .to raise_error(ArgumentError, "Expected input to be an IO like object, got String")
       end
     end
+
+    describe StreamingWithLengthInput do
+      it 'validates responds_to(:size)' do
+        stream = double("stream", read: 'data')
+        expect { StreamingWithLengthInput.validate!(Types::StreamingWithLengthInput.new(stream: stream), context: 'input') }
+          .to raise_error(ArgumentError, "Expected input to be an IO like object, got String")
+      end
+    end
   end
 end

--- a/codegen/projections/white_label/spec/validators_spec.rb
+++ b/codegen/projections/white_label/spec/validators_spec.rb
@@ -211,5 +211,12 @@ module WhiteLabel
           )
       end
     end
+
+    describe StreamingOperationInput do
+      it 'validates io like' do
+        expect { StreamingOperationInput.validate!(Types::StreamingOperationInput.new(stream: ""), context: 'input') }
+          .to raise_error(ArgumentError, "Expected input to be an IO like object, got String")
+      end
+    end
   end
 end

--- a/codegen/smithy-ruby-codegen-test/integration-specs/client_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/client_spec.rb
@@ -83,37 +83,5 @@ module WhiteLabel
         client.kitchen_sink
       end
     end
-
-    describe '#streaming_operation' do
-      context 'block is provided' do
-        let(:block_io) { double("BlockIO") }
-        it 'creates and uses a blockIO as the body' do
-          client = Client.new(stub_responses: true)
-
-          expect(Hearth::BlockIO).to receive(:new).and_return(block_io)
-
-          expect(Hearth::HTTP::Response)
-            .to receive(:new)
-                  .with(hash_including(body: block_io))
-                  .and_call_original
-
-          client.streaming_operation { |resp| resp }
-        end
-      end
-
-      context 'output_stream is set' do
-        let(:output_stream) { double("OutputStream") }
-        it 'uses the output_stream as the body' do
-          client = Client.new(stub_responses: true)
-
-          expect(Hearth::HTTP::Response)
-            .to receive(:new)
-                  .with(hash_including(body: output_stream))
-                  .and_call_original
-
-          client.streaming_operation({}, output_stream: output_stream)
-        end
-      end
-    end
   end
 end

--- a/codegen/smithy-ruby-codegen-test/integration-specs/client_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/client_spec.rb
@@ -82,7 +82,9 @@ module WhiteLabel
 
         client.kitchen_sink
       end
+    end
 
+    describe '#streaming_operation' do
       context 'block is provided' do
         let(:block_io) { double("BlockIO") }
         it 'creates and uses a blockIO as the body' do
@@ -95,7 +97,7 @@ module WhiteLabel
                   .with(hash_including(body: block_io))
                   .and_call_original
 
-          client.kitchen_sink { |resp| resp }
+          client.streaming_operation { |resp| resp }
         end
       end
 
@@ -109,7 +111,7 @@ module WhiteLabel
                   .with(hash_including(body: output_stream))
                   .and_call_original
 
-          client.kitchen_sink({}, output_stream: output_stream)
+          client.streaming_operation({}, output_stream: output_stream)
         end
       end
     end

--- a/codegen/smithy-ruby-codegen-test/integration-specs/params_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/params_spec.rb
@@ -159,5 +159,29 @@ module WhiteLabel
           .to raise_error(ArgumentError, /Expected params to have one of/)
       end
     end
+
+    describe StreamingOperationInput do
+
+      it 'converts a string to StringIO' do
+        data = StreamingOperationInput.build({stream: 'string'}, context: 'params')
+        expect(data).to be_a(Types::StreamingOperationInput)
+        expect(data.stream).to be_a(StringIO)
+        expect(data.stream.read).to eq('string')
+      end
+
+      it 'converts a nil to an empty StringIO' do
+        data = StreamingOperationInput.build({stream: nil}, context: 'params')
+        expect(data).to be_a(Types::StreamingOperationInput)
+        expect(data.stream).to be_a(StringIO)
+        expect(data.stream.read).to eq('')
+      end
+
+      it 'does not convert a readable, io like object' do
+        stream = double("stream", read: 'chunk')
+        data = StreamingOperationInput.build({stream: stream}, context: 'params')
+        expect(data).to be_a(Types::StreamingOperationInput)
+        expect(data.stream).to be(stream)
+      end
+    end
   end
 end

--- a/codegen/smithy-ruby-codegen-test/integration-specs/streaming_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/streaming_spec.rb
@@ -3,15 +3,21 @@ require_relative 'spec_helper'
 
 module WhiteLabel
   describe Client do
-
     describe '#streaming_operation' do
-      context 'block is provided' do
-        let(:block_io) { double("BlockIO") }
-        it 'creates and uses a blockIO as the body' do
-          client = Client.new(stub_responses: true)
+      let(:client) { Client.new(stub_responses:  true) }
+      let(:output) { 'test' }
 
+      before do
+        client.stub_responses(:streaming_operation, { output: output} )
+      end
+
+      context 'block is provided' do
+
+        let(:block_io) { double("BlockIO") }
+
+        it 'creates and uses a blockIO as the body' do
           expect(Hearth::BlockIO).to receive(:new).and_return(block_io)
-          expect(block_io).to receive(:write).and_return(0)
+          expect(block_io).to receive(:write).with(output).and_return(0)
 
           expect(Hearth::HTTP::Response)
             .to receive(:new)
@@ -25,14 +31,13 @@ module WhiteLabel
       context 'output_stream is set' do
         let(:output_stream) { double("OutputStream") }
         it 'uses the output_stream as the body' do
-          client = Client.new(stub_responses: true)
 
           expect(Hearth::HTTP::Response)
             .to receive(:new)
                   .with(hash_including(body: output_stream))
                   .and_call_original
 
-          expect(output_stream).to receive(:write).and_return(0)
+          expect(output_stream).to receive(:write).with(output).and_return(0)
           client.streaming_operation({}, output_stream: output_stream)
         end
       end

--- a/codegen/smithy-ruby-codegen-test/integration-specs/streaming_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/streaming_spec.rb
@@ -59,6 +59,29 @@ module WhiteLabel
           expect(resp.data.output).to be(output_stream)
         end
       end
+
+      context 'stubs' do
+        let(:output_stream) { double("OutputStream") }
+
+        it 'copies the stub to the output stream' do
+          middleware = Hearth::MiddlewareBuilder.after_send do |_, context|
+            expect(context.response.body).to be(output_stream)
+          end
+          expect(output_stream).to receive(:write).with(output).and_return(0)
+          client.streaming_operation({}, output_stream: output_stream, middleware: middleware)
+        end
+
+        context('nil stub value') do
+          let(:output) { nil }
+
+          it 'streams an empty body' do
+            expect(output_stream).not_to receive(:write)
+            client.streaming_operation({}, output_stream: output_stream)
+          end
+        end
+
+      end
+
     end
   end
 end

--- a/codegen/smithy-ruby-codegen-test/integration-specs/streaming_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/streaming_spec.rb
@@ -8,7 +8,7 @@ module WhiteLabel
       let(:output) { 'test' }
 
       before do
-        client.stub_responses(:streaming_operation, { output: output} )
+        client.stub_responses(:streaming_operation, { stream: output} )
       end
 
       context 'block is provided' do
@@ -56,7 +56,7 @@ module WhiteLabel
 
         it 'sets the field on the output' do
           resp = client.streaming_operation({}, output_stream: output_stream)
-          expect(resp.data.output).to be(output_stream)
+          expect(resp.data.stream).to be(output_stream)
         end
       end
 
@@ -79,7 +79,28 @@ module WhiteLabel
             client.streaming_operation({}, output_stream: output_stream)
           end
         end
+      end
 
+      # TODO: create an operation with @requireLength
+
+      context 'builders' do
+        it 'sets the body to the streaming member' do
+          streaming_input = StringIO.new("test")
+          middleware = Hearth::MiddlewareBuilder.before_send do |_, context|
+            expect(context.request.body).to be(streaming_input)
+          end
+          expect(streaming_input).not_to receive(:read)
+          client.streaming_operation({stream: streaming_input}, middleware: middleware)
+        end
+
+        it 'does not set content length' do
+          streaming_input = StringIO.new("test")
+          middleware = Hearth::MiddlewareBuilder.before_send do |_, context|
+            expect(context.request.headers.key?('Content-Length')).to be_falsy
+          end
+          expect(streaming_input).not_to receive(:size)
+          client.streaming_operation({stream: streaming_input}, middleware: middleware)
+        end
       end
 
     end

--- a/codegen/smithy-ruby-codegen-test/integration-specs/streaming_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/streaming_spec.rb
@@ -81,8 +81,6 @@ module WhiteLabel
         end
       end
 
-      # TODO: create an operation with @requireLength
-
       context 'builders' do
         it 'sets the body to the streaming member' do
           streaming_input = StringIO.new("test")
@@ -102,7 +100,18 @@ module WhiteLabel
           client.streaming_operation({stream: streaming_input}, middleware: middleware)
         end
       end
+    end
 
+    describe '#streaming_with_length' do
+      let(:client) { Client.new(stub_responses:  true) }
+      let(:data) { 'test' }
+
+      it 'sets content-length' do
+        middleware = Hearth::MiddlewareBuilder.before_send do |_, context|
+          expect(context.request.headers['Content-Length']).to eq(data.length.to_s)
+        end
+        client.streaming_with_length({stream: data}, middleware: middleware)
+      end
     end
   end
 end

--- a/codegen/smithy-ruby-codegen-test/integration-specs/streaming_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/streaming_spec.rb
@@ -1,0 +1,41 @@
+
+require_relative 'spec_helper'
+
+module WhiteLabel
+  describe Client do
+
+    describe '#streaming_operation' do
+      context 'block is provided' do
+        let(:block_io) { double("BlockIO") }
+        it 'creates and uses a blockIO as the body' do
+          client = Client.new(stub_responses: true)
+
+          expect(Hearth::BlockIO).to receive(:new).and_return(block_io)
+          expect(block_io).to receive(:write).and_return(0)
+
+          expect(Hearth::HTTP::Response)
+            .to receive(:new)
+                  .with(hash_including(body: block_io))
+                  .and_call_original
+
+          client.streaming_operation { |resp| resp }
+        end
+      end
+
+      context 'output_stream is set' do
+        let(:output_stream) { double("OutputStream") }
+        it 'uses the output_stream as the body' do
+          client = Client.new(stub_responses: true)
+
+          expect(Hearth::HTTP::Response)
+            .to receive(:new)
+                  .with(hash_including(body: output_stream))
+                  .and_call_original
+
+          expect(output_stream).to receive(:write).and_return(0)
+          client.streaming_operation({}, output_stream: output_stream)
+        end
+      end
+    end
+  end
+end

--- a/codegen/smithy-ruby-codegen-test/integration-specs/streaming_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/streaming_spec.rb
@@ -41,6 +41,24 @@ module WhiteLabel
           client.streaming_operation({}, output_stream: output_stream)
         end
       end
+
+      context 'parsers' do
+        let(:output_stream) { double("OutputStream") }
+
+        before do
+          expect(output_stream).to receive(:write).and_return(0)
+        end
+
+        it 'does not read the body' do
+          expect(output_stream).not_to receive(:read)
+          client.streaming_operation({}, output_stream: output_stream)
+        end
+
+        it 'sets the field on the output' do
+          resp = client.streaming_operation({}, output_stream: output_stream)
+          expect(resp.data.output).to be(output_stream)
+        end
+      end
     end
   end
 end

--- a/codegen/smithy-ruby-codegen-test/integration-specs/streaming_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/streaming_spec.rb
@@ -91,9 +91,10 @@ module WhiteLabel
           client.streaming_operation({stream: streaming_input}, middleware: middleware)
         end
 
-        it 'does not set content length' do
+        it 'sets Transfer-Encoding and does not set content length' do
           streaming_input = StringIO.new("test")
           middleware = Hearth::MiddlewareBuilder.before_send do |_, context|
+            expect(context.request.headers['Transfer-Encoding']).to eq('chunked')
             expect(context.request.headers.key?('Content-Length')).to be_falsy
           end
           expect(streaming_input).not_to receive(:size)
@@ -106,9 +107,10 @@ module WhiteLabel
       let(:client) { Client.new(stub_responses:  true) }
       let(:data) { 'test' }
 
-      it 'sets content-length' do
+      it 'sets content-length and does not set Transfer-Encoding' do
         middleware = Hearth::MiddlewareBuilder.before_send do |_, context|
           expect(context.request.headers['Content-Length']).to eq(data.length.to_s)
+          expect(context.request.headers.key?('Transfer-Encoding')).to be_falsy
         end
         client.streaming_with_length({stream: data}, middleware: middleware)
       end

--- a/codegen/smithy-ruby-codegen-test/integration-specs/validators_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/validators_spec.rb
@@ -211,5 +211,12 @@ module WhiteLabel
           )
       end
     end
+
+    describe StreamingOperationInput do
+      it 'validates io like' do
+        expect { StreamingOperationInput.validate!(Types::StreamingOperationInput.new(stream: ""), context: 'input') }
+          .to raise_error(ArgumentError, "Expected input to be an IO like object, got String")
+      end
+    end
   end
 end

--- a/codegen/smithy-ruby-codegen-test/integration-specs/validators_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/validators_spec.rb
@@ -218,5 +218,13 @@ module WhiteLabel
           .to raise_error(ArgumentError, "Expected input to be an IO like object, got String")
       end
     end
+
+    describe StreamingWithLengthInput do
+      it 'validates responds_to(:size)' do
+        stream = double("stream", read: 'data')
+        expect { StreamingWithLengthInput.validate!(Types::StreamingWithLengthInput.new(stream: stream), context: 'input') }
+          .to raise_error(ArgumentError, "Expected input to respond_to(:size)")
+      end
+    end
   end
 end

--- a/codegen/smithy-ruby-codegen-test/model/component-test/main.smithy
+++ b/codegen/smithy-ruby-codegen-test/model/component-test/main.smithy
@@ -13,7 +13,8 @@ service WhiteLabel {
         PaginatorsTestWithItems,
         __PaginatorsTestWithBadNames,
         WaitersTest,
-        DefaultsTest
+        DefaultsTest,
+        StreamingOperation
     ]
 }
 

--- a/codegen/smithy-ruby-codegen-test/model/component-test/main.smithy
+++ b/codegen/smithy-ruby-codegen-test/model/component-test/main.smithy
@@ -14,7 +14,8 @@ service WhiteLabel {
         __PaginatorsTestWithBadNames,
         WaitersTest,
         DefaultsTest,
-        StreamingOperation
+        StreamingOperation,
+        StreamingWithLength,
     ]
 }
 

--- a/codegen/smithy-ruby-codegen-test/model/component-test/streaming.smithy
+++ b/codegen/smithy-ruby-codegen-test/model/component-test/streaming.smithy
@@ -1,0 +1,21 @@
+$version: "1.0"
+namespace smithy.ruby.tests
+
+operation StreamingOperation {
+    input: StreamingOperationInput,
+    output: StreamingOperationOutput,
+}
+
+@input
+structure StreamingOperationInput {
+    output: StreamingBlob,
+}
+
+@output
+structure StreamingOperationOutput {
+    @httpPayload
+    output: StreamingBlob,
+}
+
+@streaming
+blob StreamingBlob

--- a/codegen/smithy-ruby-codegen-test/model/component-test/streaming.smithy
+++ b/codegen/smithy-ruby-codegen-test/model/component-test/streaming.smithy
@@ -20,3 +20,17 @@ structure StreamingOperationOutput {
 
 @streaming
 blob StreamingBlob
+
+operation StreamingWithLength {
+    input: StreamingWithLengthInput,
+}
+
+@input
+structure StreamingWithLengthInput {
+    @httpPayload
+    stream: FiniteStreamingBlob,
+}
+
+@streaming
+@requiresLength
+blob FiniteStreamingBlob

--- a/codegen/smithy-ruby-codegen-test/model/component-test/streaming.smithy
+++ b/codegen/smithy-ruby-codegen-test/model/component-test/streaming.smithy
@@ -8,13 +8,14 @@ operation StreamingOperation {
 
 @input
 structure StreamingOperationInput {
-    output: StreamingBlob,
+    @httpPayload
+    stream: StreamingBlob,
 }
 
 @output
 structure StreamingOperationOutput {
     @httpPayload
-    output: StreamingBlob,
+    stream: StreamingBlob,
 }
 
 @streaming

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/ApplicationTransport.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/ApplicationTransport.java
@@ -25,10 +25,12 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.HttpChecksumRequiredTrait;
 import software.amazon.smithy.model.traits.HttpTrait;
 import software.amazon.smithy.ruby.codegen.middleware.Middleware;
 import software.amazon.smithy.ruby.codegen.middleware.MiddlewareStackStep;
+import software.amazon.smithy.ruby.codegen.util.Streaming;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
 
@@ -127,6 +129,15 @@ public final class ApplicationTransport {
             List<Middleware> middleware = new ArrayList();
             middleware.add((new Middleware.Builder())
                     .klass("Hearth::HTTP::Middleware::ContentLength")
+                    .operationPredicate(
+                            (model, service, operation) ->
+                                    !Streaming.isNonFiniteStreaming(model,
+                                            model.expectShape(
+                                                    operation.getInputShape(),
+                                                    StructureShape.class
+                                            )
+                                    )
+                    )
                     .step(MiddlewareStackStep.BUILD)
                     .build()
             );

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/ApplicationTransport.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/ApplicationTransport.java
@@ -89,7 +89,7 @@ public final class ApplicationTransport {
                 .build();
 
         ClientFragment response = (new ClientFragment.Builder())
-                .render((self, ctx) -> "Hearth::HTTP::Response.new(body: output_stream(options, &block))")
+                .render((self, ctx) -> "Hearth::HTTP::Response.new(body: response_body)")
                 .build();
 
         ClientConfig wireTrace = (new ClientConfig.Builder())

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/BuilderGeneratorBase.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/BuilderGeneratorBase.java
@@ -268,6 +268,10 @@ public abstract class BuilderGeneratorBase {
         LOGGER.finer("Generated operation builder for: " + operation.getId().getName());
     }
 
+    protected void renderStubBodyBuilder(String dataGetter) {
+
+    }
+
     protected class BuilderClassGenerator extends ShapeVisitor.Default<Void> {
 
         @Override

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/BuilderGeneratorBase.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/BuilderGeneratorBase.java
@@ -39,6 +39,7 @@ import software.amazon.smithy.ruby.codegen.GenerationContext;
 import software.amazon.smithy.ruby.codegen.RubyCodeWriter;
 import software.amazon.smithy.ruby.codegen.RubySettings;
 import software.amazon.smithy.ruby.codegen.RubySymbolProvider;
+import software.amazon.smithy.ruby.codegen.util.Streaming;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
@@ -235,6 +236,7 @@ public abstract class BuilderGeneratorBase {
         Set<OperationShape> containedOperations = new TreeSet<>(
                 topDownIndex.getContainedOperations(context.service()));
         containedOperations.stream()
+                .filter((o) -> !Streaming.isEventStreaming(model, o))
                 .sorted(Comparator.comparing((o) -> o.getId().getName()))
                 .forEach(o -> {
                     Shape inputShape = model.expectShape(o.getInputShape());

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ClientGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ClientGenerator.java
@@ -39,6 +39,7 @@ import software.amazon.smithy.ruby.codegen.RubySettings;
 import software.amazon.smithy.ruby.codegen.RubySymbolProvider;
 import software.amazon.smithy.ruby.codegen.generators.docs.ShapeDocumentationGenerator;
 import software.amazon.smithy.ruby.codegen.middleware.MiddlewareBuilder;
+import software.amazon.smithy.ruby.codegen.util.Streaming;
 import software.amazon.smithy.utils.SmithyInternalApi;
 import software.amazon.smithy.utils.StringUtils;
 
@@ -228,6 +229,7 @@ public class ClientGenerator {
         Set<OperationShape> containedOperations = new TreeSet<>(
                 topDownIndex.getContainedOperations(context.service()));
         containedOperations.stream()
+                .filter((o) -> !Streaming.isEventStreaming(model, o))
                 .sorted(Comparator.comparing((o) -> o.getId().getName()))
                 .forEach(o -> renderOperation(o));
     }

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ClientGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ClientGenerator.java
@@ -30,6 +30,7 @@ import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.ruby.codegen.ClientConfig;
 import software.amazon.smithy.ruby.codegen.GenerationContext;
 import software.amazon.smithy.ruby.codegen.RubyCodeWriter;
@@ -246,6 +247,7 @@ public class ClientGenerator {
         Symbol symbol = symbolProvider.toSymbol(operation);
         ShapeId inputShapeId = operation.getInputShape();
         Shape inputShape = model.expectShape(inputShapeId);
+        Shape outputShape = model.expectShape(operation.getOutputShape());
         String operationName =
                 RubyFormatter.toSnakeCase(symbol.getName());
 
@@ -257,6 +259,14 @@ public class ClientGenerator {
                 .openBlock("def $L(params = {}, options = {}, &block)", operationName)
                 .write("stack = Hearth::MiddlewareStack.new")
                 .write("input = Params::$L.build(params)", symbolProvider.toSymbol(inputShape).getName())
+                .call(() -> {
+                    if (outputShape.members().stream()
+                            .anyMatch((m) -> m.getMemberTrait(model, StreamingTrait.class).isPresent())) {
+                       writer.write("response_body = output_stream(options, &block)");
+                    } else {
+                        writer.write("response_body = StringIO.new");
+                    }
+                })
                 .call(() -> middlewareBuilder
                         .render(writer, context, operation))
                 .write("apply_middleware(stack, options[:middleware])\n")

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ParserGeneratorBase.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ParserGeneratorBase.java
@@ -40,6 +40,7 @@ import software.amazon.smithy.ruby.codegen.GenerationContext;
 import software.amazon.smithy.ruby.codegen.RubyCodeWriter;
 import software.amazon.smithy.ruby.codegen.RubySettings;
 import software.amazon.smithy.ruby.codegen.RubySymbolProvider;
+import software.amazon.smithy.ruby.codegen.util.Streaming;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
 /**
@@ -255,6 +256,7 @@ public abstract class ParserGeneratorBase {
         Set<OperationShape> containedOperations = new TreeSet<>(
                 topDownIndex.getContainedOperations(context.service()));
         containedOperations.stream()
+                .filter((o) -> !Streaming.isEventStreaming(model, o))
                 .sorted(Comparator.comparing((o) -> o.getId().getName()))
                 .forEach(o -> {
                     Shape outputShape = model.expectShape(o.getOutputShape());

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ParserGeneratorBase.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ParserGeneratorBase.java
@@ -313,6 +313,17 @@ public abstract class ParserGeneratorBase {
         LOGGER.finer("Generated Error parser for " + s.getId().getName());
     }
 
+    @FunctionalInterface
+    public interface DataSetter {
+        /**
+         * Given a memberShape, return the appropriate data setter.
+         *
+         * @param memberShape memberShape to generate data setter for.
+         * @return dataSetter (eg `data.value = `)
+         */
+        String dataSetter(MemberShape memberShape);
+    }
+
     protected void renderStreamingBodyParser(Shape outputShape, DataSetter p) {
         MemberShape streamingMember = outputShape.members().stream()
                 .filter((m) -> m.getMemberTrait(model, StreamingTrait.class).isPresent())
@@ -324,17 +335,6 @@ public abstract class ParserGeneratorBase {
     protected void renderStreamingBodyParser(String dataSetter) {
         writer.write("$Lhttp_resp.body", dataSetter); // do NOT read the body when streaming
 
-    }
-
-    @FunctionalInterface
-    public interface DataSetter {
-        /**
-         * Given a memberShape, return the appropriate data setter.
-         *
-         * @param memberShape memberShape to generate data setter for.
-         * @return dataSetter (eg `data.value = `)
-         */
-        String dataSetter(MemberShape memberShape);
     }
 
     private class ParserClassGenerator extends ShapeVisitor.Default<Void> {

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ParserGeneratorBase.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ParserGeneratorBase.java
@@ -28,6 +28,7 @@ import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.neighbor.Walker;
 import software.amazon.smithy.model.shapes.ListShape;
 import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.SetShape;
 import software.amazon.smithy.model.shapes.Shape;
@@ -36,6 +37,7 @@ import software.amazon.smithy.model.shapes.ShapeVisitor;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.ErrorTrait;
+import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.ruby.codegen.GenerationContext;
 import software.amazon.smithy.ruby.codegen.RubyCodeWriter;
 import software.amazon.smithy.ruby.codegen.RubySettings;
@@ -309,6 +311,30 @@ public abstract class ParserGeneratorBase {
                 .call(() -> renderErrorParseMethod(s))
                 .closeBlock("end");
         LOGGER.finer("Generated Error parser for " + s.getId().getName());
+    }
+
+    protected void renderStreamingBodyParser(Shape outputShape, DataSetter p) {
+        MemberShape streamingMember = outputShape.members().stream()
+                .filter((m) -> m.getMemberTrait(model, StreamingTrait.class).isPresent())
+                .findFirst().get();
+
+        renderStreamingBodyParser(p.dataSetter(streamingMember));
+    }
+
+    protected void renderStreamingBodyParser(String dataSetter) {
+        writer.write("$Lhttp_resp.body", dataSetter); // do NOT read the body when streaming
+
+    }
+
+    @FunctionalInterface
+    public interface DataSetter {
+        /**
+         * Given a memberShape, return the appropriate data setter.
+         *
+         * @param memberShape memberShape to generate data setter for.
+         * @return dataSetter (eg `data.value = `)
+         */
+        String dataSetter(MemberShape memberShape);
     }
 
     private class ParserClassGenerator extends ShapeVisitor.Default<Void> {

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/StubsGeneratorBase.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/StubsGeneratorBase.java
@@ -286,6 +286,13 @@ public abstract class StubsGeneratorBase {
         writer.closeBlock("}");
     }
 
+    protected void renderStreamingStub(String dataGetter) {
+        writer
+                .write("stub_io = $L || ''", dataGetter)
+                .write("stub_io = String === stub_io ? StringIO.new(stub_io) : stub_io")
+                .write("IO.copy_stream(stub_io, http_resp.body)");
+    }
+
     private class StubClassGenerator extends ShapeVisitor.Default<Void> {
 
         @Override

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/StubsGeneratorBase.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/StubsGeneratorBase.java
@@ -287,10 +287,7 @@ public abstract class StubsGeneratorBase {
     }
 
     protected void renderStreamingStub(String dataGetter) {
-        writer
-                .write("stub_io = $L || ''", dataGetter)
-                .write("stub_io = String === stub_io ? StringIO.new(stub_io) : stub_io")
-                .write("IO.copy_stream(stub_io, http_resp.body)");
+        writer.write("IO.copy_stream($L, http_resp.body)", dataGetter);
     }
 
     private class StubClassGenerator extends ShapeVisitor.Default<Void> {

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ValidatorsGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ValidatorsGenerator.java
@@ -42,6 +42,7 @@ import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.RequiresLengthTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.model.transform.ModelTransformer;
 import software.amazon.smithy.ruby.codegen.GenerationContext;
@@ -290,6 +291,12 @@ public class ValidatorsGenerator extends ShapeVisitor.Default<Void> {
                         .write("raise ArgumentError, \"Expected #{context} to be an IO like object,"
                                 + " got #{$L.class}\"", input)
                         .closeBlock("end");
+                if (shape.hasTrait(RequiresLengthTrait.class)) {
+                    writer
+                            .openBlock("\nunless $1L.respond_to?(:size)", input)
+                            .write("raise ArgumentError, \"Expected #{context} to respond_to(:size)\"")
+                            .closeBlock("end");
+                }
             } else {
                 writer.write("Hearth::Validator.validate!($L, ::String, context: $L)", input, context);
             }

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/test/protocol/fakeprotocol/generators/BuilderGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/test/protocol/fakeprotocol/generators/BuilderGenerator.java
@@ -15,44 +15,29 @@
 
 package software.amazon.smithy.ruby.codegen.test.protocol.fakeprotocol.generators;
 
-import software.amazon.smithy.codegen.core.Symbol;
 import software.amazon.smithy.model.shapes.ListShape;
 import software.amazon.smithy.model.shapes.MapShape;
-import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.SetShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.ruby.codegen.GenerationContext;
-import software.amazon.smithy.ruby.codegen.generators.RestBuilderGeneratorBase;
+import software.amazon.smithy.ruby.codegen.generators.BuilderGeneratorBase;
+import software.amazon.smithy.ruby.codegen.util.Streaming;
 
-public class BuilderGenerator extends RestBuilderGeneratorBase {
+public class BuilderGenerator extends BuilderGeneratorBase {
     public BuilderGenerator(GenerationContext context) {
         super(context);
     }
 
     @Override
-    protected void renderBuildersForOperation(OperationShape operation, Shape inputShape) {
-        Symbol symbol = symbolProvider.toSymbol(operation);
-        writer
-                .write("")
-                .write("# Operation Builder for $L", operation.getId().getName())
-                .openBlock("class $L", symbol.getName())
-                .openBlock("def self.build(http_req, input:)")
-                .closeBlock("end")
-                .closeBlock("end");
-    }
-
-    @Override
-    protected void renderPayloadBodyBuilder(OperationShape operation, Shape inputShape, MemberShape payloadMember,
-                                            Shape target) {
-
-    }
-
-    @Override
-    protected void renderBodyBuilder(OperationShape operation, Shape inputShape) {
-
+    protected void renderOperationBuildMethod(OperationShape operation, Shape inputShape) {
+        writer.openBlock("def self.build(http_req, input:)");
+        if (Streaming.isStreaming(model, inputShape)) {
+            renderStreamingBodyBuilder(inputShape);
+        }
+        writer.closeBlock("end");
     }
 
     @Override

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/test/protocol/fakeprotocol/generators/ParserGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/test/protocol/fakeprotocol/generators/ParserGenerator.java
@@ -22,6 +22,7 @@ import software.amazon.smithy.model.shapes.SetShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.ruby.codegen.GenerationContext;
 import software.amazon.smithy.ruby.codegen.generators.RestParserGeneratorBase;
 
@@ -33,7 +34,9 @@ public class ParserGenerator extends RestParserGeneratorBase {
 
     @Override
     protected void renderPayloadBodyParser(Shape outputShape, MemberShape payloadMember, Shape target) {
-
+        if (target.hasTrait(StreamingTrait.class)) {
+            writer.write("data.$L = http_resp.body", symbolProvider.toMemberName(payloadMember));
+        }
     }
 
     @Override

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/test/protocol/fakeprotocol/generators/ParserGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/test/protocol/fakeprotocol/generators/ParserGenerator.java
@@ -35,7 +35,8 @@ public class ParserGenerator extends RestParserGeneratorBase {
     @Override
     protected void renderPayloadBodyParser(Shape outputShape, MemberShape payloadMember, Shape target) {
         if (target.hasTrait(StreamingTrait.class)) {
-            writer.write("data.$L = http_resp.body", symbolProvider.toMemberName(payloadMember));
+            String dataSetter = writer.format("data.$L = ", symbolProvider.toMemberName(payloadMember));
+            renderStreamingBodyParser(dataSetter);
         }
     }
 

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/test/protocol/fakeprotocol/generators/StubsGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/test/protocol/fakeprotocol/generators/StubsGenerator.java
@@ -26,7 +26,6 @@ import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.ruby.codegen.GenerationContext;
 import software.amazon.smithy.ruby.codegen.generators.RestStubsGeneratorBase;
-import software.amazon.smithy.ruby.codegen.util.Streaming;
 
 public class StubsGenerator extends RestStubsGeneratorBase {
 
@@ -65,7 +64,7 @@ public class StubsGenerator extends RestStubsGeneratorBase {
         if (target.hasTrait(StreamingTrait.class)) {
             String symbolName = ":" + symbolProvider.toMemberName(payloadMember);
             String inputGetter = "stub[" + symbolName + "]";
-            Streaming.renderStreamingStub(writer, inputGetter);
+            renderStreamingStub(inputGetter);
         }
     }
 

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/test/protocol/fakeprotocol/generators/StubsGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/test/protocol/fakeprotocol/generators/StubsGenerator.java
@@ -23,8 +23,10 @@ import software.amazon.smithy.model.shapes.SetShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.ruby.codegen.GenerationContext;
 import software.amazon.smithy.ruby.codegen.generators.RestStubsGeneratorBase;
+import software.amazon.smithy.ruby.codegen.util.Streaming;
 
 public class StubsGenerator extends RestStubsGeneratorBase {
 
@@ -60,7 +62,11 @@ public class StubsGenerator extends RestStubsGeneratorBase {
     @Override
     protected void renderPayloadBodyStub(OperationShape operation, Shape outputShape, MemberShape payloadMember,
                                          Shape target) {
-
+        if (target.hasTrait(StreamingTrait.class)) {
+            String symbolName = ":" + symbolProvider.toMemberName(payloadMember);
+            String inputGetter = "stub[" + symbolName + "]";
+            Streaming.renderStreamingStub(writer, inputGetter);
+        }
     }
 
     @Override

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/util/Streaming.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/util/Streaming.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.ruby.codegen.util;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.traits.StreamingTrait;
+import software.amazon.smithy.ruby.codegen.RubyCodeWriter;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
@@ -41,5 +42,11 @@ public final class Streaming {
                 .stream()
                 .anyMatch((m) ->
                         m.getMemberTrait(model, StreamingTrait.class).isPresent());
+    }
+
+    public static void renderStreamingStub(RubyCodeWriter writer, String dataGetter) {
+        writer
+                .write("stub_io = $1L === String ? StringIO.new($1L) : $1L", dataGetter)
+                .write("IO.copy_stream(stub_io, http_resp.body)");
     }
 }

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/util/Streaming.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/util/Streaming.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.ruby.codegen.util;
+
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.OperationShape;
+import software.amazon.smithy.model.traits.StreamingTrait;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Utility methods related to Streaming.
+ */
+@SmithyInternalApi
+public final class Streaming {
+    private Streaming() {
+    }
+
+    public static boolean isEventStreaming(Model model, OperationShape operationShape) {
+        return operationShape.members()
+                .stream()
+                .anyMatch((m) ->
+                        m.getMemberTrait(model, StreamingTrait.class).isPresent()
+                                && model.expectShape(m.getTarget()).isUnionShape());
+    }
+
+    public static boolean isStreaming(Model model, OperationShape operationShape) {
+        return operationShape.members()
+                .stream()
+                .anyMatch((m) ->
+                        m.getMemberTrait(model, StreamingTrait.class).isPresent());
+    }
+}

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/util/Streaming.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/util/Streaming.java
@@ -46,7 +46,7 @@ public final class Streaming {
 
     public static void renderStreamingStub(RubyCodeWriter writer, String dataGetter) {
         writer
-                .write("stub_io = $1L === String ? StringIO.new($1L) : $1L", dataGetter)
+                .write("stub_io = String === $1L ? StringIO.new($1L) : $1L", dataGetter)
                 .write("IO.copy_stream(stub_io, http_resp.body)");
     }
 }

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/util/Streaming.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/util/Streaming.java
@@ -40,9 +40,7 @@ public final class Streaming {
     public static boolean isEventStreaming(Model model, Shape inputOrOutput) {
         return inputOrOutput.members()
                 .stream()
-                .anyMatch((m) ->
-                        m.getMemberTrait(model, StreamingTrait.class).isPresent()
-                                && model.expectShape(m.getTarget()).isUnionShape());
+                .anyMatch((m) -> StreamingTrait.isEventStream(model, m));
     }
 
     public static boolean isStreaming(Model model, Shape inputOrOutput) {

--- a/codegen/smithy-ruby-rails-codegen-test/model/protocol-test/main.smithy
+++ b/codegen/smithy-ruby-rails-codegen-test/model/protocol-test/main.smithy
@@ -47,6 +47,7 @@ service RailsJson {
         HttpResponseCode,
         __789BadName,
         NestedAttributesOperation,
+        StreamingOperation
     ],
 }
 

--- a/codegen/smithy-ruby-rails-codegen-test/model/protocol-test/streaming.smithy
+++ b/codegen/smithy-ruby-rails-codegen-test/model/protocol-test/streaming.smithy
@@ -1,0 +1,24 @@
+$version: "1.0"
+
+namespace smithy.ruby.protocoltests.railsjson
+
+@http(method: "POST", uri: "/streamingoperation")
+operation StreamingOperation {
+    input: StreamingOperationInput,
+    output: StreamingOperationOutput,
+}
+
+@input
+structure StreamingOperationInput {
+    @httpPayload
+    output: StreamingBlob,
+}
+
+@output
+structure StreamingOperationOutput {
+    @httpPayload
+    output: StreamingBlob,
+}
+
+@streaming
+blob StreamingBlob

--- a/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/protocol/railsjson/generators/BuilderGenerator.java
+++ b/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/protocol/railsjson/generators/BuilderGenerator.java
@@ -40,6 +40,7 @@ import software.amazon.smithy.model.traits.HttpQueryParamsTrait;
 import software.amazon.smithy.model.traits.HttpQueryTrait;
 import software.amazon.smithy.model.traits.JsonNameTrait;
 import software.amazon.smithy.model.traits.MediaTypeTrait;
+import software.amazon.smithy.model.traits.RequiresLengthTrait;
 import software.amazon.smithy.model.traits.SparseTrait;
 import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait;
@@ -88,7 +89,7 @@ public class BuilderGenerator extends RestBuilderGeneratorBase {
         String symbolName = ":" + symbolProvider.toMemberName(payloadMember);
         String inputGetter = "input[" + symbolName + "]";
         if (target.hasTrait(StreamingTrait.class)) {
-            renderStreamingBodyBuilder(inputGetter);
+            renderStreamingBodyBuilder(inputGetter, target.hasTrait(RequiresLengthTrait.class));
         } else {
             target.accept(new PayloadMemberSerializer(payloadMember, inputGetter));
         }

--- a/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/protocol/railsjson/generators/BuilderGenerator.java
+++ b/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/protocol/railsjson/generators/BuilderGenerator.java
@@ -41,6 +41,7 @@ import software.amazon.smithy.model.traits.HttpQueryTrait;
 import software.amazon.smithy.model.traits.JsonNameTrait;
 import software.amazon.smithy.model.traits.MediaTypeTrait;
 import software.amazon.smithy.model.traits.SparseTrait;
+import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait;
 import software.amazon.smithy.ruby.codegen.GenerationContext;
 import software.amazon.smithy.ruby.codegen.RubyFormatter;
@@ -86,7 +87,11 @@ public class BuilderGenerator extends RestBuilderGeneratorBase {
                                             Shape target) {
         String symbolName = ":" + symbolProvider.toMemberName(payloadMember);
         String inputGetter = "input[" + symbolName + "]";
-        target.accept(new PayloadMemberSerializer(payloadMember, inputGetter));
+        if (target.hasTrait(StreamingTrait.class)) {
+            renderStreamingBodyBuilder(inputGetter);
+        } else {
+            target.accept(new PayloadMemberSerializer(payloadMember, inputGetter));
+        }
     }
 
     @Override

--- a/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/protocol/railsjson/generators/ParserGenerator.java
+++ b/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/protocol/railsjson/generators/ParserGenerator.java
@@ -37,6 +37,7 @@ import software.amazon.smithy.model.traits.HttpQueryTrait;
 import software.amazon.smithy.model.traits.HttpResponseCodeTrait;
 import software.amazon.smithy.model.traits.JsonNameTrait;
 import software.amazon.smithy.model.traits.SparseTrait;
+import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait;
 import software.amazon.smithy.ruby.codegen.GenerationContext;
 import software.amazon.smithy.ruby.codegen.RubyFormatter;
@@ -316,9 +317,13 @@ public class ParserGenerator extends RestParserGeneratorBase {
 
         @Override
         public Void blobShape(BlobShape shape) {
-            writer
-                    .write("payload = http_resp.body.read")
-                    .write("$Lpayload unless payload.empty?", dataSetter);
+            if (shape.hasTrait(StreamingTrait.class)) {
+                writer.write("$Lhttp_resp.body", dataSetter); // do NOT read the body when streaming
+            } else {
+                writer
+                        .write("payload = http_resp.body.read")
+                        .write("$Lpayload unless payload.empty?", dataSetter);
+            }
             return null;
         }
 

--- a/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/protocol/railsjson/generators/ParserGenerator.java
+++ b/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/protocol/railsjson/generators/ParserGenerator.java
@@ -318,7 +318,7 @@ public class ParserGenerator extends RestParserGeneratorBase {
         @Override
         public Void blobShape(BlobShape shape) {
             if (shape.hasTrait(StreamingTrait.class)) {
-                writer.write("$Lhttp_resp.body", dataSetter); // do NOT read the body when streaming
+                renderStreamingBodyParser(dataSetter);
             } else {
                 writer
                         .write("payload = http_resp.body.read")

--- a/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/protocol/railsjson/generators/StubsGenerator.java
+++ b/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/protocol/railsjson/generators/StubsGenerator.java
@@ -44,7 +44,6 @@ import software.amazon.smithy.ruby.codegen.GenerationContext;
 import software.amazon.smithy.ruby.codegen.RubyFormatter;
 import software.amazon.smithy.ruby.codegen.generators.RestStubsGeneratorBase;
 import software.amazon.smithy.ruby.codegen.trait.NoSerializeTrait;
-import software.amazon.smithy.ruby.codegen.util.Streaming;
 import software.amazon.smithy.ruby.codegen.util.TimestampFormat;
 
 public class StubsGenerator extends RestStubsGeneratorBase {
@@ -322,7 +321,7 @@ public class StubsGenerator extends RestStubsGeneratorBase {
         @Override
         public Void blobShape(BlobShape shape) {
             if (shape.hasTrait(StreamingTrait.class)) {
-                Streaming.renderStreamingStub(writer, inputGetter);
+                renderStreamingStub(inputGetter);
             } else {
                 Optional<MediaTypeTrait> mediaTypeTrait = shape.getTrait(MediaTypeTrait.class);
                 String mediaType = "application/octet-stream";

--- a/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/protocol/railsjson/generators/StubsGenerator.java
+++ b/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/protocol/railsjson/generators/StubsGenerator.java
@@ -38,11 +38,13 @@ import software.amazon.smithy.model.traits.HttpQueryTrait;
 import software.amazon.smithy.model.traits.JsonNameTrait;
 import software.amazon.smithy.model.traits.MediaTypeTrait;
 import software.amazon.smithy.model.traits.SparseTrait;
+import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.model.traits.TimestampFormatTrait;
 import software.amazon.smithy.ruby.codegen.GenerationContext;
 import software.amazon.smithy.ruby.codegen.RubyFormatter;
 import software.amazon.smithy.ruby.codegen.generators.RestStubsGeneratorBase;
 import software.amazon.smithy.ruby.codegen.trait.NoSerializeTrait;
+import software.amazon.smithy.ruby.codegen.util.Streaming;
 import software.amazon.smithy.ruby.codegen.util.TimestampFormat;
 
 public class StubsGenerator extends RestStubsGeneratorBase {
@@ -108,7 +110,6 @@ public class StubsGenerator extends RestStubsGeneratorBase {
                 .closeBlock("end")
                 .write("data")
                 .closeBlock("end");
-
     }
 
     @Override
@@ -320,15 +321,19 @@ public class StubsGenerator extends RestStubsGeneratorBase {
 
         @Override
         public Void blobShape(BlobShape shape) {
-            Optional<MediaTypeTrait> mediaTypeTrait = shape.getTrait(MediaTypeTrait.class);
-            String mediaType = "application/octet-stream";
-            if (mediaTypeTrait.isPresent()) {
-                mediaType = mediaTypeTrait.get().getValue();
-            }
+            if (shape.hasTrait(StreamingTrait.class)) {
+                Streaming.renderStreamingStub(writer, inputGetter);
+            } else {
+                Optional<MediaTypeTrait> mediaTypeTrait = shape.getTrait(MediaTypeTrait.class);
+                String mediaType = "application/octet-stream";
+                if (mediaTypeTrait.isPresent()) {
+                    mediaType = mediaTypeTrait.get().getValue();
+                }
 
-            writer
-                    .write("http_resp.headers['Content-Type'] = '$L'", mediaType)
-                    .write("http_resp.body = StringIO.new($L || '')", inputGetter);
+                writer
+                        .write("http_resp.headers['Content-Type'] = '$L'", mediaType)
+                        .write("http_resp.body = StringIO.new($L || '')", inputGetter);
+            }
             return null;
         }
 


### PR DESCRIPTION
*Description of changes:*
Output Streaming:
- Set the response body to output_stream only on streaming operations.
- In parsers, we need to NOT read the body.  In protocols that support @httpPaylaod, @streaming can only be applied to payload members and must be on a blob.  (@streaming on a union is event streaming and will be handled differently).  

TODO:
Input streaming:
- Modify builders, add support
- Modify content length
- Modify validators


Testing:
We don't get coverage of streaming behavior from protocol tests so we'll need to add some integration tests.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
