### PR TITLE
Support enums as constants with documentation

### DIFF
--- a/codegen/projections/rails_json/lib/rails_json/client.rb
+++ b/codegen/projections/rails_json/lib/rails_json/client.rb
@@ -101,9 +101,9 @@ module RailsJson
     #     query_timestamp_list: [
     #       Time.now
     #     ],
-    #     query_enum: 'Foo', # accepts Foo, Baz, Bar, 1, 0
+    #     query_enum: 'Foo', # accepts ["Foo", "Baz", "Bar", "1", "0"]
     #     query_enum_list: [
-    #       'Foo' # accepts Foo, Baz, Bar, 1, 0
+    #       'Foo' # accepts ["Foo", "Baz", "Bar", "1", "0"]
     #     ],
     #     query_params_map_of_strings: {
     #       'key' => 'value'
@@ -1324,9 +1324,9 @@ module RailsJson
     #     header_timestamp_list: [
     #       Time.now
     #     ],
-    #     header_enum: 'Foo', # accepts Foo, Baz, Bar, 1, 0
+    #     header_enum: 'Foo', # accepts ["Foo", "Baz", "Bar", "1", "0"]
     #     header_enum_list: [
-    #       'Foo' # accepts Foo, Baz, Bar, 1, 0
+    #       'Foo' # accepts ["Foo", "Baz", "Bar", "1", "0"]
     #     ]
     #   )
     #
@@ -1352,9 +1352,9 @@ module RailsJson
     #   resp.data.header_boolean_list[0] #=> Boolean
     #   resp.data.header_timestamp_list #=> Array<Time>
     #   resp.data.header_timestamp_list[0] #=> Time
-    #   resp.data.header_enum #=> String, one of Foo, Baz, Bar, 1, 0
+    #   resp.data.header_enum #=> String, one of ["Foo", "Baz", "Bar", "1", "0"]
     #   resp.data.header_enum_list #=> Array<String>
-    #   resp.data.header_enum_list[0] #=> String, one of Foo, Baz, Bar, 1, 0
+    #   resp.data.header_enum_list[0] #=> String, one of ["Foo", "Baz", "Bar", "1", "0"]
     #
     def input_and_output_with_headers(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -1405,32 +1405,32 @@ module RailsJson
     # @example Request syntax with placeholder values
     #
     #   resp = client.json_enums(
-    #     foo_enum1: 'Foo', # accepts Foo, Baz, Bar, 1, 0
-    #     foo_enum2: 'Foo', # accepts Foo, Baz, Bar, 1, 0
-    #     foo_enum3: 'Foo', # accepts Foo, Baz, Bar, 1, 0
+    #     foo_enum1: 'Foo', # accepts ["Foo", "Baz", "Bar", "1", "0"]
+    #     foo_enum2: 'Foo', # accepts ["Foo", "Baz", "Bar", "1", "0"]
+    #     foo_enum3: 'Foo', # accepts ["Foo", "Baz", "Bar", "1", "0"]
     #     foo_enum_list: [
-    #       'Foo' # accepts Foo, Baz, Bar, 1, 0
+    #       'Foo' # accepts ["Foo", "Baz", "Bar", "1", "0"]
     #     ],
     #     foo_enum_set: [
-    #       'Foo' # accepts Foo, Baz, Bar, 1, 0
+    #       'Foo' # accepts ["Foo", "Baz", "Bar", "1", "0"]
     #     ],
     #     foo_enum_map: {
-    #       'key' => 'Foo' # accepts Foo, Baz, Bar, 1, 0
+    #       'key' => 'Foo' # accepts ["Foo", "Baz", "Bar", "1", "0"]
     #     }
     #   )
     #
     # @example Response structure
     #
     #   resp.data #=> Types::JsonEnumsOutput
-    #   resp.data.foo_enum1 #=> String, one of Foo, Baz, Bar, 1, 0
-    #   resp.data.foo_enum2 #=> String, one of Foo, Baz, Bar, 1, 0
-    #   resp.data.foo_enum3 #=> String, one of Foo, Baz, Bar, 1, 0
+    #   resp.data.foo_enum1 #=> String, one of ["Foo", "Baz", "Bar", "1", "0"]
+    #   resp.data.foo_enum2 #=> String, one of ["Foo", "Baz", "Bar", "1", "0"]
+    #   resp.data.foo_enum3 #=> String, one of ["Foo", "Baz", "Bar", "1", "0"]
     #   resp.data.foo_enum_list #=> Array<String>
-    #   resp.data.foo_enum_list[0] #=> String, one of Foo, Baz, Bar, 1, 0
+    #   resp.data.foo_enum_list[0] #=> String, one of ["Foo", "Baz", "Bar", "1", "0"]
     #   resp.data.foo_enum_set #=> Set<String>
-    #   resp.data.foo_enum_set[0] #=> String, one of Foo, Baz, Bar, 1, 0
+    #   resp.data.foo_enum_set[0] #=> String, one of ["Foo", "Baz", "Bar", "1", "0"]
     #   resp.data.foo_enum_map #=> Hash<String, String>
-    #   resp.data.foo_enum_map['key'] #=> String, one of Foo, Baz, Bar, 1, 0
+    #   resp.data.foo_enum_map['key'] #=> String, one of ["Foo", "Baz", "Bar", "1", "0"]
     #
     def json_enums(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new
@@ -1594,7 +1594,7 @@ module RailsJson
     #       number_value: 1,
     #       blob_value: 'blobValue',
     #       timestamp_value: Time.now,
-    #       enum_value: 'Foo', # accepts Foo, Baz, Bar, 1, 0
+    #       enum_value: 'Foo', # accepts ["Foo", "Baz", "Bar", "1", "0"]
     #       list_value: [
     #         'member'
     #       ],

--- a/codegen/projections/rails_json/lib/rails_json/types.rb
+++ b/codegen/projections/rails_json/lib/rails_json/types.rb
@@ -75,6 +75,7 @@ module RailsJson
     #   @return [Array<Time>]
     #
     # @!attribute query_enum
+    #   Enum, one of: ["Foo", "Baz", "Bar", "1", "0"]
     #
     #   @return [String]
     #
@@ -342,6 +343,30 @@ module RailsJson
       keyword_init: true
     ) do
       include Hearth::Structure
+    end
+
+    # Enum, one of: ["Foo", "Baz", "Bar", "1", "0"]
+    #
+    module FooEnum
+      # No documentation available.
+      #
+      FOO = "Foo"
+
+      # No documentation available.
+      #
+      BAZ = "Baz"
+
+      # No documentation available.
+      #
+      BAR = "Bar"
+
+      # No documentation available.
+      #
+      ONE = "1"
+
+      # No documentation available.
+      #
+      ZERO = "0"
     end
 
     # @!attribute hi
@@ -751,6 +776,7 @@ module RailsJson
     #   @return [Array<Time>]
     #
     # @!attribute header_enum
+    #   Enum, one of: ["Foo", "Baz", "Bar", "1", "0"]
     #
     #   @return [String]
     #
@@ -837,6 +863,7 @@ module RailsJson
     #   @return [Array<Time>]
     #
     # @!attribute header_enum
+    #   Enum, one of: ["Foo", "Baz", "Bar", "1", "0"]
     #
     #   @return [String]
     #
@@ -880,14 +907,17 @@ module RailsJson
     end
 
     # @!attribute foo_enum1
+    #   Enum, one of: ["Foo", "Baz", "Bar", "1", "0"]
     #
     #   @return [String]
     #
     # @!attribute foo_enum2
+    #   Enum, one of: ["Foo", "Baz", "Bar", "1", "0"]
     #
     #   @return [String]
     #
     # @!attribute foo_enum3
+    #   Enum, one of: ["Foo", "Baz", "Bar", "1", "0"]
     #
     #   @return [String]
     #
@@ -916,14 +946,17 @@ module RailsJson
     end
 
     # @!attribute foo_enum1
+    #   Enum, one of: ["Foo", "Baz", "Bar", "1", "0"]
     #
     #   @return [String]
     #
     # @!attribute foo_enum2
+    #   Enum, one of: ["Foo", "Baz", "Bar", "1", "0"]
     #
     #   @return [String]
     #
     # @!attribute foo_enum3
+    #   Enum, one of: ["Foo", "Baz", "Bar", "1", "0"]
     #
     #   @return [String]
     #
@@ -1575,6 +1608,8 @@ module RailsJson
         end
       end
 
+      # Enum, one of: ["Foo", "Baz", "Bar", "1", "0"]
+      #
       class EnumValue < MyUnion
         def to_h
           { enum_value: super(__getobj__) }

--- a/codegen/projections/rails_json/lib/rails_json/types.rb
+++ b/codegen/projections/rails_json/lib/rails_json/types.rb
@@ -345,7 +345,7 @@ module RailsJson
       include Hearth::Structure
     end
 
-    # Enum, one of: ["Foo", "Baz", "Bar", "1", "0"]
+    # Includes enum constants for FooEnum
     #
     module FooEnum
       # No documentation available.

--- a/codegen/projections/rails_json/sig/rails_json/types.rbs
+++ b/codegen/projections/rails_json/sig/rails_json/types.rbs
@@ -52,6 +52,18 @@ module RailsJson
 
     ErrorWithoutMembers: untyped
 
+    module FooEnum
+      FOO: ::String
+
+      BAZ: ::String
+
+      BAR: ::String
+
+      ONE: ::String
+
+      ZERO: ::String
+    end
+
     GreetingStruct: untyped
 
     GreetingWithErrorsInput: untyped

--- a/codegen/projections/weather/lib/weather/client.rb
+++ b/codegen/projections/weather/lib/weather/client.rb
@@ -360,7 +360,7 @@ module Weather
     #     boxed_bool: false,
     #     default_number: 1,
     #     boxed_number: 1,
-    #     some_enum: 'YES', # accepts YES, NO
+    #     some_enum: 'YES', # accepts ["YES", "NO"]
     #     page_size: 1
     #   )
     #
@@ -368,7 +368,7 @@ module Weather
     #
     #   resp.data #=> Types::ListCitiesOutput
     #   resp.data.next_token #=> String
-    #   resp.data.some_enum #=> String, one of YES, NO
+    #   resp.data.some_enum #=> String, one of ["YES", "NO"]
     #   resp.data.a_string #=> String
     #   resp.data.default_bool #=> Boolean
     #   resp.data.boxed_bool #=> Boolean

--- a/codegen/projections/weather/lib/weather/types.rb
+++ b/codegen/projections/weather/lib/weather/types.rb
@@ -327,6 +327,7 @@ module Weather
     #   @return [Integer]
     #
     # @!attribute some_enum
+    #   Enum, one of: ["YES", "NO"]
     #
     #   @return [String]
     #
@@ -359,6 +360,7 @@ module Weather
     #   @return [String]
     #
     # @!attribute some_enum
+    #   Enum, one of: ["YES", "NO"]
     #
     #   @return [String]
     #
@@ -501,6 +503,8 @@ module Weather
         end
       end
 
+      # Enum, one of: ["YES", "NO"]
+      #
       class Snow < Precipitation
         def to_h
           { snow: super(__getobj__) }
@@ -511,6 +515,8 @@ module Weather
         end
       end
 
+      # Enum, one of: ["YES", "NO"]
+      #
       class Mixed < Precipitation
         def to_h
           { mixed: super(__getobj__) }
@@ -572,6 +578,18 @@ module Weather
           "#<Weather::Types::Unknown #{__getobj__ || 'nil'}>"
         end
       end
+    end
+
+    # Enum, one of: ["YES", "NO"]
+    #
+    module TypedYesNo
+      # No documentation available.
+      #
+      YES = "YES"
+
+      # No documentation available.
+      #
+      NO = "NO"
     end
 
     # @!attribute member___123foo

--- a/codegen/projections/weather/lib/weather/types.rb
+++ b/codegen/projections/weather/lib/weather/types.rb
@@ -580,7 +580,7 @@ module Weather
       end
     end
 
-    # Enum, one of: ["YES", "NO"]
+    # Includes enum constants for TypedYesNo
     #
     module TypedYesNo
       # No documentation available.

--- a/codegen/projections/weather/sig/weather/types.rbs
+++ b/codegen/projections/weather/sig/weather/types.rbs
@@ -124,6 +124,12 @@ module Weather
       end
     end
 
+    module TypedYesNo
+      YES: ::String
+
+      NO: ::String
+    end
+
     Struct____456efg: untyped
 
     Struct____789BadNameInput: untyped

--- a/codegen/projections/white_label/lib/white_label/client.rb
+++ b/codegen/projections/white_label/lib/white_label/client.rb
@@ -179,8 +179,8 @@ module WhiteLabel
     #
     #   resp = client.kitchen_sink(
     #     string: 'String',
-    #     simple_enum: 'YES', # accepts ["YES", "NO", "Maybe"]
-    #     typed_enum: 'YES', # accepts ["YES", "NO", "Maybe"]
+    #     simple_enum: 'YES', # accepts ["YES", "NO", "MAYBE"]
+    #     typed_enum: 'YES', # accepts ["YES", "NO", "MAYBE"]
     #     struct: {
     #       value: 'value'
     #     },
@@ -211,8 +211,8 @@ module WhiteLabel
     #
     #   resp.data #=> Types::KitchenSinkOutput
     #   resp.data.string #=> String
-    #   resp.data.simple_enum #=> String, one of ["YES", "NO", "Maybe"]
-    #   resp.data.typed_enum #=> String, one of ["YES", "NO", "Maybe"]
+    #   resp.data.simple_enum #=> String, one of ["YES", "NO", "MAYBE"]
+    #   resp.data.typed_enum #=> String, one of ["YES", "NO", "MAYBE"]
     #   resp.data.struct #=> Types::Struct
     #   resp.data.struct.value #=> String
     #   resp.data.document #=> Hash,Array,String,Boolean,Numeric

--- a/codegen/projections/white_label/lib/white_label/client.rb
+++ b/codegen/projections/white_label/lib/white_label/client.rb
@@ -179,6 +179,8 @@ module WhiteLabel
     #
     #   resp = client.kitchen_sink(
     #     string: 'String',
+    #     simple_enum: 'YES', # accepts ["YES", "NO", "Maybe"]
+    #     typed_enum: 'YES', # accepts ["YES", "NO", "Maybe"]
     #     struct: {
     #       value: 'value'
     #     },
@@ -209,6 +211,8 @@ module WhiteLabel
     #
     #   resp.data #=> Types::KitchenSinkOutput
     #   resp.data.string #=> String
+    #   resp.data.simple_enum #=> String, one of ["YES", "NO", "Maybe"]
+    #   resp.data.typed_enum #=> String, one of ["YES", "NO", "Maybe"]
     #   resp.data.struct #=> Types::Struct
     #   resp.data.struct.value #=> String
     #   resp.data.document #=> Hash,Array,String,Boolean,Numeric

--- a/codegen/projections/white_label/lib/white_label/params.rb
+++ b/codegen/projections/white_label/lib/white_label/params.rb
@@ -61,6 +61,8 @@ module WhiteLabel
         Hearth::Validator.validate!(params, ::Hash, Types::KitchenSinkInput, context: context)
         type = Types::KitchenSinkInput.new
         type.string = params[:string]
+        type.simple_enum = params[:simple_enum]
+        type.typed_enum = params[:typed_enum]
         type.struct = Struct.build(params[:struct], context: "#{context}[:struct]") unless params[:struct].nil?
         type.document = params[:document]
         type.list_of_strings = ListOfStrings.build(params[:list_of_strings], context: "#{context}[:list_of_strings]") unless params[:list_of_strings].nil?
@@ -78,6 +80,8 @@ module WhiteLabel
         Hearth::Validator.validate!(params, ::Hash, Types::KitchenSinkOutput, context: context)
         type = Types::KitchenSinkOutput.new
         type.string = params[:string]
+        type.simple_enum = params[:simple_enum]
+        type.typed_enum = params[:typed_enum]
         type.struct = Struct.build(params[:struct], context: "#{context}[:struct]") unless params[:struct].nil?
         type.document = params[:document]
         type.list_of_strings = ListOfStrings.build(params[:list_of_strings], context: "#{context}[:list_of_strings]") unless params[:list_of_strings].nil?

--- a/codegen/projections/white_label/lib/white_label/stubs.rb
+++ b/codegen/projections/white_label/lib/white_label/stubs.rb
@@ -31,6 +31,8 @@ module WhiteLabel
       def self.default(visited=[])
         {
           string: 'string',
+          simple_enum: 'simple_enum',
+          typed_enum: 'typed_enum',
           struct: Stubs::Struct.default(visited),
           document: nil,
           list_of_strings: Stubs::ListOfStrings.default(visited),

--- a/codegen/projections/white_label/lib/white_label/types.rb
+++ b/codegen/projections/white_label/lib/white_label/types.rb
@@ -117,12 +117,12 @@ module WhiteLabel
     #   @return [String]
     #
     # @!attribute simple_enum
-    #   Enum, one of: ["YES", "NO", "Maybe"]
+    #   Enum, one of: ["YES", "NO", "MAYBE"]
     #
     #   @return [String]
     #
     # @!attribute typed_enum
-    #   Enum, one of: ["YES", "NO", "Maybe"]
+    #   Enum, one of: ["YES", "NO", "MAYBE"]
     #
     #   @return [String]
     #
@@ -266,12 +266,12 @@ module WhiteLabel
     #   @return [String]
     #
     # @!attribute simple_enum
-    #   Enum, one of: ["YES", "NO", "Maybe"]
+    #   Enum, one of: ["YES", "NO", "MAYBE"]
     #
     #   @return [String]
     #
     # @!attribute typed_enum
-    #   Enum, one of: ["YES", "NO", "Maybe"]
+    #   Enum, one of: ["YES", "NO", "MAYBE"]
     #
     #   @return [String]
     #
@@ -492,7 +492,7 @@ module WhiteLabel
       end
     end
 
-    # Enum, one of: ["YES", "NO", "Maybe"]
+    # Includes enum constants for TypedEnum
     #
     module TypedEnum
       # No documentation available.
@@ -510,7 +510,7 @@ module WhiteLabel
       #
       # Tags: ["Test"]
       #
-      MAYBE = "Maybe"
+      MAYBE = "MAYBE"
     end
 
     # This is some union documentation.

--- a/codegen/projections/white_label/lib/white_label/types.rb
+++ b/codegen/projections/white_label/lib/white_label/types.rb
@@ -116,6 +116,16 @@ module WhiteLabel
     #
     #   @return [String]
     #
+    # @!attribute simple_enum
+    #   Enum, one of: ["YES", "NO", "Maybe"]
+    #
+    #   @return [String]
+    #
+    # @!attribute typed_enum
+    #   Enum, one of: ["YES", "NO", "Maybe"]
+    #
+    #   @return [String]
+    #
     # @!attribute struct
     #   This is some member documentation of Struct.
     #   It should override Struct's documentation.
@@ -194,6 +204,8 @@ module WhiteLabel
     #
     KitchenSinkInput = ::Struct.new(
       :string,
+      :simple_enum,
+      :typed_enum,
       :struct,
       :document,
       :list_of_strings,
@@ -209,6 +221,8 @@ module WhiteLabel
       def to_s
         "#<struct WhiteLabel::Types::KitchenSinkInput "\
           "string=\"[SENSITIVE]\", "\
+          "simple_enum=#{simple_enum || 'nil'}, "\
+          "typed_enum=#{typed_enum || 'nil'}, "\
           "struct=\"[SENSITIVE]\", "\
           "document=#{document || 'nil'}, "\
           "list_of_strings=#{list_of_strings || 'nil'}, "\
@@ -248,6 +262,16 @@ module WhiteLabel
     #
     #   @note
     #     This shape is sensitive and must be handled with care.
+    #
+    #   @return [String]
+    #
+    # @!attribute simple_enum
+    #   Enum, one of: ["YES", "NO", "Maybe"]
+    #
+    #   @return [String]
+    #
+    # @!attribute typed_enum
+    #   Enum, one of: ["YES", "NO", "Maybe"]
     #
     #   @return [String]
     #
@@ -329,6 +353,8 @@ module WhiteLabel
     #
     KitchenSinkOutput = ::Struct.new(
       :string,
+      :simple_enum,
+      :typed_enum,
       :struct,
       :document,
       :list_of_strings,
@@ -344,6 +370,8 @@ module WhiteLabel
       def to_s
         "#<struct WhiteLabel::Types::KitchenSinkOutput "\
           "string=\"[SENSITIVE]\", "\
+          "simple_enum=#{simple_enum || 'nil'}, "\
+          "typed_enum=#{typed_enum || 'nil'}, "\
           "struct=\"[SENSITIVE]\", "\
           "document=#{document || 'nil'}, "\
           "list_of_strings=#{list_of_strings || 'nil'}, "\
@@ -462,6 +490,27 @@ module WhiteLabel
       def to_s
         "#<struct WhiteLabel::Types::Struct [SENSITIVE]>"
       end
+    end
+
+    # Enum, one of: ["YES", "NO", "Maybe"]
+    #
+    module TypedEnum
+      # No documentation available.
+      #
+      YES = "YES"
+
+      # No documentation available.
+      #
+      NO = "NO"
+
+      # This documentation should be applied.
+      #
+      # @deprecated
+      #   This enum value is deprecated.
+      #
+      # Tags: ["Test"]
+      #
+      MAYBE = "Maybe"
     end
 
     # This is some union documentation.

--- a/codegen/projections/white_label/lib/white_label/validators.rb
+++ b/codegen/projections/white_label/lib/white_label/validators.rb
@@ -66,6 +66,8 @@ module WhiteLabel
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::KitchenSinkInput, context: context)
         Hearth::Validator.validate!(input[:string], ::String, context: "#{context}[:string]")
+        Hearth::Validator.validate!(input[:simple_enum], ::String, context: "#{context}[:simple_enum]")
+        Hearth::Validator.validate!(input[:typed_enum], ::String, context: "#{context}[:typed_enum]")
         Validators::Struct.validate!(input[:struct], context: "#{context}[:struct]") unless input[:struct].nil?
         Validators::Document.validate!(input[:document], context: "#{context}[:document]") unless input[:document].nil?
         Validators::ListOfStrings.validate!(input[:list_of_strings], context: "#{context}[:list_of_strings]") unless input[:list_of_strings].nil?
@@ -81,6 +83,8 @@ module WhiteLabel
       def self.validate!(input, context:)
         Hearth::Validator.validate!(input, Types::KitchenSinkOutput, context: context)
         Hearth::Validator.validate!(input[:string], ::String, context: "#{context}[:string]")
+        Hearth::Validator.validate!(input[:simple_enum], ::String, context: "#{context}[:simple_enum]")
+        Hearth::Validator.validate!(input[:typed_enum], ::String, context: "#{context}[:typed_enum]")
         Validators::Struct.validate!(input[:struct], context: "#{context}[:struct]") unless input[:struct].nil?
         Validators::Document.validate!(input[:document], context: "#{context}[:document]") unless input[:document].nil?
         Validators::ListOfStrings.validate!(input[:list_of_strings], context: "#{context}[:list_of_strings]") unless input[:list_of_strings].nil?

--- a/codegen/projections/white_label/sig/white_label/types.rbs
+++ b/codegen/projections/white_label/sig/white_label/types.rbs
@@ -34,6 +34,14 @@ module WhiteLabel
 
     Struct: untyped
 
+    module TypedEnum
+      YES: ::String
+
+      NO: ::String
+
+      MAYBE: ::String
+    end
+
     class Union < Hearth::Union
       class String < Union
         def to_h: () -> { string: Hash[Symbol,Union] }

--- a/codegen/smithy-ruby-codegen-test/integration-specs/types_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/types_spec.rb
@@ -73,5 +73,19 @@ module WhiteLabel
         expect(subject.boxed_number).to be nil
       end
     end
+
+    describe 'SimpleEnum' do
+      it 'is not defined' do
+        expect(defined?(Types::SimpleEnum)).to be false
+      end
+    end
+
+    describe TypedEnum do
+      it 'has typed enums' do
+        expect(Types::TypedEnum::YES).to be "YES"
+        expect(Types::TypedEnum::NO).to be "NO"
+        expect(Types::TypedEnum::MAYBE).to be "MAYBE"
+      end
+    end
   end
 end

--- a/codegen/smithy-ruby-codegen-test/integration-specs/types_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/types_spec.rb
@@ -76,15 +76,15 @@ module WhiteLabel
 
     describe 'SimpleEnum' do
       it 'is not defined' do
-        expect(defined?(Types::SimpleEnum)).to be false
+        expect(defined?(Types::SimpleEnum)).to be nil
       end
     end
 
     describe TypedEnum do
       it 'has typed enums' do
-        expect(Types::TypedEnum::YES).to be "YES"
-        expect(Types::TypedEnum::NO).to be "NO"
-        expect(Types::TypedEnum::MAYBE).to be "MAYBE"
+        expect(Types::TypedEnum::YES).to eq "YES"
+        expect(Types::TypedEnum::NO).to eq "NO"
+        expect(Types::TypedEnum::MAYBE).to eq "MAYBE"
       end
     end
   end

--- a/codegen/smithy-ruby-codegen-test/model/component-test/documentation.smithy
+++ b/codegen/smithy-ruby-codegen-test/model/component-test/documentation.smithy
@@ -121,11 +121,11 @@ apply Union$String @sensitive
 // test enum documentation
 apply TypedEnum @enum(
   [
-    {value: "Maybe", name: "MAYBE", documentation: "This documentation should be applied.", deprecated: true, tags: ["Test"]}
+    {value: "MAYBE", name: "MAYBE", documentation: "This documentation should be applied.", deprecated: true, tags: ["Test"]}
   ]
 )
 apply SimpleEnum @enum(
   [
-    {value: "Maybe", documentation: "This documentation should exist in an empty module.", deprecated: true, tags: ["Test"]}
+    {value: "MAYBE", documentation: "This documentation should exist in an empty module.", deprecated: true, tags: ["Test"]}
   ]
 )

--- a/codegen/smithy-ruby-codegen-test/model/component-test/documentation.smithy
+++ b/codegen/smithy-ruby-codegen-test/model/component-test/documentation.smithy
@@ -117,3 +117,15 @@ apply Union$String @internal
 apply Union$String @since("today")
 apply Union$String @unstable
 apply Union$String @sensitive
+
+// test enum documentation
+apply TypedEnum @enum(
+  [
+    {value: "Maybe", name: "MAYBE", documentation: "This documentation should be applied.", deprecated: true, tags: ["Test"]}
+  ]
+)
+apply SimpleEnum @enum(
+  [
+    {value: "Maybe", documentation: "This documentation should exist in an empty module.", deprecated: true, tags: ["Test"]}
+  ]
+)

--- a/codegen/smithy-ruby-codegen-test/model/component-test/main.smithy
+++ b/codegen/smithy-ruby-codegen-test/model/component-test/main.smithy
@@ -27,6 +27,10 @@ structure KitchenSinkInputOutput {
     // simple member
     String: String,
 
+    // enum members
+    SimpleEnum: SimpleEnum,
+    TypedEnum: TypedEnum,
+
     // complex member
     Struct: Struct,
 
@@ -43,6 +47,12 @@ structure KitchenSinkInputOutput {
     // union member
     Union: Union,
 }
+
+@enum([{value: "YES"}, {value: "NO"}])
+string SimpleEnum
+
+@enum([{value: "YES", name: "YES"}, {value: "NO", name: "NO"}])
+string TypedEnum
 
 structure Struct {
     value: String,

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubySymbolProvider.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubySymbolProvider.java
@@ -206,7 +206,7 @@ public class RubySymbolProvider implements SymbolProvider,
 
     @Override
     public Symbol stringShape(StringShape shape) {
-        return createSymbolBuilder(shape, "", "String", "String").build();
+        return createSymbolBuilder(shape, getDefaultShapeName(shape, "String__"), "String", "String").build();
     }
 
     @Override

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/TypesGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/TypesGenerator.java
@@ -220,10 +220,9 @@ public class TypesGenerator {
                 // only write out a module if there is at least one enum constant
                 if (enumDefinitions.size() > 0) {
                     String shapeName = symbolProvider.toSymbol(shape).getName();
-                    String shapeDocumentation = new ShapeDocumentationGenerator(model, symbolProvider, shape).render();
 
                     writer
-                            .writeInline("$L", shapeDocumentation)
+                            .writeDocstring("Includes enum constants for " + shapeName)
                             .openBlock("module $L", shapeName);
 
                     enumDefinitions.forEach(enumDefinition -> {

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/TypesGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/TypesGenerator.java
@@ -30,8 +30,11 @@ import software.amazon.smithy.model.shapes.BooleanShape;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeVisitor;
+import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.UnionShape;
+import software.amazon.smithy.model.traits.EnumDefinition;
+import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.model.traits.SensitiveTrait;
 import software.amazon.smithy.model.transform.ModelTransformer;
 import software.amazon.smithy.ruby.codegen.GenerationContext;
@@ -199,9 +202,53 @@ public class TypesGenerator {
                     .openBlock("def to_s")
                     .write("\"#<$L::Types::Unknown #{__getobj__ || 'nil'}>\"", settings.getModule())
                     .closeBlock("end")
-                    .closeBlock("end");
+                    .closeBlock("end")
+                    .closeBlock("end\n");
 
-            writer.closeBlock("end\n");
+            return null;
+        }
+
+        @Override
+        public Void stringShape(StringShape shape) {
+            // Only write out string shapes for enums
+            if (shape.hasTrait(EnumTrait.class)) {
+                EnumTrait enumTrait = shape.expectTrait(EnumTrait.class);
+                List<EnumDefinition> enumDefinitions = enumTrait.getValues().stream()
+                                .filter(value -> value.getName().isPresent())
+                                .collect(Collectors.toList());
+
+                // only write out a module if there is at least one enum constant
+                if (enumDefinitions.size() > 0) {
+                    String shapeName = symbolProvider.toSymbol(shape).getName();
+                    String shapeDocumentation = new ShapeDocumentationGenerator(model, symbolProvider, shape).render();
+
+                    writer
+                            .writeInline("$L", shapeDocumentation)
+                            .openBlock("module $L", shapeName);
+
+                    enumDefinitions.forEach(enumDefinition -> {
+                        String enumName = enumDefinition.getName().get();
+                        String enumValue = enumDefinition.getValue();
+                        String enumDocumentation = enumDefinition.getDocumentation()
+                                .orElse("No documentation available.");
+                        writer.writeDocstring(enumDocumentation);
+                        if (enumDefinition.isDeprecated()) {
+                            writer.writeYardDeprecated("This enum value is deprecated.", "");
+                        }
+                        if (!enumDefinition.getTags().isEmpty()) {
+                            String enumTags = enumDefinition.getTags().stream()
+                                    .map((tag) -> "\"" + tag + "\"")
+                                    .collect(Collectors.joining(", "));
+                            writer.writeDocstring("Tags: [" + enumTags + "]");
+                        }
+                        writer.write("$L = $S\n", enumName, enumValue);
+                    });
+
+                    writer
+                            .unwrite("\n")
+                            .closeBlock("end\n");
+                }
+            }
 
             return null;
         }
@@ -341,6 +388,32 @@ public class TypesGenerator {
                     .write("def to_h: () -> { unknown: Hash[Symbol,$L] }", shapeName)
                     .closeBlock("end")
                     .closeBlock("end\n");
+
+            return null;
+        }
+
+        @Override
+        public Void stringShape(StringShape shape) {
+            // Only write out string shapes for enums
+            if (shape.hasTrait(EnumTrait.class)) {
+                EnumTrait enumTrait = shape.expectTrait(EnumTrait.class);
+                List<EnumDefinition> enumDefinitions = enumTrait.getValues().stream()
+                        .filter(value -> value.getName().isPresent())
+                        .collect(Collectors.toList());
+
+                // only write out a module if there is at least one enum constant
+                if (enumDefinitions.size() > 0) {
+                    String shapeName = symbolProvider.toSymbol(shape).getName();
+                    rbsWriter.openBlock("module $L", shapeName);
+                    enumDefinitions.forEach(enumDefinition -> {
+                        String enumName = enumDefinition.getName().get();
+                        rbsWriter.write("$L: ::String\n", enumName);
+                    });
+                    rbsWriter
+                            .unwrite("\n")
+                            .closeBlock("end\n");
+                }
+            }
 
             return null;
         }

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/docs/PlaceholderExampleGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/docs/PlaceholderExampleGenerator.java
@@ -178,12 +178,13 @@ public class PlaceholderExampleGenerator {
             if (shape.hasTrait(EnumTrait.class)) {
                 EnumTrait enumTrait = shape.expectTrait(EnumTrait.class);
                 String defaultValue = enumTrait.getValues().get(0).getValue();
-                String accepts =
-                        enumTrait.getValues().stream().map((v) -> v.getValue()).collect(Collectors.joining(", "));
+                String accepts = enumTrait.getEnumDefinitionValues().stream()
+                        .map((value) -> "\"" + value + "\"")
+                        .collect(Collectors.joining(", "));
                 if (memberShape.hasTrait(RequiredTrait.class)) {
-                    accepts = " - accepts " + accepts;
+                    accepts = " - accepts [" + accepts + "]";
                 } else {
-                    accepts = " # accepts " + accepts;
+                    accepts = " # accepts [" + accepts + "]";
                 }
                 writer.write("$L'$L'$L", dataSetter, defaultValue, eol + accepts);
             } else {

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/docs/ResponseExampleGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/docs/ResponseExampleGenerator.java
@@ -80,9 +80,10 @@ public class ResponseExampleGenerator {
         public Void stringShape(StringShape shape) {
             if (shape.hasTrait(EnumTrait.class)) {
                 EnumTrait enumTrait = shape.expectTrait(EnumTrait.class);
-                String values =
-                        enumTrait.getValues().stream().map((v) -> v.getValue()).collect(Collectors.joining(", "));
-                writer.write("$L #=> String, one of $L", dataGetter, values);
+                String values = enumTrait.getEnumDefinitionValues().stream()
+                        .map((value) -> "\"" + value + "\"")
+                        .collect(Collectors.joining(", "));
+                writer.write("$L #=> String, one of [$L]", dataGetter, values);
             } else {
                 writer.write("$L #=> String", dataGetter);
             }

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/docs/ShapeDocumentationGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/docs/ShapeDocumentationGenerator.java
@@ -27,7 +27,6 @@ import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.shapes.ShapeId;
 import software.amazon.smithy.model.shapes.ShapeVisitor;
-import software.amazon.smithy.model.shapes.StringShape;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.DeprecatedTrait;
@@ -287,13 +286,6 @@ public class ShapeDocumentationGenerator {
 
         @Override
         public Void serviceShape(ServiceShape shape) {
-            writeAllShapeTraits();
-            return null;
-        }
-
-        @Override
-        public Void stringShape(StringShape shape) {
-            // used for enums
             writeAllShapeTraits();
             return null;
         }


### PR DESCRIPTION
Adds an enum module in Types ONLY if there are names (which define the constant). Also adds documentation on the member shapes which reference available types (even if names are not defined).