### PR TITLE
Refactor ConfigProviders to use ClientFragmenets (allowing dependencies on other ClientConfig).

### DIFF
--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/ClientFragment.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/ClientFragment.java
@@ -57,11 +57,11 @@ public class ClientFragment {
 
     @FunctionalInterface
     /**
-     * Called to Render the addition of this middleware to the stack.
+     * Called to Render the fragment.
      */
     public interface RenderOperation {
         /**
-         * Called to Render the addition of this middleware to the stack.
+         * Called to Render the fragment.
          *
          * @param fragment - fragment to render
          * @param context  - additional context
@@ -104,6 +104,17 @@ public class ClientFragment {
          */
         public Builder render(RenderOperation r) {
             this.render = r;
+            return this;
+        }
+
+        /**
+         * @param staticRubyStatement static ruby statement to render
+         * @return this builder
+         */
+        public Builder render(String staticRubyStatement) {
+            this.render = (f, c) -> {
+                return staticRubyStatement;
+            };
             return this;
         }
 

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/CodegenOrchestrator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/CodegenOrchestrator.java
@@ -289,16 +289,15 @@ public class CodegenOrchestrator {
 
         // get all config
         Set<ClientConfig> unorderedConfig = new HashSet<>();
-        unorderedConfig
-                .addAll(context.applicationTransport().getClientConfig());
-        unorderedConfig.addAll(middlewareBuilder.getClientConfig(context));
-        unorderedConfig.addAll(context.integrations()
-                .stream()
-                .map((i) -> i.getAdditionalClientConfig(context))
-                .flatMap(Collection::stream)
-                .collect(Collectors.toList())
-        );
-        context.protocolGenerator().ifPresent((g) -> unorderedConfig.addAll(g.getAdditionalClientConfig(context)));
+        context.applicationTransport().getClientConfig().forEach((c) -> c.addToConfigCollection(unorderedConfig));
+        middlewareBuilder.getClientConfig(context).forEach((c) -> c.addToConfigCollection(unorderedConfig));
+
+        context.integrations().forEach((i) -> {
+            i.getAdditionalClientConfig(context).forEach((c) -> c.addToConfigCollection(unorderedConfig));
+        });
+        context.protocolGenerator().ifPresent((g) -> {
+            g.getAdditionalClientConfig(context).forEach((c) -> c.addToConfigCollection(unorderedConfig));
+        });
 
         List<ClientConfig> clientConfigList = unorderedConfig.stream()
                 .sorted(Comparator.comparing(ClientConfig::getName))

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/config/ClientConfig.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/config/ClientConfig.java
@@ -16,6 +16,7 @@
 package software.amazon.smithy.ruby.codegen.config;
 
 import java.util.Objects;
+import java.util.Set;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
@@ -102,6 +103,19 @@ public class ClientConfig {
             getConfigValue = "options.fetch(:" + getName() + ", @config." + getName() + ")";
         }
         return getConfigValue;
+    }
+
+    /**
+     * @param configCollection set of config to add this ClientConfig and all of its dependent config to.
+     */
+    public void addToConfigCollection(Set<ClientConfig> configCollection) {
+        if (!configCollection.contains(this)) {
+            configCollection.add(this);
+            defaults.getProviders().forEach( (p) -> {
+                p.providerFragment().getClientConfig()
+                        .forEach((c) -> c.addToConfigCollection(configCollection));
+            });
+        }
     }
 
     @Override

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/config/ConfigProvider.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/config/ConfigProvider.java
@@ -16,13 +16,14 @@
 package software.amazon.smithy.ruby.codegen.config;
 
 import java.util.Optional;
+import software.amazon.smithy.ruby.codegen.ClientFragment;
 
 public interface ConfigProvider {
 
     /**
      * @return the provider rendered into Ruby code
      */
-    String render();
+    ClientFragment providerFragment();
 
     /**
      * @return an optional default value to use in documentation.

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/config/ConfigProviderChain.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/config/ConfigProviderChain.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.ruby.codegen.config;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import software.amazon.smithy.ruby.codegen.ClientFragment;
 import software.amazon.smithy.utils.SmithyBuilder;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
@@ -83,6 +84,15 @@ public class ConfigProviderChain {
          */
         public Builder dynamicProvider(String rubyDefaultBlock) {
             this.providers.add(new DynamicConfigProvider(rubyDefaultBlock));
+            return this;
+        }
+
+        /**
+         * @param providerFragment a ClientFragment to provide a value
+         * @return this builder
+         */
+        public Builder dynamicProvider(ClientFragment providerFragment) {
+            this.providers.add(new DynamicConfigProvider(providerFragment));
             return this;
         }
 

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/config/DynamicConfigProvider.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/config/DynamicConfigProvider.java
@@ -15,22 +15,31 @@
 
 package software.amazon.smithy.ruby.codegen.config;
 
+import software.amazon.smithy.ruby.codegen.ClientFragment;
+
 /**
  * Config provider for dynamically getting config values from arbitrary ruby code blocks.
  */
 public class DynamicConfigProvider implements ConfigProvider {
 
-    private final String rubyDefaultBlock;
+    private final ClientFragment providerFragment;
 
     /**
      * @param rubyDefaultBlock ruby code block to provide the config value
      */
     public DynamicConfigProvider(String rubyDefaultBlock) {
-        this.rubyDefaultBlock = rubyDefaultBlock;
+        providerFragment = new ClientFragment.Builder().render(rubyDefaultBlock).build();
+    }
+
+    /**
+     * @param providerFragment fragment to provide the config value
+     */
+    public DynamicConfigProvider(ClientFragment providerFragment) {
+        this.providerFragment = providerFragment;
     }
 
     @Override
-    public String render() {
-        return rubyDefaultBlock;
+    public ClientFragment providerFragment() {
+        return providerFragment;
     }
 }

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/config/EnvConfigProvider.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/config/EnvConfigProvider.java
@@ -15,24 +15,26 @@
 
 package software.amazon.smithy.ruby.codegen.config;
 
+import software.amazon.smithy.ruby.codegen.ClientFragment;
+
 /**
  * ConfigProvider for extracting values from the ENV.
  */
 public class EnvConfigProvider implements ConfigProvider {
-    private final String environmentKey;
-    private final String type;
+    private final ClientFragment providerFragment;
 
     /**
      * @param environmentKey the name of the ENV variable
-     * @param type rubyType to coerce the value to
+     * @param type           rubyType to coerce the value to
      */
     public EnvConfigProvider(String environmentKey, String type) {
-        this.environmentKey = environmentKey;
-        this.type = type;
+        providerFragment = new ClientFragment.Builder()
+                .render("Hearth::Config::EnvProvider.new(" + environmentKey + ", type: '" + type + "')")
+                .build();
     }
 
     @Override
-    public String render() {
-        return "Hearth::Config::EnvProvider.new(" + environmentKey + ", type: '" + type + "')";
+    public ClientFragment providerFragment() {
+        return providerFragment;
     }
 }

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/config/SharedConfigProvider.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/config/SharedConfigProvider.java
@@ -15,17 +15,19 @@
 
 package software.amazon.smithy.ruby.codegen.config;
 
+import software.amazon.smithy.ruby.codegen.ClientFragment;
+
 public class SharedConfigProvider implements ConfigProvider {
-    private final String configKey;
-    private final String type;
+    private final ClientFragment providerFragment;
 
     public SharedConfigProvider(String configKey, String type) {
-        this.configKey = configKey;
-        this.type = type;
+        providerFragment = new ClientFragment.Builder()
+                .render("AWS::SDK::Core::SharedConfigProvider.new(" + configKey + ", type: '" + type + "')")
+                .build();
     }
 
     @Override
-    public String render() {
-        return "AWS::SDK::Core::SharedConfigProvider.new(" + configKey + ", type: '" + type + "')";
+    public ClientFragment providerFragment() {
+        return providerFragment;
     }
 }

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/config/StaticConfigProvider.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/config/StaticConfigProvider.java
@@ -16,11 +16,13 @@
 package software.amazon.smithy.ruby.codegen.config;
 
 import java.util.Optional;
+import software.amazon.smithy.ruby.codegen.ClientFragment;
 
 /**
  * Static Config Provider.
  */
 public class StaticConfigProvider implements ConfigProvider {
+    private final ClientFragment renderValue;
     private final String value;
 
     /**
@@ -28,12 +30,13 @@ public class StaticConfigProvider implements ConfigProvider {
      */
     public StaticConfigProvider(String value) {
         this.value = value;
+        this.renderValue = new ClientFragment.Builder().render(value).build();
     }
 
-    @Override
-    public String render() {
-        return value;
-    }
+   @Override
+   public ClientFragment providerFragment() {
+        return renderValue;
+   }
 
     @Override
     public Optional<String> getDocumentationDefault() {

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ConfigGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ConfigGenerator.java
@@ -155,7 +155,7 @@ public class ConfigGenerator {
 
         clientConfigList.forEach(clientConfig -> {
             String defaults = clientConfig.getDefaults().getProviders().stream()
-                    .map((p) -> p.render())
+                    .map((p) -> p.providerFragment().render(context))
                     .collect(Collectors.joining(","));
             writer.write("$L: [$L],", clientConfig.getName(), defaults);
         });


### PR DESCRIPTION

*Description of changes:*
Change the static string rendering in ConfigProviders to use ClientFragments.  This allows ConfigProviders to express dependencies on additional ClientConfig (as well as allowing dynamic rendering based on the context). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
