### PR TITLE
Added directed codegen implementation

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -28,7 +28,7 @@ allprojects {
     version = "0.1.0"
 }
 
-extra["smithyVersion"] = "1.23.0"
+extra["smithyVersion"] = "1.26.0"
 
 // The root project doesn't produce a JAR.
 tasks["jar"].enabled = false

--- a/codegen/projections/weather/lib/weather/types.rb
+++ b/codegen/projections/weather/lib/weather/types.rb
@@ -72,9 +72,6 @@ module Weather
     end
 
     # @!attribute latitude
-    #   @deprecated
-    #     Use Float instead, and add the @default trait to structure members that targets this shape
-    #     Since: 2.0
     #
     #   @return [Float]
     #
@@ -475,10 +472,7 @@ module Weather
     end
 
     class Precipitation < Hearth::Union
-      # @deprecated
-      #   Use Boolean instead, and add the @default trait to structure members that targets this shape
-      #   Since: 2.0
-      #
+
       class Rain < Precipitation
         def to_h
           { rain: super(__getobj__) }
@@ -489,10 +483,6 @@ module Weather
         end
       end
 
-      # @deprecated
-      #   Use Boolean instead, and add the @default trait to structure members that targets this shape
-      #   Since: 2.0
-      #
       class Sleet < Precipitation
         def to_h
           { sleet: super(__getobj__) }

--- a/codegen/projections/white_label/lib/white_label/types.rb
+++ b/codegen/projections/white_label/lib/white_label/types.rb
@@ -136,11 +136,6 @@ module WhiteLabel
     #   @note
     #     This shape is meant for internal use only.
     #
-    #   @note
-    #     This shape is recommended.
-    #     Reason: This structure member is
-    #     cool AF.
-    #
     #   @since today
     #
     #   @return [String]
@@ -269,11 +264,6 @@ module WhiteLabel
     #
     #   @note
     #     This shape is meant for internal use only.
-    #
-    #   @note
-    #     This shape is recommended.
-    #     Reason: This structure member is
-    #     cool AF.
     #
     #   @since today
     #

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/DirectedRubyCodegen.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/DirectedRubyCodegen.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.ruby.codegen;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import software.amazon.smithy.codegen.core.SymbolProvider;
+import software.amazon.smithy.codegen.core.directed.CreateContextDirective;
+import software.amazon.smithy.codegen.core.directed.CreateSymbolProviderDirective;
+import software.amazon.smithy.codegen.core.directed.CustomizeDirective;
+import software.amazon.smithy.codegen.core.directed.DirectedCodegen;
+import software.amazon.smithy.codegen.core.directed.GenerateEnumDirective;
+import software.amazon.smithy.codegen.core.directed.GenerateErrorDirective;
+import software.amazon.smithy.codegen.core.directed.GenerateIntEnumDirective;
+import software.amazon.smithy.codegen.core.directed.GenerateServiceDirective;
+import software.amazon.smithy.codegen.core.directed.GenerateStructureDirective;
+import software.amazon.smithy.codegen.core.directed.GenerateUnionDirective;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ServiceShape;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.ruby.codegen.config.ClientConfig;
+import software.amazon.smithy.ruby.codegen.generators.ClientGenerator;
+import software.amazon.smithy.ruby.codegen.generators.ConfigGenerator;
+import software.amazon.smithy.ruby.codegen.generators.GemspecGenerator;
+import software.amazon.smithy.ruby.codegen.generators.HttpProtocolTestGenerator;
+import software.amazon.smithy.ruby.codegen.generators.ModuleGenerator;
+import software.amazon.smithy.ruby.codegen.generators.PaginatorsGenerator;
+import software.amazon.smithy.ruby.codegen.generators.ParamsGenerator;
+import software.amazon.smithy.ruby.codegen.generators.TypesGenerator;
+import software.amazon.smithy.ruby.codegen.generators.ValidatorsGenerator;
+import software.amazon.smithy.ruby.codegen.generators.WaitersGenerator;
+import software.amazon.smithy.ruby.codegen.generators.YardOptsGenerator;
+import software.amazon.smithy.ruby.codegen.middleware.MiddlewareBuilder;
+
+public class DirectedRubyCodegen
+    implements DirectedCodegen<GenerationContext, RubySettings, RubyIntegration> {
+
+    private static final Logger LOGGER =
+            Logger.getLogger(DirectedRubyCodegen.class.getName());
+
+    @Override
+    public SymbolProvider createSymbolProvider(CreateSymbolProviderDirective<RubySettings> directive) {
+        return new RubySymbolProvider(directive.model(), directive.settings(), "Types", true);
+    }
+
+    @Override
+    public GenerationContext createContext(CreateContextDirective<RubySettings, RubyIntegration> directive) {
+        ServiceShape service = directive.service();
+        Model model = directive.model();
+        List<RubyIntegration> integrations = directive.integrations();
+
+        Map<ShapeId, ProtocolGenerator> supportedProtocols = ProtocolGenerator
+            .collectSupportedProtocolGenerators(integrations);
+
+        ShapeId protocol = directive.settings()
+            .resolveServiceProtocol(service, model, supportedProtocols.keySet());
+
+        Optional<ProtocolGenerator> protocolGenerator =
+            ProtocolGenerator.resolve(protocol, integrations);
+
+        ApplicationTransport applicationTransport;
+
+        if (protocolGenerator.isPresent()) {
+            applicationTransport =
+                protocolGenerator.get().getApplicationTransport();
+        } else {
+            applicationTransport = ApplicationTransport
+                .createDefaultHttpApplicationTransport();
+        }
+
+        return new GenerationContext(
+            directive.settings(),
+            directive.fileManifest(),
+            integrations,
+            model,
+            service,
+            protocol,
+            protocolGenerator,
+            applicationTransport,
+            collectDependencies(model, service, protocol, directive.settings(), integrations),
+            directive.symbolProvider()
+        );
+    }
+
+    @Override
+    public void generateService(GenerateServiceDirective<GenerationContext, RubySettings> directive) {
+        GenerationContext context = directive.context();
+
+        // Register all middleware
+        MiddlewareBuilder middlewareBuilder = new MiddlewareBuilder();
+        middlewareBuilder.addDefaultMiddleware(context);
+
+        context.integrations().forEach((integration) -> {
+            integration.modifyClientMiddleware(middlewareBuilder, context);
+        });
+
+        context.protocolGenerator().ifPresent((g) -> g.modifyClientMiddleware(middlewareBuilder, context));
+
+        // get all config
+        Set<ClientConfig> unorderedConfig = new HashSet<>();
+        context.applicationTransport().getClientConfig().forEach((c) -> c.addToConfigCollection(unorderedConfig));
+        middlewareBuilder.getClientConfig(context).forEach((c) -> c.addToConfigCollection(unorderedConfig));
+
+        context.integrations().forEach((i) -> {
+            i.getAdditionalClientConfig(context).forEach((c) -> c.addToConfigCollection(unorderedConfig));
+        });
+        context.protocolGenerator().ifPresent((g) -> {
+            g.getAdditionalClientConfig(context).forEach((c) -> c.addToConfigCollection(unorderedConfig));
+        });
+
+        List<ClientConfig> clientConfigList = unorderedConfig.stream()
+                .sorted(Comparator.comparing(ClientConfig::getName))
+                .collect(Collectors.toList());
+
+        LOGGER.fine("Client config: "
+                + clientConfigList.stream().map((m) -> m.toString()).collect(Collectors.joining(",")));
+
+        ConfigGenerator configGenerator = new ConfigGenerator(context);
+        configGenerator.render(clientConfigList);
+        configGenerator.renderRbs();
+        LOGGER.info("generated config");
+
+        ClientGenerator clientGenerator = new ClientGenerator(context);
+        clientGenerator.render(middlewareBuilder);
+        clientGenerator.renderRbs();
+        LOGGER.info("generated client");
+    }
+
+    @Override
+    public void generateStructure(GenerateStructureDirective<GenerationContext, RubySettings> directive) {
+        TypesGenerator typesGenerator = new TypesGenerator(directive.context());
+        typesGenerator.render();
+        typesGenerator.renderRbs();
+
+        ParamsGenerator paramsGenerator = new ParamsGenerator(directive.context());
+        paramsGenerator.render();
+
+        ValidatorsGenerator validatorsGenerator = new ValidatorsGenerator(directive.context());
+        validatorsGenerator.render();
+
+        GenerationContext context = directive.context();
+
+        if (directive.context().protocolGenerator().isPresent()) {
+            ProtocolGenerator generator = directive.context().protocolGenerator().get();
+            generator.generateBuilders(directive.context());
+            generator.generateParsers(directive.context());
+            generator.generateStubs(directive.context());
+        }
+
+        WaitersGenerator waitersGenerator = new WaitersGenerator(context);
+        waitersGenerator.render();
+        waitersGenerator.renderRbs();
+
+        PaginatorsGenerator paginatorsGenerator = new PaginatorsGenerator(context);
+        paginatorsGenerator.render();
+        paginatorsGenerator.renderRbs();
+    }
+
+    @Override
+    public void generateError(GenerateErrorDirective<GenerationContext, RubySettings> directive) {
+        if (directive.context().protocolGenerator().isPresent()) {
+            directive.context().protocolGenerator().get().generateErrors(directive.context());
+        }
+    }
+
+    @Override
+    public void generateUnion(GenerateUnionDirective<GenerationContext, RubySettings> directive) {
+
+    }
+
+    @Override
+    public void generateEnumShape(GenerateEnumDirective<GenerationContext, RubySettings> directive) {
+
+    }
+
+    @Override
+    public void generateIntEnumShape(GenerateIntEnumDirective<GenerationContext, RubySettings> directive) {
+
+    }
+
+    @Override
+    public void customizeBeforeIntegrations(CustomizeDirective<GenerationContext, RubySettings> directive) {
+
+    }
+
+    @Override
+    public void customizeAfterIntegrations(CustomizeDirective<GenerationContext, RubySettings> directive) {
+        GenerationContext context = directive.context();
+
+        List<String> additionalFiles = context.integrations().stream()
+                .map((integration) -> integration.writeAdditionalFiles(context))
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+
+        new ModuleGenerator(context).render(additionalFiles);
+        new GemspecGenerator(context).render();
+        new YardOptsGenerator(context).render();
+
+        if (context.applicationTransport().isHttpTransport()) {
+            HttpProtocolTestGenerator testGenerator =
+                    new HttpProtocolTestGenerator(context);
+            testGenerator.render();
+        }
+    }
+
+    private Set<RubyDependency> collectDependencies(
+        Model model,
+        ServiceShape service,
+        ShapeId protocol,
+        RubySettings settings,
+        List<RubyIntegration> integrations
+    ) {
+        Set<RubyDependency> rubyDependencies = new HashSet<>();
+        rubyDependencies.addAll(settings.getBaseDependencies());
+        rubyDependencies.addAll(
+            integrations.stream()
+                .map((integration) -> integration
+                        .additionalGemDependencies(settings, model, service, protocol))
+                .flatMap(Collection::stream)
+                .collect(Collectors.toSet())
+        );
+
+        return rubyDependencies;
+    }
+}

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/DirectedRubyCodegenPlugin.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/DirectedRubyCodegenPlugin.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.ruby.codegen;
+
+import software.amazon.smithy.build.PluginContext;
+import software.amazon.smithy.build.SmithyBuildPlugin;
+import software.amazon.smithy.codegen.core.directed.CodegenDirector;
+import software.amazon.smithy.utils.SmithyInternalApi;
+
+/**
+ * Plugin to trigger Ruby code generation.
+ */
+@SmithyInternalApi
+public class DirectedRubyCodegenPlugin implements SmithyBuildPlugin {
+    @Override
+    public String getName() {
+        return "ruby-codegen";
+    }
+
+    @Override
+    public void execute(PluginContext context) {
+        CodegenDirector<RubyCodeWriter, RubyIntegration, GenerationContext, RubySettings> runner
+                = new CodegenDirector<>();
+
+        runner.directedCodegen(new DirectedRubyCodegen());
+
+        runner.integrationClass(RubyIntegration.class);
+
+        runner.fileManifest(context.getFileManifest());
+
+        runner.model(context.getModel());
+
+        RubySettings settings = RubySettings.from(context.getSettings());
+
+        runner.settings(settings);
+
+        runner.service(settings.getService());
+
+        runner.performDefaultCodegenTransforms();
+
+        runner.createDedicatedInputsAndOutputs();
+
+        runner.run();
+    }
+}

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/ProtocolGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/ProtocolGenerator.java
@@ -16,7 +16,10 @@
 package software.amazon.smithy.ruby.codegen;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ServiceShape;
@@ -131,5 +134,32 @@ public interface ProtocolGenerator {
             RubySettings rubySettings, Model finalResolvedModel,
             ServiceShape service, ShapeId protocol) {
         return Collections.emptySet();
+    }
+
+    static Map<ShapeId, ProtocolGenerator> collectSupportedProtocolGenerators(
+        List<RubyIntegration> integrations
+    ) {
+        Map<ShapeId, ProtocolGenerator> generators = new HashMap<>();
+        for (RubyIntegration integration : integrations) {
+            for (ProtocolGenerator generator : integration.getProtocolGenerators()) {
+                generators.put(generator.getProtocol(), generator);
+            }
+        }
+        return generators;
+    }
+
+    static Optional<ProtocolGenerator> resolve(
+        ShapeId protocol,
+        List<RubyIntegration> integrations
+    ) {
+        for (RubyIntegration integration : integrations) {
+            Optional<ProtocolGenerator> pg = integration.getProtocolGenerators()
+                    .stream().filter((p) -> p.getProtocol().equals(protocol))
+                    .findFirst();
+            if (pg.isPresent()) {
+                return pg;
+            }
+        }
+        return Optional.empty();
     }
 }

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubySymbolProvider.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubySymbolProvider.java
@@ -15,7 +15,6 @@
 
 package software.amazon.smithy.ruby.codegen;
 
-import software.amazon.smithy.codegen.core.CodegenException;
 import software.amazon.smithy.codegen.core.ReservedWordSymbolProvider;
 import software.amazon.smithy.codegen.core.ReservedWords;
 import software.amazon.smithy.codegen.core.ReservedWordsBuilder;
@@ -352,6 +351,10 @@ public class RubySymbolProvider implements SymbolProvider,
 
     @Override
     public Symbol resourceShape(ResourceShape shape) {
-        throw new CodegenException("Resources are not currently supported");
+        // TODO: handle ResourceShape code generation and define Symbol definitionFile
+        return Symbol.builder()
+            .name(getDefaultShapeName(shape, "Resources__"))
+            .namespace(moduleName, "::")
+            .build();
     }
 }

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ModuleGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ModuleGenerator.java
@@ -28,6 +28,11 @@ public class ModuleGenerator {
     private static final Logger LOGGER =
             Logger.getLogger(ModuleGenerator.class.getName());
 
+    private static final String[] DEFAULT_REQUIRES = {
+        "builders", "client", "config", "errors", "paginators", "params",
+        "parsers", "stubs", "types", "validators", "waiters"
+    };
+
     private final GenerationContext context;
 
     public ModuleGenerator(GenerationContext context) {
@@ -45,12 +50,7 @@ public class ModuleGenerator {
         }));
         writer.write("\n");
 
-        String[] requires = {
-                "builders", "client", "config", "errors", "paginators", "params",
-                "parsers", "stubs", "types", "validators", "waiters"
-        };
-
-        for (String require : requires) {
+        for (String require : DEFAULT_REQUIRES) {
             writer.write("require_relative '$L/$L'", settings.getGemName(),
                     require);
         }

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/YardOptsGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/YardOptsGenerator.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package software.amazon.smithy.ruby.codegen.generators;
+
+import java.util.Optional;
+import software.amazon.smithy.build.FileManifest;
+import software.amazon.smithy.model.traits.TitleTrait;
+import software.amazon.smithy.ruby.codegen.GenerationContext;
+import software.amazon.smithy.ruby.codegen.RubyCodeWriter;
+
+public class YardOptsGenerator {
+
+    private GenerationContext context;
+
+    public YardOptsGenerator(GenerationContext context) {
+        this.context = context;
+    }
+
+    public void render() {
+        Optional<TitleTrait> title = context.service().getTrait(TitleTrait.class);
+        if (title.isPresent()) {
+            FileManifest fileManifest = context.fileManifest();
+            RubyCodeWriter writer = new RubyCodeWriter(context.settings().getModule());
+            writer.write("--title \"$L\"", title.get().getValue());
+            writer.write("--hide-api private");
+            String fileName = context.settings().getGemName() + "/.yardopts";
+            fileManifest.writeFile(fileName, writer.toString());
+        }
+    }
+}

--- a/codegen/smithy-ruby-codegen/src/main/resources/META-INF/services/software.amazon.smithy.build.SmithyBuildPlugin
+++ b/codegen/smithy-ruby-codegen/src/main/resources/META-INF/services/software.amazon.smithy.build.SmithyBuildPlugin
@@ -1,1 +1,1 @@
-software.amazon.smithy.ruby.codegen.RubyCodegenPlugin
+software.amazon.smithy.ruby.codegen.DirectedRubyCodegenPlugin

--- a/hearth/spec/hearth/retry/client_rate_limiter_spec.rb
+++ b/hearth/spec/hearth/retry/client_rate_limiter_spec.rb
@@ -121,7 +121,7 @@ module Hearth
 
         # Request a new token every 100ms (10 TPS) for 2 seconds.
         expect(mutex).not_to receive(:sleep)
-        (0..20).each do |t|
+        20.times do |t|
           allow(Process).to receive(:clock_gettime)
             .with(Process::CLOCK_MONOTONIC).and_return(1 + (0.1 * t))
           subject.token_bucket_acquire(1)


### PR DESCRIPTION
*Description of changes:*

This is a basic implementation of directed codegen re-using existing ruby code generators. The goal is to ensure the same ruby code is generated and not deviate from existing codegen implementation. (There will be more PRs for refactoring and generating unions, enums, etc.)

Changes:
* Update smithy version to 1.26.0
* Added directed ruby codegen implementation
  * Added DirectedRubyCodegen class
  * Added DirectedRubyCodegenPlugin class
  * Populated existing code generation logic into DirectedRubyCodegen

Testing: 
* `./gradlew clean build`
* Confirmed generated ruby code remains the same

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
