### PR TITLE
Refactor SymbolProvider usages

### DIFF
--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/CodegenOrchestrator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/CodegenOrchestrator.java
@@ -138,8 +138,7 @@ public class CodegenOrchestrator {
 
         // TODO: Apply CodeInterceptors (where?)
 
-        SymbolProvider symbolProvider = new RubySymbolProvider(
-                resolvedModel, rubySettings, "Types", true);
+        SymbolProvider symbolProvider = new RubySymbolProvider(resolvedModel, rubySettings);
 
         for (RubyIntegration integration : integrations) {
             symbolProvider = integration.decorateSymbolProvider(resolvedModel, rubySettings, symbolProvider);

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/DirectedRubyCodegen.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/DirectedRubyCodegen.java
@@ -60,7 +60,7 @@ public class DirectedRubyCodegen
 
     @Override
     public SymbolProvider createSymbolProvider(CreateSymbolProviderDirective<RubySettings> directive) {
-        return new RubySymbolProvider(directive.model(), directive.settings(), "Types", true);
+        return new RubySymbolProvider(directive.model(), directive.settings());
     }
 
     @Override

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubyFormatter.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/RubyFormatter.java
@@ -50,4 +50,12 @@ public final class RubyFormatter {
                 .replace('-', '_')
                 .toLowerCase();
     }
+
+    public static String prefixLeadingInvalidIdentCharacters(String value, String prefix) {
+        if (!Character.isLetter(value.charAt(0))) {
+            return prefix + value;
+        } else {
+            return value;
+        }
+    }
 }

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/BuilderGeneratorBase.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/BuilderGeneratorBase.java
@@ -23,6 +23,7 @@ import java.util.TreeSet;
 import java.util.logging.Logger;
 import software.amazon.smithy.build.FileManifest;
 import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.neighbor.Walker;
@@ -41,7 +42,6 @@ import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.ruby.codegen.GenerationContext;
 import software.amazon.smithy.ruby.codegen.RubyCodeWriter;
 import software.amazon.smithy.ruby.codegen.RubySettings;
-import software.amazon.smithy.ruby.codegen.RubySymbolProvider;
 import software.amazon.smithy.ruby.codegen.util.Streaming;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
@@ -77,7 +77,7 @@ public abstract class BuilderGeneratorBase {
     /**
      * SymbolProvider scoped to this module.
      */
-    protected final RubySymbolProvider symbolProvider;
+    protected final SymbolProvider symbolProvider;
 
     public BuilderGeneratorBase(GenerationContext context) {
         this.settings = context.settings();
@@ -85,7 +85,7 @@ public abstract class BuilderGeneratorBase {
         this.generatedBuilders = new HashSet<>();
         this.context = context;
         this.writer = new RubyCodeWriter(context.settings().getModule() + "::Builder");
-        this.symbolProvider = new RubySymbolProvider(model, settings, "Builder", true);
+        this.symbolProvider = context.symbolProvider();
     }
 
     /**

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ClientGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ClientGenerator.java
@@ -22,6 +22,7 @@ import java.util.TreeSet;
 import java.util.logging.Logger;
 import software.amazon.smithy.build.FileManifest;
 import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.TopDownIndex;
 import software.amazon.smithy.model.shapes.OperationShape;
@@ -34,7 +35,6 @@ import software.amazon.smithy.ruby.codegen.RubyCodeWriter;
 import software.amazon.smithy.ruby.codegen.RubyFormatter;
 import software.amazon.smithy.ruby.codegen.RubyImportContainer;
 import software.amazon.smithy.ruby.codegen.RubySettings;
-import software.amazon.smithy.ruby.codegen.RubySymbolProvider;
 import software.amazon.smithy.ruby.codegen.generators.docs.ShapeDocumentationGenerator;
 import software.amazon.smithy.ruby.codegen.middleware.MiddlewareBuilder;
 import software.amazon.smithy.ruby.codegen.util.Streaming;
@@ -50,7 +50,7 @@ public class ClientGenerator {
 
     private final GenerationContext context;
     private final RubySettings settings;
-    private final RubySymbolProvider symbolProvider;
+    private final SymbolProvider symbolProvider;
     private final Model model;
     private final RubyCodeWriter writer;
     private final RubyCodeWriter rbsWriter;
@@ -65,7 +65,7 @@ public class ClientGenerator {
         this.model = context.model();
         this.writer = new RubyCodeWriter(context.settings().getModule());
         this.rbsWriter = new RubyCodeWriter(context.settings().getModule());
-        this.symbolProvider = new RubySymbolProvider(model, context.settings(), "Client", false);
+        this.symbolProvider = context.symbolProvider();
         this.hasStreamingOperation = false;
     }
 

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/HttpProtocolTestGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/HttpProtocolTestGenerator.java
@@ -43,7 +43,6 @@ import software.amazon.smithy.ruby.codegen.RubyDependency;
 import software.amazon.smithy.ruby.codegen.RubyFormatter;
 import software.amazon.smithy.ruby.codegen.RubyImportContainer;
 import software.amazon.smithy.ruby.codegen.RubySettings;
-import software.amazon.smithy.ruby.codegen.RubySymbolProvider;
 import software.amazon.smithy.ruby.codegen.trait.SkipTest;
 import software.amazon.smithy.ruby.codegen.trait.SkipTestsTrait;
 import software.amazon.smithy.ruby.codegen.util.ParamsToHash;
@@ -73,7 +72,7 @@ public class HttpProtocolTestGenerator {
         this.settings = context.settings();
         this.model = context.model();
         this.writer = new RubyCodeWriter(context.settings().getModule() + "");
-        this.symbolProvider = new RubySymbolProvider(model, settings, "", true);
+        this.symbolProvider = context.symbolProvider();
     }
 
     /**

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/PaginatorsGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/PaginatorsGenerator.java
@@ -28,7 +28,6 @@ import software.amazon.smithy.ruby.codegen.GenerationContext;
 import software.amazon.smithy.ruby.codegen.RubyCodeWriter;
 import software.amazon.smithy.ruby.codegen.RubyFormatter;
 import software.amazon.smithy.ruby.codegen.RubySettings;
-import software.amazon.smithy.ruby.codegen.RubySymbolProvider;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 @SmithyInternalApi
@@ -50,7 +49,7 @@ public class PaginatorsGenerator {
         this.model = context.model();
         this.writer = new RubyCodeWriter(context.settings().getModule() + "::Paginators");
         this.rbsWriter = new RubyCodeWriter(context.settings().getModule() + "::Paginators");
-        this.symbolProvider = new RubySymbolProvider(model, settings, "Paginators", false);
+        this.symbolProvider = context.symbolProvider();
     }
 
     public void render() {

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ParserGeneratorBase.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ParserGeneratorBase.java
@@ -40,7 +40,6 @@ import software.amazon.smithy.model.traits.StreamingTrait;
 import software.amazon.smithy.ruby.codegen.GenerationContext;
 import software.amazon.smithy.ruby.codegen.RubyCodeWriter;
 import software.amazon.smithy.ruby.codegen.RubySettings;
-import software.amazon.smithy.ruby.codegen.RubySymbolProvider;
 import software.amazon.smithy.ruby.codegen.util.Streaming;
 import software.amazon.smithy.utils.SmithyUnstableApi;
 
@@ -72,7 +71,7 @@ public abstract class ParserGeneratorBase {
         this.model = context.model();
         this.generatedParsers = new HashSet<>();
         this.writer = new RubyCodeWriter(context.settings().getModule() + "::Parsers");
-        this.symbolProvider = new RubySymbolProvider(model, settings, "Parsers", true);
+        this.symbolProvider = context.symbolProvider();
     }
 
     /**
@@ -284,7 +283,7 @@ public abstract class ParserGeneratorBase {
         writer
                 .write("")
                 .write("# Error Parser for $L", s.getId().getName())
-                .openBlock("class $T", symbolProvider.toSymbol(s))
+                .openBlock("class $L", symbolProvider.toSymbol(s).getName())
                 .call(() -> renderErrorParseMethod(s))
                 .closeBlock("end");
         LOGGER.finer("Generated Error parser for " + s.getId().getName());
@@ -309,7 +308,7 @@ public abstract class ParserGeneratorBase {
         public Void structureShape(StructureShape s) {
             writer
                     .write("")
-                    .openBlock("class $T", symbolProvider.toSymbol(s))
+                    .openBlock("class $L", symbolProvider.toSymbol(s).getName())
                     .call(() -> renderStructureParseMethod(s))
                     .closeBlock("end");
 
@@ -320,7 +319,7 @@ public abstract class ParserGeneratorBase {
         public Void listShape(ListShape s) {
             writer
                     .write("")
-                    .openBlock("class $T", symbolProvider.toSymbol(s))
+                    .openBlock("class $L", symbolProvider.toSymbol(s).getName())
                     .call(() -> renderListParseMethod(s))
                     .closeBlock("end");
 
@@ -331,7 +330,7 @@ public abstract class ParserGeneratorBase {
         public Void mapShape(MapShape s) {
             writer
                     .write("")
-                    .openBlock("class $T", symbolProvider.toSymbol(s))
+                    .openBlock("class $L", symbolProvider.toSymbol(s).getName())
                     .call(() -> renderMapParseMethod(s))
                     .closeBlock("end");
 
@@ -342,7 +341,7 @@ public abstract class ParserGeneratorBase {
         public Void unionShape(UnionShape s) {
             writer
                     .write("")
-                    .openBlock("class $T", symbolProvider.toSymbol(s))
+                    .openBlock("class $L", symbolProvider.toSymbol(s).getName())
                     .call(() -> renderUnionParseMethod(s))
                     .closeBlock("end");
 

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/RestBuilderGeneratorBase.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/RestBuilderGeneratorBase.java
@@ -163,7 +163,6 @@ public abstract class RestBuilderGeneratorBase extends BuilderGeneratorBase {
             String inputGetter = "input[:" + symbolProvider.toMemberName(m) + "]";
             MapShape queryParamMap = model.expectShape(m.getTarget(), MapShape.class);
             Shape target = model.expectShape(queryParamMap.getValue().getTarget());
-            String shapeName = symbolProvider.toSymbol(queryParamMap).getName();
 
             writer.openBlock("unless $1L.nil? || $1L.empty?", inputGetter)
                     .openBlock("$1L.each do |k, v|", inputGetter)

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/StubsGeneratorBase.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/StubsGeneratorBase.java
@@ -53,7 +53,6 @@ import software.amazon.smithy.ruby.codegen.GenerationContext;
 import software.amazon.smithy.ruby.codegen.RubyCodeWriter;
 import software.amazon.smithy.ruby.codegen.RubyFormatter;
 import software.amazon.smithy.ruby.codegen.RubySettings;
-import software.amazon.smithy.ruby.codegen.RubySymbolProvider;
 
 /**
  * Base class for Stubs which iterates shapes and builds skeleton classes.
@@ -82,7 +81,7 @@ public abstract class StubsGeneratorBase {
         this.generatedStubs = new HashSet<>();
         this.context = context;
         this.writer = new RubyCodeWriter(context.settings().getModule() + "::Stubs");
-        this.symbolProvider = new RubySymbolProvider(model, settings, "Stubs", true);
+        this.symbolProvider = context.symbolProvider();
     }
 
     /**
@@ -243,7 +242,7 @@ public abstract class StubsGeneratorBase {
         writer
                 .write("")
                 .write("# Operation Stubber for $L", operation.getId().getName())
-                .openBlock("class $T", symbolProvider.toSymbol(operation))
+                .openBlock("class $L", symbolProvider.toSymbol(operation).getName())
                 .openBlock("def self.default(visited=[])")
                 .call(() -> renderMemberDefaults(outputShape))
                 .closeBlock("end")
@@ -287,7 +286,7 @@ public abstract class StubsGeneratorBase {
             writer
                     .write("")
                     .write("# Structure Stubber for $L", shape.getId().getName())
-                    .openBlock("class $T", symbolProvider.toSymbol(shape))
+                    .openBlock("class $L", name)
                     .openBlock("def self.default(visited=[])")
                     .write("return nil if visited.include?('$L')", name)
                     .write("visited = visited + ['$L']", name)
@@ -308,7 +307,7 @@ public abstract class StubsGeneratorBase {
             writer
                     .write("")
                     .write("# List Stubber for $L", shape.getId().getName())
-                    .openBlock("class $T", symbolProvider.toSymbol(shape))
+                    .openBlock("class $L", name)
                     .openBlock("def self.default(visited=[])")
                     .write("return nil if visited.include?('$L')", name)
                     .write("visited = visited + ['$L']", name)
@@ -332,7 +331,7 @@ public abstract class StubsGeneratorBase {
             writer
                     .write("")
                     .write("# Map Stubber for $L", shape.getId().getName())
-                    .openBlock("class $T", symbolProvider.toSymbol(shape))
+                    .openBlock("class $L", name)
                     .openBlock("def self.default(visited=[])")
                     .write("return nil if visited.include?('$L')", name)
                     .write("visited = visited + ['$L']", name)
@@ -355,7 +354,7 @@ public abstract class StubsGeneratorBase {
             writer
                     .write("")
                     .write("# Union Stubber for $L", shape.getId().getName())
-                    .openBlock("class $T", symbolProvider.toSymbol(shape))
+                    .openBlock("class $L", name)
                     .openBlock("def self.default(visited=[])")
                     .write("return nil if visited.include?('$L')", name)
                     .write("visited = visited + ['$L']", name)
@@ -382,7 +381,7 @@ public abstract class StubsGeneratorBase {
             writer
                     .write("")
                     .write("# Document Type Stubber for $L", name)
-                    .openBlock("class $T", symbolProvider.toSymbol(shape))
+                    .openBlock("class $L", name)
                     .openBlock("def self.default(visited=[])")
                     .write("return nil if visited.include?('$L')", name)
                     .write("visited = visited + ['$L']", name)
@@ -493,7 +492,7 @@ public abstract class StubsGeneratorBase {
          * For complex shapes, simply delegate to their Stubber.
          */
         private void complexShapeDefaults(Shape shape) {
-            writer.write("$L$T.default(visited)$L", dataSetter, symbolProvider.toSymbol(shape), eol);
+            writer.write("$L$L.default(visited)$L", dataSetter, symbolProvider.toSymbol(shape).getName(), eol);
         }
 
         @Override

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/TypesGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/TypesGenerator.java
@@ -22,6 +22,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import software.amazon.smithy.build.FileManifest;
 import software.amazon.smithy.codegen.core.Symbol;
+import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.knowledge.NullableIndex;
 import software.amazon.smithy.model.neighbor.Walker;
@@ -41,7 +42,6 @@ import software.amazon.smithy.ruby.codegen.Hearth;
 import software.amazon.smithy.ruby.codegen.RubyCodeWriter;
 import software.amazon.smithy.ruby.codegen.RubyFormatter;
 import software.amazon.smithy.ruby.codegen.RubySettings;
-import software.amazon.smithy.ruby.codegen.RubySymbolProvider;
 import software.amazon.smithy.ruby.codegen.generators.docs.ShapeDocumentationGenerator;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
@@ -56,7 +56,7 @@ public class TypesGenerator {
     private final Model model;
     private final RubyCodeWriter writer;
     private final RubyCodeWriter rbsWriter;
-    private final RubySymbolProvider symbolProvider;
+    private final SymbolProvider symbolProvider;
 
     public TypesGenerator(GenerationContext context) {
         this.context = context;
@@ -64,7 +64,7 @@ public class TypesGenerator {
         this.model = context.model();
         this.writer = new RubyCodeWriter(context.settings().getModule() + "::Types");
         this.rbsWriter = new RubyCodeWriter(context.settings().getModule() + "::Types");
-        this.symbolProvider = new RubySymbolProvider(model, settings, "Types", false);
+        this.symbolProvider = context.symbolProvider();
     }
 
     public void render() {

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/WaitersGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/WaitersGenerator.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import software.amazon.smithy.build.FileManifest;
+import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.jmespath.ExpressionSerializer;
 import software.amazon.smithy.jmespath.ExpressionVisitor;
 import software.amazon.smithy.jmespath.JmespathExpression;
@@ -70,7 +71,7 @@ public class WaitersGenerator {
     private final Model model;
     private final RubyCodeWriter writer;
     private final RubyCodeWriter rbsWriter;
-    private final RubySymbolProvider symbolProvider;
+    private final SymbolProvider symbolProvider;
 
     public WaitersGenerator(GenerationContext context) {
         this.context = context;
@@ -78,7 +79,7 @@ public class WaitersGenerator {
         this.model = context.model();
         this.writer = new RubyCodeWriter(context.settings().getModule() + "::Waiters");
         this.rbsWriter = new RubyCodeWriter(context.settings().getModule() + "::Waiters");
-        this.symbolProvider = new RubySymbolProvider(context.model(), settings, "Waiters", false);
+        this.symbolProvider = context.symbolProvider();
     }
 
     public void render() {
@@ -323,7 +324,7 @@ public class WaitersGenerator {
         }
     }
 
-    private class JmespathTranslator implements ExpressionVisitor<JmespathExpression> {
+    private static class JmespathTranslator implements ExpressionVisitor<JmespathExpression> {
 
         @Override
         public JmespathExpression visitComparator(ComparatorExpression expression) {
@@ -373,7 +374,7 @@ public class WaitersGenerator {
         @Override
         public JmespathExpression visitField(FieldExpression expression) {
             return new FieldExpression(
-                    symbolProvider.toMemberName(expression.getName()),
+                    RubySymbolProvider.toMemberName(expression.getName()),
                     expression.getLine(), expression.getColumn());
         }
 

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/docs/ResponseExampleGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/docs/ResponseExampleGenerator.java
@@ -18,6 +18,7 @@ package software.amazon.smithy.ruby.codegen.generators.docs;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
+import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.ListShape;
 import software.amazon.smithy.model.shapes.MapShape;
@@ -31,7 +32,6 @@ import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.EnumTrait;
 import software.amazon.smithy.ruby.codegen.RubyCodeWriter;
 import software.amazon.smithy.ruby.codegen.RubyFormatter;
-import software.amazon.smithy.ruby.codegen.RubySymbolProvider;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 @SmithyInternalApi
@@ -40,11 +40,11 @@ public class ResponseExampleGenerator {
     private final OperationShape operation;
     private final RubyCodeWriter writer;
     private final Set<ShapeId> visited;
-    private final RubySymbolProvider symbolProvider;
+    private final SymbolProvider symbolProvider;
     private final Model model;
 
     public ResponseExampleGenerator(OperationShape operation,
-                                    RubySymbolProvider symbolProvider, Model model) {
+                                    SymbolProvider symbolProvider, Model model) {
         this.operation = operation;
         this.symbolProvider = symbolProvider;
         this.model = model;

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/docs/ShapeDocumentationGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/docs/ShapeDocumentationGenerator.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
@@ -40,7 +41,6 @@ import software.amazon.smithy.model.traits.SinceTrait;
 import software.amazon.smithy.model.traits.TagsTrait;
 import software.amazon.smithy.model.traits.UnstableTrait;
 import software.amazon.smithy.ruby.codegen.RubyCodeWriter;
-import software.amazon.smithy.ruby.codegen.RubySymbolProvider;
 import software.amazon.smithy.utils.SmithyInternalApi;
 
 /**
@@ -50,7 +50,7 @@ import software.amazon.smithy.utils.SmithyInternalApi;
 public class ShapeDocumentationGenerator {
     private final Model model;
     private final RubyCodeWriter writer;
-    private final RubySymbolProvider symbolProvider;
+    private final SymbolProvider symbolProvider;
     private final Shape shape;
 
     /**
@@ -58,7 +58,7 @@ public class ShapeDocumentationGenerator {
      * @param symbolProvider symbol provider
      * @param shape shape to generate documentation for
      */
-    public ShapeDocumentationGenerator(Model model, RubySymbolProvider symbolProvider, Shape shape) {
+    public ShapeDocumentationGenerator(Model model, SymbolProvider symbolProvider, Shape shape) {
         this.writer = new RubyCodeWriter("");
         this.model = model;
         this.symbolProvider = symbolProvider;

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/middleware/MiddlewareBuilder.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/middleware/MiddlewareBuilder.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import software.amazon.smithy.codegen.core.SymbolProvider;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.pattern.SmithyPattern;
 import software.amazon.smithy.model.shapes.OperationShape;
@@ -113,8 +114,7 @@ public class MiddlewareBuilder {
 
     public void addDefaultMiddleware(GenerationContext context) {
         ApplicationTransport transport = context.applicationTransport();
-        RubySymbolProvider symbolProvider =
-                new RubySymbolProvider(context.model(), context.settings(), "Client", false);
+        SymbolProvider symbolProvider = context.symbolProvider();
 
         ClientConfig validateInput = (new ClientConfig.Builder())
                 .name("validate_input")
@@ -159,7 +159,7 @@ public class MiddlewareBuilder {
                         if (segment.isLabel()) {
                             // Here, we rebuild the smithy pattern with reserved word support.
                             // Otherwise we could use pattern.toString()
-                            String label = symbolProvider.toMemberName(segment.getContent());
+                            String label = RubySymbolProvider.toMemberName(segment.getContent());
                             prefix.append("{" + label + "}");
                         } else {
                             prefix.append(segment);

--- a/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/protocol/railsjson/generators/BuilderGenerator.java
+++ b/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/protocol/railsjson/generators/BuilderGenerator.java
@@ -145,7 +145,7 @@ public class BuilderGenerator extends RestBuilderGeneratorBase {
 
         shape.members().forEach((member) -> {
             writer
-                    .write("when $T", context.symbolProvider().toSymbol(member))
+                    .write("when $T", symbolProvider.toSymbol(member))
                     .indent();
             renderUnionMemberBuilder(shape, member);
             writer.dedent();


### PR DESCRIPTION
*Description of changes:*

When using directed codegen, a single instance of SymbolProvider is created. Behind the scene, Directed codgen caches symbols returned by the SymbolProvider instance (see [here](https://github.com/awslabs/smithy/blob/main/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/directed/CodegenDirector.java#L360-L370) and [here](https://github.com/awslabs/smithy/blob/main/smithy-codegen-core/src/main/java/software/amazon/smithy/codegen/core/CachingSymbolProvider.java)). 

We should avoid multiple instances of SymbolProvider if possible and take advantage of the caching mechanism.

This PR contains the following changes:
* Replace RubySymbolProvider initializations with `context.symbolProvider()` in code generators 
* Set default module to `Types` and definitionFile `types.rb` in SymbolProvider

Testing: Ran `./gradlew clean build` and confirm generated ruby code remains unchanged

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
