### PR TITLE
Fix missed filtering of integrations

### DIFF
--- a/codegen/smithy-ruby-codegen/build.gradle.kts
+++ b/codegen/smithy-ruby-codegen/build.gradle.kts
@@ -33,6 +33,7 @@ buildscript {
 
 dependencies {
     api("software.amazon.smithy:smithy-codegen-core:${rootProject.extra["smithyVersion"]}")
+    api("software.amazon.smithy:smithy-rules-engine:${rootProject.extra["smithyVersion"]}")
     implementation("software.amazon.smithy:smithy-waiters:${rootProject.extra["smithyVersion"]}")
     implementation("software.amazon.smithy:smithy-protocol-test-traits:${rootProject.extra["smithyVersion"]}")
 }

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/DirectedRubyCodegen.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/DirectedRubyCodegen.java
@@ -73,7 +73,10 @@ public class DirectedRubyCodegen
     public GenerationContext createContext(CreateContextDirective<RubySettings, RubyIntegration> directive) {
         ServiceShape service = directive.service();
         Model model = directive.model();
-        List<RubyIntegration> integrations = directive.integrations();
+        List<RubyIntegration> integrations = directive.integrations().stream()
+                .filter((integration) -> integration
+                        .includeFor(service, model))
+                .collect(Collectors.toList());
 
         Map<ShapeId, ProtocolGenerator> supportedProtocols = ProtocolGenerator
             .collectSupportedProtocolGenerators(integrations);

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ParamsGenerator.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/ParamsGenerator.java
@@ -290,7 +290,9 @@ public class ParamsGenerator extends RubyGeneratorBase {
                 // Note: No need to check for box trait for V1 Smithy models.
                 // Smithy convert V1 to V2 model and populate Default trait automatically
                 boolean containsRequiredAndDefaultTraits =
-                        memberShape.hasTrait(DefaultTrait.class) && memberShape.hasTrait(RequiredTrait.class);
+                        memberShape.hasTrait(DefaultTrait.class) &&
+                                !memberShape.expectTrait(DefaultTrait.class).toNode().isNullNode() &&
+                                memberShape.hasTrait(RequiredTrait.class);
 
                 if (containsRequiredAndDefaultTraits) {
                     Shape targetShape = model.expectShape(memberShape.getTarget());


### PR DESCRIPTION

*Description of changes:*
Add back in filtering of integrations that was missed in earlier PRs that moved the Orchestartor to the Directed codegen.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
