### PR TITLE
Fix issue with float rounding of fractional seconds

### DIFF
--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/util/ParamsToHash.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/util/ParamsToHash.java
@@ -195,8 +195,8 @@ public class ParamsToHash extends ShapeVisitor.Default<String> {
             if (node.expectNumberNode().isFloatingPointNumber()) {
                 // rounding of floats cause an issue in the precision of fractional seconds
                 Double n = node.expectNumberNode().getValue().doubleValue();
-                int seconds = (int) Math.floor(n);
-                int ms = (int) ((n - Math.floor(n)) * 1000);
+                long seconds = (long) Math.floor(n);
+                long ms = (long) ((n - Math.floor(n)) * 1000);
                 return "Time.at(" + seconds + ", " + ms + ", :millisecond)";
             } else {
                 return "Time.at(" + node.expectNumberNode().getValue().toString() + ")";

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/util/ParamsToHash.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/util/ParamsToHash.java
@@ -192,7 +192,15 @@ public class ParamsToHash extends ShapeVisitor.Default<String> {
             return "";
         }
         if (node.isNumberNode()) {
-            return "Time.at(" + node.expectNumberNode().getValue().toString() + ")";
+            if (node.expectNumberNode().isFloatingPointNumber()) {
+                // rounding of floats cause an issue in the precision of fractional seconds
+                Double n = node.expectNumberNode().getValue().doubleValue();
+                int seconds = (int) Math.floor(n);
+                int ms = (int) ((n - Math.floor(n)) * 1000);
+                return "Time.at(" + seconds + ", " + ms + ", :millisecond)";
+            } else {
+                return "Time.at(" + node.expectNumberNode().getValue().toString() + ")";
+            }
         }
         return "Time.parse('" + node + "')";
     }


### PR DESCRIPTION

*Description of changes:*
Rounding of float fractional seconds causes protocol test failures:

```
 t1 = Time.parse("2000-01-02T20:34:56.123Z") # this is how its parsed from the wire
t2 = Time.at(946845296.123) # the code in the protocol test
t1 == t2 # false
t1.to_f == t2.to_f # true

t3 = Time.at(946845296, 123, :millisecond) # that same number, split into seconds/ms.  
t1 == t3 # true
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
