### PR TITLE
Add support for fractional timestamps

### DIFF
--- a/codegen/projections/rails_json/spec/protocol_spec.rb
+++ b/codegen/projections/rails_json/spec/protocol_spec.rb
@@ -3830,6 +3830,24 @@ module RailsJson
             timestamp: Time.at(946845296)
           }, **opts)
         end
+        # Serializes fractional timestamp shapes
+        #
+        it 'rails_json_serializes_fractional_timestamp_shapes' do
+          middleware = Hearth::MiddlewareBuilder.before_send do |input, context|
+            request = context.request
+            request_uri = URI.parse(request.url)
+            expect(request.http_method).to eq('POST')
+            expect(request_uri.path).to eq('/')
+            { 'Content-Type' => 'application/json' }.each { |k, v| expect(request.headers[k]).to eq(v) }
+            ['Content-Length'].each { |k| expect(request.headers.key?(k)).to be(true) }
+            expect(JSON.parse(request.body.read)).to eq(JSON.parse('{"timestamp":"2000-01-02T20:34:56.123Z"}'))
+            Hearth::Output.new
+          end
+          opts = {middleware: middleware}
+          client.kitchen_sink_operation({
+            timestamp: Time.at(946845296, 123, :millisecond)
+          }, **opts)
+        end
         # Serializes timestamp shapes with iso8601 timestampFormat
         #
         it 'rails_json_serializes_timestamp_shapes_with_iso8601_timestampformat' do
@@ -4424,6 +4442,23 @@ module RailsJson
             timestamp: Time.at(946845296)
           })
         end
+        # Parses fractional timestamp shapes
+        #
+        it 'rails_json_parses_fractional_timestamp_shapes' do
+          middleware = Hearth::MiddlewareBuilder.around_send do |app, input, context|
+            response = context.response
+            response.status = 200
+            response.headers = Hearth::HTTP::Headers.new({ 'Content-Type' => 'application/json' })
+            response.body.write('{"timestamp":"2000-01-02T20:34:56.123Z"}')
+            response.body.rewind
+            Hearth::Output.new
+          end
+          middleware.remove_send.remove_build.remove_retry
+          output = client.kitchen_sink_operation({}, middleware: middleware)
+          expect(output.data.to_h).to eq({
+            timestamp: Time.at(946845296, 123, :millisecond)
+          })
+        end
         # Parses iso8601 timestamps
         #
         it 'rails_json_parses_iso8601_timestamps' do
@@ -4456,6 +4491,23 @@ module RailsJson
           output = client.kitchen_sink_operation({}, middleware: middleware)
           expect(output.data.to_h).to eq({
             httpdate_timestamp: Time.at(946845296)
+          })
+        end
+        # Parses fractional httpdate timestamps
+        #
+        it 'rails_json_parses_fractional_httpdate_timestamps' do
+          middleware = Hearth::MiddlewareBuilder.around_send do |app, input, context|
+            response = context.response
+            response.status = 200
+            response.headers = Hearth::HTTP::Headers.new({ 'Content-Type' => 'application/json' })
+            response.body.write('{"httpdate_timestamp":"Sun, 02 Jan 2000 20:34:56.123 GMT"}')
+            response.body.rewind
+            Hearth::Output.new
+          end
+          middleware.remove_send.remove_build.remove_retry
+          output = client.kitchen_sink_operation({}, middleware: middleware)
+          expect(output.data.to_h).to eq({
+            httpdate_timestamp: Time.at(946845296, 123, :millisecond)
           })
         end
         # Parses list shapes
@@ -4889,6 +4941,22 @@ module RailsJson
             timestamp: Time.at(946845296)
           })
         end
+        # Parses fractional timestamp shapes
+        #
+        it 'stubs rails_json_parses_fractional_timestamp_shapes' do
+          middleware = Hearth::MiddlewareBuilder.after_send do |input, context|
+            response = context.response
+            expect(response.status).to eq(200)
+          end
+          middleware.remove_build.remove_retry
+          client.stub_responses(:kitchen_sink_operation, {
+            timestamp: Time.at(946845296, 123, :millisecond)
+          })
+          output = client.kitchen_sink_operation({}, middleware: middleware)
+          expect(output.data.to_h).to eq({
+            timestamp: Time.at(946845296, 123, :millisecond)
+          })
+        end
         # Parses iso8601 timestamps
         #
         it 'stubs rails_json_parses_iso8601_timestamps' do
@@ -4919,6 +4987,22 @@ module RailsJson
           output = client.kitchen_sink_operation({}, middleware: middleware)
           expect(output.data.to_h).to eq({
             httpdate_timestamp: Time.at(946845296)
+          })
+        end
+        # Parses fractional httpdate timestamps
+        #
+        it 'stubs rails_json_parses_fractional_httpdate_timestamps' do
+          middleware = Hearth::MiddlewareBuilder.after_send do |input, context|
+            response = context.response
+            expect(response.status).to eq(200)
+          end
+          middleware.remove_build.remove_retry
+          client.stub_responses(:kitchen_sink_operation, {
+            httpdate_timestamp: Time.at(946845296, 123, :millisecond)
+          })
+          output = client.kitchen_sink_operation({}, middleware: middleware)
+          expect(output.data.to_h).to eq({
+            httpdate_timestamp: Time.at(946845296, 123, :millisecond)
           })
         end
         # Parses list shapes

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/util/ParamsToHash.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/util/ParamsToHash.java
@@ -196,7 +196,7 @@ public class ParamsToHash extends ShapeVisitor.Default<String> {
                 // rounding of floats cause an issue in the precision of fractional seconds
                 Double n = node.expectNumberNode().getValue().doubleValue();
                 long seconds = (long) Math.floor(n);
-                long ms = (long) ((n - Math.floor(n)) * 1000);
+                long ms = Math.round((n - Math.floor(n)) * 1000);
                 return "Time.at(" + seconds + ", " + ms + ", :millisecond)";
             } else {
                 return "Time.at(" + node.expectNumberNode().getValue().toString() + ")";

--- a/codegen/smithy-ruby-rails-codegen-test/model/protocol-test/kitchen-sink.smithy
+++ b/codegen/smithy-ruby-rails-codegen-test/model/protocol-test/kitchen-sink.smithy
@@ -169,6 +169,22 @@ use smithy.test#httpResponseTests
         uri: "/",
     },
     {
+        id: "rails_json_serializes_fractional_timestamp_shapes",
+        protocol: railsJson,
+        documentation: "Serializes fractional timestamp shapes",
+        body: "{\"timestamp\":\"2000-01-02T20:34:56.123Z\"}",
+        bodyMediaType: "application/json",
+        headers: {"Content-Type": "application/json"},
+        requireHeaders: [
+            "Content-Length"
+        ],
+        params: {
+            Timestamp: 946845296.123,
+        },
+        method: "POST",
+        uri: "/",
+    },
+    {
         id: "rails_json_serializes_timestamp_shapes_with_iso8601_timestampformat",
         protocol: railsJson,
         documentation: "Serializes timestamp shapes with iso8601 timestampFormat",
@@ -665,6 +681,18 @@ use smithy.test#httpResponseTests
         code: 200,
     },
     {
+        id: "rails_json_parses_fractional_timestamp_shapes",
+        protocol: railsJson,
+        documentation: "Parses fractional timestamp shapes",
+        body: "{\"timestamp\":\"2000-01-02T20:34:56.123Z\"}",
+        bodyMediaType: "application/json",
+        headers: {"Content-Type": "application/json"},
+        params: {
+            Timestamp: 946845296.123,
+        },
+        code: 200,
+    },
+    {
         id: "rails_json_parses_iso8601_timestamps",
         protocol: railsJson,
         documentation: "Parses iso8601 timestamps",
@@ -685,6 +713,18 @@ use smithy.test#httpResponseTests
         headers: {"Content-Type": "application/json"},
         params: {
             HttpdateTimestamp: 946845296,
+        },
+        code: 200,
+    },
+    {
+        id: "rails_json_parses_fractional_httpdate_timestamps",
+        protocol: railsJson,
+        documentation: "Parses fractional httpdate timestamps",
+        body: "{\"httpdate_timestamp\":\"Sun, 02 Jan 2000 20:34:56.123 GMT\"}",
+        bodyMediaType: "application/json",
+        headers: {"Content-Type": "application/json"},
+        params: {
+            HttpdateTimestamp: 946845296.123,
         },
         code: 200,
     },

--- a/hearth/lib/hearth/time_helper.rb
+++ b/hearth/lib/hearth/time_helper.rb
@@ -11,7 +11,11 @@ module Hearth
       # @param [Time] time
       # @return [String<Date Time>] The time as an ISO8601 string.
       def to_date_time(time)
-        time.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
+        if time.subsec.zero?
+          time.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
+        else
+          time.utc.strftime('%Y-%m-%dT%H:%M:%S.%LZ')
+        end
       end
 
       # @param [Time] time
@@ -28,7 +32,16 @@ module Hearth
       # @return [String<Http Date>] Returns the time formatted
       #   as an HTTP header date.
       def to_http_date(time)
-        time.utc.httpdate
+        if time.subsec.zero?
+          time.utc.httpdate
+        else
+          t = time.utc
+          format('%s, %02d %s %0*d %02d:%02d:%02d.%03d GMT',
+                 Time::RFC2822_DAY_NAME[t.wday],
+                 t.day, Time::RFC2822_MONTH_NAME[t.mon - 1],
+                 t.year.negative? ? 5 : 4, t.year,
+                 t.hour, t.min, t.sec, (t.subsec * 1000).round)
+        end
       end
     end
   end

--- a/hearth/lib/hearth/time_helper.rb
+++ b/hearth/lib/hearth/time_helper.rb
@@ -11,11 +11,8 @@ module Hearth
       # @param [Time] time
       # @return [String<Date Time>] The time as an ISO8601 string.
       def to_date_time(time)
-        if time.subsec.zero?
-          time.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
-        else
-          time.utc.strftime('%Y-%m-%dT%H:%M:%S.%LZ')
-        end
+        optional_ms_digits = time.subsec.zero? ? nil : 3
+        time.utc.iso8601(optional_ms_digits)
       end
 
       # @param [Time] time
@@ -32,11 +29,8 @@ module Hearth
       # @return [String<Http Date>] Returns the time formatted
       #   as an HTTP header date.
       def to_http_date(time)
-        if time.subsec.zero?
-          time.utc.httpdate
-        else
-          time.utc.strftime('%a, %d %b %Y %H:%M:%S.%L GMT')
-        end
+        fractional = '.%L' unless time.subsec.zero?
+        time.utc.strftime("%a, %d %b %Y %H:%M:%S#{fractional} GMT")
       end
     end
   end

--- a/hearth/lib/hearth/time_helper.rb
+++ b/hearth/lib/hearth/time_helper.rb
@@ -35,12 +35,7 @@ module Hearth
         if time.subsec.zero?
           time.utc.httpdate
         else
-          t = time.utc
-          format('%s, %02d %s %0*d %02d:%02d:%02d.%03d GMT',
-                 Time::RFC2822_DAY_NAME[t.wday],
-                 t.day, Time::RFC2822_MONTH_NAME[t.mon - 1],
-                 t.year.negative? ? 5 : 4, t.year,
-                 t.hour, t.min, t.sec, (t.subsec * 1000).round)
+          time.utc.strftime('%a, %d %b %Y %H:%M:%S.%L GMT')
         end
       end
     end

--- a/hearth/spec/hearth/time_helper_spec.rb
+++ b/hearth/spec/hearth/time_helper_spec.rb
@@ -8,6 +8,13 @@ module Hearth
       it 'converts a time object to date time format' do
         expect(subject.to_date_time(time)).to eq '1970-01-01T00:00:00Z'
       end
+
+      context 'fractional seconds' do
+        let(:time) { Time.at(946_845_296, 123, :millisecond) }
+        it 'converts to date time format with milliseconds' do
+          expect(subject.to_date_time(time)).to eq '2000-01-02T20:34:56.123Z'
+        end
+      end
     end
 
     describe '.to_epoch_seconds' do
@@ -19,6 +26,14 @@ module Hearth
     describe '.to_http_date' do
       it 'converts a time object to http date format' do
         expect(subject.to_http_date(time)).to eq 'Thu, 01 Jan 1970 00:00:00 GMT'
+      end
+
+      context 'fractional seconds' do
+        let(:time) { Time.at(946_845_296, 123, :millisecond) }
+        it 'converts to http date format with milliseconds' do
+          expect(subject.to_http_date(time))
+            .to eq 'Sun, 02 Jan 2000 20:34:56.123 GMT'
+        end
       end
     end
   end

--- a/hearth/spec/hearth/time_helper_spec.rb
+++ b/hearth/spec/hearth/time_helper_spec.rb
@@ -21,6 +21,13 @@ module Hearth
       it 'converts a time object to epoch seconds format' do
         expect(subject.to_epoch_seconds(time)).to eq 0.0
       end
+
+      context 'fractional seconds' do
+        let(:time) { Time.at(946_845_296, 123, :millisecond) }
+        it 'converts to date time format with milliseconds' do
+          expect(subject.to_epoch_seconds(time)).to eq 946_845_296.123
+        end
+      end
     end
 
     describe '.to_http_date' do


### PR DESCRIPTION
*Description of changes:*
Add support for fractional timestamps.  Port fractional timestamp protocol tests from AWS.

References:
* https://github.com/awslabs/smithy/pull/1627
* https://smithy.io/1.0/spec/core/protocol-traits.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
