### PR TITLE
Add support for specifying relative middleware ordering

### DIFF
--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/middleware/Middleware.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/middleware/Middleware.java
@@ -28,6 +28,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import software.amazon.smithy.codegen.core.CodegenException;
@@ -54,6 +55,8 @@ public final class Middleware {
     private final String klass;
     private final MiddlewareStackStep step;
     private final byte order;
+
+    private final Optional<Relative> relative;
     private final Set<ClientConfig> clientConfig;
     private final OperationParams operationParams;
     private final Map<String, String> additionalParams;
@@ -68,6 +71,7 @@ public final class Middleware {
         this.klass = builder.klass;
         this.step = builder.step;
         this.order = builder.order;
+        this.relative = builder.relative;
         this.clientConfig = builder.clientConfig;
         this.operationParams = builder.operationParams;
         this.additionalParams = builder.additionalParams;
@@ -96,6 +100,13 @@ public final class Middleware {
      */
     public byte getOrder() {
         return order;
+    }
+
+    /**
+     * @return relative order within stack step
+     */
+    public Optional<Relative> getRelative() {
+        return relative;
     }
 
     /**
@@ -236,6 +247,7 @@ public final class Middleware {
                     }
                 };
         private byte order = 0;
+        private Optional<Relative> relative = Optional.empty();
         private String klass;
         private MiddlewareStackStep step;
         private Set<ClientConfig> clientConfig = new HashSet<>();
@@ -263,7 +275,18 @@ public final class Middleware {
          * @return Returns the builder
          */
         public Builder order(byte order) {
+            if (relative.isPresent()) {
+                throw new IllegalArgumentException("Cannot combine relative ordering with explicit order value.");
+            }
             this.order = order;
+            return this;
+        }
+
+        public Builder relative(Relative relative) {
+            if (order != 0) {
+                throw new IllegalArgumentException("Cannot combine relative ordering with explicit order value.");
+            }
+            this.relative = Optional.of(relative);
             return this;
         }
 
@@ -465,6 +488,33 @@ public final class Middleware {
         @Override
         public Middleware build() {
             return new Middleware(this);
+        }
+    }
+
+    public static class Relative {
+        private final Type type;
+        private final String to;
+
+        public Relative(Type type, String to) {
+            this.type = type;
+            this.to = to;
+        }
+
+        public Type getType() {
+            return type;
+        }
+
+        public String getTo() {
+            return to;
+        }
+
+        public String toString() {
+            return type + " " + to;
+        }
+
+        public enum Type {
+            BEFORE,
+            AFTER
         }
     }
 }


### PR DESCRIPTION
*Description of changes:*

Add relative middleware ordering.

Middleware may EITHER set an explicit "order" (with 0 being default) OR set a `Relative` and specify the ruby class. Middleware may only specify ONE relative ordering constraint.

When rendering the middleware stack for each operation, we first apply the service/operation predicate to get a set of all middleware for the stack, then we recursively attempt to resolve the order.  If a middleware was a Relative, we resolve the order for that middleware.  If it does not, we use the given order (which defaults to 0).  

In java code this looks like:
```java
        // Add two demo relative middlewares
        Middleware a = (new Middleware.Builder())
                .klass("Hearth::Middleware::Middleware1")
                .step(MiddlewareStackStep.SERIALIZE)
                .relative(new Middleware.Relative(Middleware.Relative.Type.BEFORE, "Hearth::Middleware::Middleware2"))
                .build();

        Middleware b = (new Middleware.Builder())
                .klass("Hearth::Middleware::Middleware2")
                .step(MiddlewareStackStep.SERIALIZE)
                .relative(new Middleware.Relative(Middleware.Relative.Type.AFTER, "Hearth::Middleware::Build"))
                .build();
```

This produces:
```ruby
stack.use(Hearth::Middleware::Validate,
        validator: Validators::CreateHighScoreInput,
        validate_input: @config.validate_input
      )
      stack.use(Hearth::Middleware::Middleware1)
      stack.use(Hearth::Middleware::Build,
        builder: Builders::CreateHighScore
      ) 
      stack.use(Hearth::Middleware::Middleware2)
      stack.use(Hearth::HTTP::Middleware::ContentLength)
```

There are a few error cases that will result in errors during codegen time:
* circular dependencies: These will result in a stack overflow.  Here we catch the error and raise a message.
* specifying a Relative to that doesn't exist (ie, it may have gotten filtered for a given operation) - here was also raise an error w/ a message.

There is one weakness - you can only specify one relative ordering and it doesn't guarantee the rest of the order.
eg:
A before B
B after C
This could produce:
A -> C -> B
C -> A -> B
(ie, either is perfectly valid, but A may care about its relation to both C and B).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
