### PR TITLE
Fix bug in handling of renamed shapes

### DIFF
--- a/codegen/projections/rails_json/lib/rails_json/builders.rb
+++ b/codegen/projections/rails_json/lib/rails_json/builders.rb
@@ -295,6 +295,15 @@ module RailsJson
     end
 
     # Structure Builder for GreetingStruct
+    class RenamedGreeting
+      def self.build(input)
+        data = {}
+        data[:salutation] = input[:salutation] unless input[:salutation].nil?
+        data
+      end
+    end
+
+    # Structure Builder for GreetingStruct
     class GreetingStruct
       def self.build(input)
         data = {}
@@ -849,6 +858,8 @@ module RailsJson
           data[:map_value] = (Builders::StringMap.build(input) unless input.nil?)
         when Types::MyUnion::StructureValue
           data[:structure_value] = (Builders::GreetingStruct.build(input) unless input.nil?)
+        when Types::MyUnion::RenamedStructureValue
+          data[:renamed_structure_value] = (Builders::RenamedGreeting.build(input) unless input.nil?)
         else
           raise ArgumentError,
           "Expected input to be one of the subclasses of Types::MyUnion"

--- a/codegen/projections/rails_json/lib/rails_json/client.rb
+++ b/codegen/projections/rails_json/lib/rails_json/client.rb
@@ -1784,6 +1784,9 @@ module RailsJson
     #       },
     #       structure_value: {
     #         hi: 'hi'
+    #       },
+    #       renamed_structure_value: {
+    #         salutation: 'salutation'
     #       }
     #     }
     #   )
@@ -1791,7 +1794,7 @@ module RailsJson
     # @example Response structure
     #
     #   resp.data #=> Types::JsonUnionsOutput
-    #   resp.data.contents #=> Types::MyUnion, one of [StringValue, BooleanValue, NumberValue, BlobValue, TimestampValue, EnumValue, ListValue, MapValue, StructureValue]
+    #   resp.data.contents #=> Types::MyUnion, one of [StringValue, BooleanValue, NumberValue, BlobValue, TimestampValue, EnumValue, ListValue, MapValue, StructureValue, RenamedStructureValue]
     #   resp.data.contents.string_value #=> String
     #   resp.data.contents.boolean_value #=> Boolean
     #   resp.data.contents.number_value #=> Integer
@@ -1804,6 +1807,8 @@ module RailsJson
     #   resp.data.contents.map_value['key'] #=> String
     #   resp.data.contents.structure_value #=> Types::GreetingStruct
     #   resp.data.contents.structure_value.hi #=> String
+    #   resp.data.contents.renamed_structure_value #=> Types::RenamedGreeting
+    #   resp.data.contents.renamed_structure_value.salutation #=> String
     #
     def json_unions(params = {}, options = {}, &block)
       stack = Hearth::MiddlewareStack.new

--- a/codegen/projections/rails_json/lib/rails_json/params.rb
+++ b/codegen/projections/rails_json/lib/rails_json/params.rb
@@ -339,6 +339,15 @@ module RailsJson
       end
     end
 
+    module RenamedGreeting
+      def self.build(params, context: '')
+        Hearth::Validator.validate_types!(params, ::Hash, Types::RenamedGreeting, context: context)
+        type = Types::RenamedGreeting.new
+        type.salutation = params[:salutation]
+        type
+      end
+    end
+
     module GreetingWithErrorsInput
       def self.build(params, context: '')
         Hearth::Validator.validate_types!(params, ::Hash, Types::GreetingWithErrorsInput, context: context)
@@ -1005,9 +1014,13 @@ module RailsJson
           Types::MyUnion::StructureValue.new(
             (GreetingStruct.build(params[:structure_value], context: "#{context}[:structure_value]") unless params[:structure_value].nil?)
           )
+        when :renamed_structure_value
+          Types::MyUnion::RenamedStructureValue.new(
+            (RenamedGreeting.build(params[:renamed_structure_value], context: "#{context}[:renamed_structure_value]") unless params[:renamed_structure_value].nil?)
+          )
         else
           raise ArgumentError,
-                "Expected #{context} to have one of :string_value, :boolean_value, :number_value, :blob_value, :timestamp_value, :enum_value, :list_value, :map_value, :structure_value set"
+                "Expected #{context} to have one of :string_value, :boolean_value, :number_value, :blob_value, :timestamp_value, :enum_value, :list_value, :map_value, :structure_value, :renamed_structure_value set"
         end
       end
     end

--- a/codegen/projections/rails_json/lib/rails_json/parsers.rb
+++ b/codegen/projections/rails_json/lib/rails_json/parsers.rb
@@ -223,6 +223,14 @@ module RailsJson
       end
     end
 
+    class RenamedGreeting
+      def self.parse(map)
+        data = Types::RenamedGreeting.new
+        data.salutation = map['salutation']
+        return data
+      end
+    end
+
     class GreetingStruct
       def self.parse(map)
         data = Types::GreetingStruct.new
@@ -669,6 +677,9 @@ module RailsJson
         when 'structure_value'
           value = (Parsers::GreetingStruct.parse(value) unless value.nil?)
           Types::MyUnion::StructureValue.new(value) if value
+        when 'renamed_structure_value'
+          value = (Parsers::RenamedGreeting.parse(value) unless value.nil?)
+          Types::MyUnion::RenamedStructureValue.new(value) if value
         else
           Types::MyUnion::Unknown.new({name: key, value: value})
         end

--- a/codegen/projections/rails_json/lib/rails_json/stubs.rb
+++ b/codegen/projections/rails_json/lib/rails_json/stubs.rb
@@ -336,6 +336,24 @@ module RailsJson
     end
 
     # Structure Stubber for GreetingStruct
+    class RenamedGreeting
+      def self.default(visited=[])
+        return nil if visited.include?('RenamedGreeting')
+        visited = visited + ['RenamedGreeting']
+        {
+          salutation: 'salutation',
+        }
+      end
+
+      def self.stub(stub)
+        stub ||= Types::RenamedGreeting.new
+        data = {}
+        data[:salutation] = stub[:salutation] unless stub[:salutation].nil?
+        data
+      end
+    end
+
+    # Structure Stubber for GreetingStruct
     class GreetingStruct
       def self.default(visited=[])
         return nil if visited.include?('GreetingStruct')
@@ -1095,6 +1113,8 @@ module RailsJson
           data[:map_value] = (Stubs::StringMap.stub(stub.__getobj__) unless stub.__getobj__.nil?)
         when Types::MyUnion::StructureValue
           data[:structure_value] = (Stubs::GreetingStruct.stub(stub.__getobj__) unless stub.__getobj__.nil?)
+        when Types::MyUnion::RenamedStructureValue
+          data[:renamed_structure_value] = (Stubs::RenamedGreeting.stub(stub.__getobj__) unless stub.__getobj__.nil?)
         else
           raise ArgumentError,
           "Expected input to be one of the subclasses of Types::MyUnion"

--- a/codegen/projections/rails_json/lib/rails_json/types.rb
+++ b/codegen/projections/rails_json/lib/rails_json/types.rb
@@ -1650,6 +1650,16 @@ module RailsJson
         end
       end
 
+      class RenamedStructureValue < MyUnion
+        def to_h
+          { renamed_structure_value: super(__getobj__) }
+        end
+
+        def to_s
+          "#<RailsJson::Types::RenamedStructureValue #{__getobj__ || 'nil'}>"
+        end
+      end
+
       # Handles unknown future members
       #
       class Unknown < MyUnion
@@ -1866,6 +1876,17 @@ module RailsJson
 
     QueryParamsAsStringListMapOutput = ::Struct.new(
       nil,
+      keyword_init: true
+    ) do
+      include Hearth::Structure
+    end
+
+    # @!attribute salutation
+    #
+    #   @return [String]
+    #
+    RenamedGreeting = ::Struct.new(
+      :salutation,
       keyword_init: true
     ) do
       include Hearth::Structure

--- a/codegen/projections/rails_json/lib/rails_json/validators.rb
+++ b/codegen/projections/rails_json/lib/rails_json/validators.rb
@@ -299,6 +299,13 @@ module RailsJson
       end
     end
 
+    class RenamedGreeting
+      def self.validate!(input, context:)
+        Hearth::Validator.validate_types!(input, Types::RenamedGreeting, context: context)
+        Hearth::Validator.validate_types!(input[:salutation], ::String, context: "#{context}[:salutation]")
+      end
+    end
+
     class GreetingWithErrorsInput
       def self.validate!(input, context:)
         Hearth::Validator.validate_types!(input, Types::GreetingWithErrorsInput, context: context)
@@ -864,6 +871,8 @@ module RailsJson
           StringMap.validate!(input.__getobj__, context: context) unless input.__getobj__.nil?
         when Types::MyUnion::StructureValue
           GreetingStruct.validate!(input.__getobj__, context: context) unless input.__getobj__.nil?
+        when Types::MyUnion::RenamedStructureValue
+          RenamedGreeting.validate!(input.__getobj__, context: context) unless input.__getobj__.nil?
         else
           raise ArgumentError,
                 "Expected #{context} to be a union member of "\
@@ -922,6 +931,12 @@ module RailsJson
       class StructureValue
         def self.validate!(input, context:)
           Validators::GreetingStruct.validate!(input, context: context) unless input.nil?
+        end
+      end
+
+      class RenamedStructureValue
+        def self.validate!(input, context:)
+          Validators::RenamedGreeting.validate!(input, context: context) unless input.nil?
         end
       end
     end

--- a/codegen/projections/rails_json/sig/rails_json/types.rbs
+++ b/codegen/projections/rails_json/sig/rails_json/types.rbs
@@ -179,6 +179,10 @@ module RailsJson
         def to_h: () -> { structure_value: Hash[Symbol,MyUnion] }
       end
 
+      class RenamedStructureValue < MyUnion
+        def to_h: () -> { renamed_structure_value: Hash[Symbol,MyUnion] }
+      end
+
       class Unknown < MyUnion
         def to_h: () -> { unknown: Hash[Symbol,MyUnion] }
       end
@@ -213,6 +217,8 @@ module RailsJson
     QueryParamsAsStringListMapInput: untyped
 
     QueryParamsAsStringListMapOutput: untyped
+
+    RenamedGreeting: untyped
 
     SimpleStruct: untyped
 

--- a/codegen/projections/rails_json/spec/protocol_spec.rb
+++ b/codegen/projections/rails_json/spec/protocol_spec.rb
@@ -3192,6 +3192,32 @@ module RailsJson
             }
           }, **opts)
         end
+        # Serializes a renamed structure union value
+        #
+        it 'RailsJsonSerializeRenamedStructureUnionValue' do
+          middleware = Hearth::MiddlewareBuilder.before_send do |input, context|
+            request = context.request
+            expect(request.http_method).to eq('POST')
+            expect(request.uri.path).to eq('/jsonunions')
+            { 'Content-Type' => 'application/json' }.each { |k, v| expect(request.headers[k]).to eq(v) }
+            expect(JSON.parse(request.body.read)).to eq(JSON.parse('{
+                "contents": {
+                    "renamed_structure_value": {
+                        "salutation": "hello!"
+                    }
+                }
+            }'))
+            Hearth::Output.new
+          end
+          opts = {middleware: middleware}
+          client.json_unions({
+            contents: {
+              renamed_structure_value: {
+                salutation: "hello!"
+              }
+            }
+          }, **opts)
+        end
       end
 
       describe 'responses' do

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/CodegenUtils.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/CodegenUtils.java
@@ -61,6 +61,6 @@ public final class CodegenUtils {
      * @return TreeSet sorted by shape name in alphabetical order
      */
     public static TreeSet<Shape> getAlphabeticalOrderedShapesSet() {
-        return new TreeSet<>(Comparator.comparing(o -> o.getId().getName()));
+        return new TreeSet<>(Comparator.comparing(o -> o.getId().getName() + " " + o.getId()));
     }
 }

--- a/codegen/smithy-ruby-rails-codegen-test/model/high-score-service.smithy
+++ b/codegen/smithy-ruby-rails-codegen-test/model/high-score-service.smithy
@@ -10,7 +10,7 @@ use smithy.ruby.protocols#UnprocessableEntityError
 @title("High Score Sample Rails Service")
 service HighScoreService {
     version: "2021-02-15",
-    resources: [HighScore],
+    resources: [HighScore]
 }
 
 /// Rails default scaffold operations

--- a/codegen/smithy-ruby-rails-codegen-test/model/protocol-test/main.smithy
+++ b/codegen/smithy-ruby-rails-codegen-test/model/protocol-test/main.smithy
@@ -11,6 +11,10 @@ use smithy.test#httpResponseTests
 @title("RailsJson Protocol Test Service")
 service RailsJson {
     version: "2018-01-01",
+    // Ensure that generators are able to handle renames.
+    rename: {
+        "aws.protocoltests.restjson.nested#GreetingStruct": "RenamedGreeting",
+    },
     operations: [
         KitchenSinkOperation,
         EndpointOperation,

--- a/codegen/smithy-ruby-rails-codegen-test/model/protocol-test/unions.smithy
+++ b/codegen/smithy-ruby-rails-codegen-test/model/protocol-test/unions.smithy
@@ -37,6 +37,10 @@ union MyUnion {
     listValue: StringList,
     mapValue: StringMap,
     structureValue: GreetingStruct,
+
+    // Note that this uses a conflicting structure name with
+    // GreetingStruct, so it must be renamed in the service.
+    renamedStructureValue: aws.protocoltests.restjson.nested#GreetingStruct,
 }
 
 apply JsonUnions @httpRequestTests([
@@ -244,6 +248,30 @@ apply JsonUnions @httpRequestTests([
             contents: {
                 structureValue: {
                     hi: "hello",
+                }
+            }
+        }
+    },
+    {
+        id: "RailsJsonSerializeRenamedStructureUnionValue",
+        documentation: "Serializes a renamed structure union value",
+        protocol: railsJson,
+        method: "POST",
+        uri: "/jsonunions",
+        body: """
+            {
+                "contents": {
+                    "renamed_structure_value": {
+                        "salutation": "hello!"
+                    }
+                }
+            }""",
+        bodyMediaType: "application/json",
+        headers: {"Content-Type": "application/json"},
+        params: {
+            contents: {
+                renamedStructureValue: {
+                    salutation: "hello!",
                 }
             }
         }


### PR DESCRIPTION
*Description of changes:*
Fixes a bug in the handling or renamed shapes.  The TreeSet used to store/sort the shapes we generate (eg in Builders) had a comparator that only considered the shape's name.  When a shape has a duplicate name (but is renamed in the service), it looks like a duplicate and isn't added to the set.  

This change adds the shapeId to the end of the string used for comparison (with a space to ensure that sort order is maintained).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
