### PR TITLE
Refactor http client and allow it on config

### DIFF
--- a/codegen/projections/high_score_service/lib/high_score_service/client.rb
+++ b/codegen/projections/high_score_service/lib/high_score_service/client.rb
@@ -87,7 +87,7 @@ module HighScoreService
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::CreateHighScore,
         stubs: @stubs,
         params_class: Params::CreateHighScoreOutput
@@ -151,7 +151,7 @@ module HighScoreService
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::DeleteHighScore,
         stubs: @stubs,
         params_class: Params::DeleteHighScoreOutput
@@ -221,7 +221,7 @@ module HighScoreService
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::GetHighScore,
         stubs: @stubs,
         params_class: Params::GetHighScoreOutput
@@ -287,7 +287,7 @@ module HighScoreService
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::ListHighScores,
         stubs: @stubs,
         params_class: Params::ListHighScoresOutput
@@ -364,7 +364,7 @@ module HighScoreService
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::UpdateHighScore,
         stubs: @stubs,
         params_class: Params::UpdateHighScoreOutput

--- a/codegen/projections/high_score_service/lib/high_score_service/client.rb
+++ b/codegen/projections/high_score_service/lib/high_score_service/client.rb
@@ -87,7 +87,7 @@ module HighScoreService
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::CreateHighScore,
         stubs: @stubs,
         params_class: Params::CreateHighScoreOutput
@@ -151,7 +151,7 @@ module HighScoreService
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::DeleteHighScore,
         stubs: @stubs,
         params_class: Params::DeleteHighScoreOutput
@@ -221,7 +221,7 @@ module HighScoreService
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::GetHighScore,
         stubs: @stubs,
         params_class: Params::GetHighScoreOutput
@@ -287,7 +287,7 @@ module HighScoreService
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::ListHighScores,
         stubs: @stubs,
         params_class: Params::ListHighScoresOutput
@@ -364,7 +364,7 @@ module HighScoreService
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::UpdateHighScore,
         stubs: @stubs,
         params_class: Params::UpdateHighScoreOutput

--- a/codegen/projections/high_score_service/lib/high_score_service/config.rb
+++ b/codegen/projections/high_score_service/lib/high_score_service/config.rb
@@ -9,20 +9,20 @@
 
 module HighScoreService
   # @!method initialize(*options)
+  #   @option args [Hearth::HTTP::Client] :client (Hearth::HTTP::Client.new)
+  #     The HTTP Client to use for request transport.
+  #
   #   @option args [Boolean] :disable_host_prefix (false)
   #     When `true`, does not perform host prefix injection using @endpoint's hostPrefix property.
   #
   #   @option args [String] :endpoint
   #     Endpoint of the service
   #
-  #   @option args [Boolean] :http_wire_trace (false)
-  #     Enable debug wire trace on http requests.
-  #
   #   @option args [Symbol] :log_level (:info)
-  #     Default log level to use
+  #     The default log level to use with the Logger.
   #
-  #   @option args [Logger] :logger ($stdout)
-  #     Logger to use for output
+  #   @option args [Logger] :logger (Logger.new($stdout, level: cfg.log_level))
+  #     The Logger instance to use for logging.
   #
   #   @option args [Hearth::Retry::Strategy] :retry_strategy (Hearth::Retry::Standard.new)
   #     Specifies which retry strategy class to use. Strategy classes
@@ -37,14 +37,14 @@ module HighScoreService
   #   @option args [Boolean] :validate_input (true)
   #     When `true`, request parameters are validated using the modeled shapes.
   #
+  # @!attribute client
+  #   @return [Hearth::HTTP::Client]
+  #
   # @!attribute disable_host_prefix
   #   @return [Boolean]
   #
   # @!attribute endpoint
   #   @return [String]
-  #
-  # @!attribute http_wire_trace
-  #   @return [Boolean]
   #
   # @!attribute log_level
   #   @return [Symbol]
@@ -62,9 +62,9 @@ module HighScoreService
   #   @return [Boolean]
   #
   Config = ::Struct.new(
+    :client,
     :disable_host_prefix,
     :endpoint,
-    :http_wire_trace,
     :log_level,
     :logger,
     :retry_strategy,
@@ -77,9 +77,9 @@ module HighScoreService
     private
 
     def validate!
+      Hearth::Validator.validate_types!(client, Hearth::HTTP::Client, context: 'options[:client]')
       Hearth::Validator.validate_types!(disable_host_prefix, TrueClass, FalseClass, context: 'options[:disable_host_prefix]')
       Hearth::Validator.validate_types!(endpoint, String, context: 'options[:endpoint]')
-      Hearth::Validator.validate_types!(http_wire_trace, TrueClass, FalseClass, context: 'options[:http_wire_trace]')
       Hearth::Validator.validate_types!(log_level, Symbol, context: 'options[:log_level]')
       Hearth::Validator.validate_types!(logger, Logger, context: 'options[:logger]')
       Hearth::Validator.validate_types!(retry_strategy, Hearth::Retry::Strategy, context: 'options[:retry_strategy]')
@@ -89,9 +89,9 @@ module HighScoreService
 
     def self.defaults
       @defaults ||= {
+        client: [Hearth::HTTP::Client.new],
         disable_host_prefix: [false],
         endpoint: [proc { |cfg| cfg[:stub_responses] ? 'http://localhost' : nil } ],
-        http_wire_trace: [false],
         log_level: [:info],
         logger: [proc { |cfg| Logger.new($stdout, level: cfg[:log_level]) } ],
         retry_strategy: [Hearth::Retry::Standard.new],

--- a/codegen/projections/high_score_service/lib/high_score_service/config.rb
+++ b/codegen/projections/high_score_service/lib/high_score_service/config.rb
@@ -9,14 +9,14 @@
 
 module HighScoreService
   # @!method initialize(*options)
-  #   @option args [Hearth::HTTP::Client] :client (Hearth::HTTP::Client.new)
-  #     The HTTP Client to use for request transport.
-  #
   #   @option args [Boolean] :disable_host_prefix (false)
   #     When `true`, does not perform host prefix injection using @endpoint's hostPrefix property.
   #
   #   @option args [String] :endpoint
   #     Endpoint of the service
+  #
+  #   @option args [Hearth::HTTP::Client] :http_client (Hearth::HTTP::Client.new)
+  #     The HTTP Client to use for request transport.
   #
   #   @option args [Symbol] :log_level (:info)
   #     The default log level to use with the Logger.
@@ -37,14 +37,14 @@ module HighScoreService
   #   @option args [Boolean] :validate_input (true)
   #     When `true`, request parameters are validated using the modeled shapes.
   #
-  # @!attribute client
-  #   @return [Hearth::HTTP::Client]
-  #
   # @!attribute disable_host_prefix
   #   @return [Boolean]
   #
   # @!attribute endpoint
   #   @return [String]
+  #
+  # @!attribute http_client
+  #   @return [Hearth::HTTP::Client]
   #
   # @!attribute log_level
   #   @return [Symbol]
@@ -62,9 +62,9 @@ module HighScoreService
   #   @return [Boolean]
   #
   Config = ::Struct.new(
-    :client,
     :disable_host_prefix,
     :endpoint,
+    :http_client,
     :log_level,
     :logger,
     :retry_strategy,
@@ -77,9 +77,9 @@ module HighScoreService
     private
 
     def validate!
-      Hearth::Validator.validate_types!(client, Hearth::HTTP::Client, context: 'options[:client]')
       Hearth::Validator.validate_types!(disable_host_prefix, TrueClass, FalseClass, context: 'options[:disable_host_prefix]')
       Hearth::Validator.validate_types!(endpoint, String, context: 'options[:endpoint]')
+      Hearth::Validator.validate_types!(http_client, Hearth::HTTP::Client, context: 'options[:http_client]')
       Hearth::Validator.validate_types!(log_level, Symbol, context: 'options[:log_level]')
       Hearth::Validator.validate_types!(logger, Logger, context: 'options[:logger]')
       Hearth::Validator.validate_types!(retry_strategy, Hearth::Retry::Strategy, context: 'options[:retry_strategy]')
@@ -89,9 +89,9 @@ module HighScoreService
 
     def self.defaults
       @defaults ||= {
-        client: [Hearth::HTTP::Client.new],
         disable_host_prefix: [false],
         endpoint: [proc { |cfg| cfg[:stub_responses] ? 'http://localhost' : nil } ],
+        http_client: [Hearth::HTTP::Client.new],
         log_level: [:info],
         logger: [proc { |cfg| Logger.new($stdout, level: cfg[:log_level]) } ],
         retry_strategy: [Hearth::Retry::Standard.new],

--- a/codegen/projections/rails_json/lib/rails_json/client.rb
+++ b/codegen/projections/rails_json/lib/rails_json/client.rb
@@ -109,7 +109,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::AllQueryStringTypes,
         stubs: @stubs,
         params_class: Params::AllQueryStringTypesOutput
@@ -173,7 +173,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::ConstantAndVariableQueryString,
         stubs: @stubs,
         params_class: Params::ConstantAndVariableQueryStringOutput
@@ -237,7 +237,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::ConstantQueryString,
         stubs: @stubs,
         params_class: Params::ConstantQueryStringOutput
@@ -308,7 +308,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::DocumentType,
         stubs: @stubs,
         params_class: Params::DocumentTypeOutput
@@ -377,7 +377,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::DocumentTypeAsPayload,
         stubs: @stubs,
         params_class: Params::DocumentTypeAsPayloadOutput
@@ -434,7 +434,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::EmptyOperation,
         stubs: @stubs,
         params_class: Params::EmptyOperationOutput
@@ -495,7 +495,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::EndpointOperation,
         stubs: @stubs,
         params_class: Params::EndpointOperationOutput
@@ -558,7 +558,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::EndpointWithHostLabelOperation,
         stubs: @stubs,
         params_class: Params::EndpointWithHostLabelOperationOutput
@@ -625,7 +625,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::GreetingWithErrors,
         stubs: @stubs,
         params_class: Params::GreetingWithErrorsOutput
@@ -692,7 +692,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::HttpPayloadTraits,
         stubs: @stubs,
         params_class: Params::HttpPayloadTraitsOutput
@@ -757,7 +757,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::HttpPayloadTraitsWithMediaType,
         stubs: @stubs,
         params_class: Params::HttpPayloadTraitsWithMediaTypeOutput
@@ -827,7 +827,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::HttpPayloadWithStructure,
         stubs: @stubs,
         params_class: Params::HttpPayloadWithStructureOutput
@@ -896,7 +896,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::HttpPrefixHeaders,
         stubs: @stubs,
         params_class: Params::HttpPrefixHeadersOutput
@@ -957,7 +957,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::HttpPrefixHeadersInResponse,
         stubs: @stubs,
         params_class: Params::HttpPrefixHeadersInResponseOutput
@@ -1017,7 +1017,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::HttpRequestWithFloatLabels,
         stubs: @stubs,
         params_class: Params::HttpRequestWithFloatLabelsOutput
@@ -1077,7 +1077,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::HttpRequestWithGreedyLabelInPath,
         stubs: @stubs,
         params_class: Params::HttpRequestWithGreedyLabelInPathOutput
@@ -1152,7 +1152,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::HttpRequestWithLabels,
         stubs: @stubs,
         params_class: Params::HttpRequestWithLabelsOutput
@@ -1220,7 +1220,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::HttpRequestWithLabelsAndTimestampFormat,
         stubs: @stubs,
         params_class: Params::HttpRequestWithLabelsAndTimestampFormatOutput
@@ -1278,7 +1278,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::HttpResponseCode,
         stubs: @stubs,
         params_class: Params::HttpResponseCodeOutput
@@ -1340,7 +1340,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::IgnoreQueryParamsInResponse,
         stubs: @stubs,
         params_class: Params::IgnoreQueryParamsInResponseOutput
@@ -1451,7 +1451,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::InputAndOutputWithHeaders,
         stubs: @stubs,
         params_class: Params::InputAndOutputWithHeadersOutput
@@ -1532,7 +1532,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::JsonEnums,
         stubs: @stubs,
         params_class: Params::JsonEnumsOutput
@@ -1640,7 +1640,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::JsonMaps,
         stubs: @stubs,
         params_class: Params::JsonMapsOutput
@@ -1739,7 +1739,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::JsonUnions,
         stubs: @stubs,
         params_class: Params::JsonUnionsOutput
@@ -1904,7 +1904,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::KitchenSinkOperation,
         stubs: @stubs,
         params_class: Params::KitchenSinkOperationOutput
@@ -1966,7 +1966,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::MediaTypeHeader,
         stubs: @stubs,
         params_class: Params::MediaTypeHeaderOutput
@@ -2028,7 +2028,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::NestedAttributesOperation,
         stubs: @stubs,
         params_class: Params::NestedAttributesOperationOutput
@@ -2099,7 +2099,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::NullAndEmptyHeadersClient,
         stubs: @stubs,
         params_class: Params::NullAndEmptyHeadersClientOutput
@@ -2169,7 +2169,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::NullOperation,
         stubs: @stubs,
         params_class: Params::NullOperationOutput
@@ -2231,7 +2231,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::OmitsNullSerializesEmptyString,
         stubs: @stubs,
         params_class: Params::OmitsNullSerializesEmptyStringOutput
@@ -2291,7 +2291,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::OperationWithOptionalInputOutput,
         stubs: @stubs,
         params_class: Params::OperationWithOptionalInputOutputOutput
@@ -2354,7 +2354,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::QueryIdempotencyTokenAutoFill,
         stubs: @stubs,
         params_class: Params::QueryIdempotencyTokenAutoFillOutput
@@ -2418,7 +2418,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::QueryParamsAsStringListMap,
         stubs: @stubs,
         params_class: Params::QueryParamsAsStringListMapOutput
@@ -2477,7 +2477,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::StreamingOperation,
         stubs: @stubs,
         params_class: Params::StreamingOperationOutput
@@ -2551,7 +2551,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::TimestampFormatHeaders,
         stubs: @stubs,
         params_class: Params::TimestampFormatHeadersOutput
@@ -2615,7 +2615,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::Operation____789BadName,
         stubs: @stubs,
         params_class: Params::Struct____789BadNameOutput

--- a/codegen/projections/rails_json/lib/rails_json/client.rb
+++ b/codegen/projections/rails_json/lib/rails_json/client.rb
@@ -109,7 +109,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::AllQueryStringTypes,
         stubs: @stubs,
         params_class: Params::AllQueryStringTypesOutput
@@ -173,7 +173,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::ConstantAndVariableQueryString,
         stubs: @stubs,
         params_class: Params::ConstantAndVariableQueryStringOutput
@@ -237,7 +237,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::ConstantQueryString,
         stubs: @stubs,
         params_class: Params::ConstantQueryStringOutput
@@ -308,7 +308,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::DocumentType,
         stubs: @stubs,
         params_class: Params::DocumentTypeOutput
@@ -377,7 +377,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::DocumentTypeAsPayload,
         stubs: @stubs,
         params_class: Params::DocumentTypeAsPayloadOutput
@@ -434,7 +434,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::EmptyOperation,
         stubs: @stubs,
         params_class: Params::EmptyOperationOutput
@@ -495,7 +495,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::EndpointOperation,
         stubs: @stubs,
         params_class: Params::EndpointOperationOutput
@@ -558,7 +558,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::EndpointWithHostLabelOperation,
         stubs: @stubs,
         params_class: Params::EndpointWithHostLabelOperationOutput
@@ -625,7 +625,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::GreetingWithErrors,
         stubs: @stubs,
         params_class: Params::GreetingWithErrorsOutput
@@ -692,7 +692,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::HttpPayloadTraits,
         stubs: @stubs,
         params_class: Params::HttpPayloadTraitsOutput
@@ -757,7 +757,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::HttpPayloadTraitsWithMediaType,
         stubs: @stubs,
         params_class: Params::HttpPayloadTraitsWithMediaTypeOutput
@@ -827,7 +827,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::HttpPayloadWithStructure,
         stubs: @stubs,
         params_class: Params::HttpPayloadWithStructureOutput
@@ -896,7 +896,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::HttpPrefixHeaders,
         stubs: @stubs,
         params_class: Params::HttpPrefixHeadersOutput
@@ -957,7 +957,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::HttpPrefixHeadersInResponse,
         stubs: @stubs,
         params_class: Params::HttpPrefixHeadersInResponseOutput
@@ -1017,7 +1017,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::HttpRequestWithFloatLabels,
         stubs: @stubs,
         params_class: Params::HttpRequestWithFloatLabelsOutput
@@ -1077,7 +1077,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::HttpRequestWithGreedyLabelInPath,
         stubs: @stubs,
         params_class: Params::HttpRequestWithGreedyLabelInPathOutput
@@ -1152,7 +1152,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::HttpRequestWithLabels,
         stubs: @stubs,
         params_class: Params::HttpRequestWithLabelsOutput
@@ -1220,7 +1220,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::HttpRequestWithLabelsAndTimestampFormat,
         stubs: @stubs,
         params_class: Params::HttpRequestWithLabelsAndTimestampFormatOutput
@@ -1278,7 +1278,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::HttpResponseCode,
         stubs: @stubs,
         params_class: Params::HttpResponseCodeOutput
@@ -1340,7 +1340,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::IgnoreQueryParamsInResponse,
         stubs: @stubs,
         params_class: Params::IgnoreQueryParamsInResponseOutput
@@ -1451,7 +1451,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::InputAndOutputWithHeaders,
         stubs: @stubs,
         params_class: Params::InputAndOutputWithHeadersOutput
@@ -1532,7 +1532,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::JsonEnums,
         stubs: @stubs,
         params_class: Params::JsonEnumsOutput
@@ -1640,7 +1640,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::JsonMaps,
         stubs: @stubs,
         params_class: Params::JsonMapsOutput
@@ -1739,7 +1739,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::JsonUnions,
         stubs: @stubs,
         params_class: Params::JsonUnionsOutput
@@ -1904,7 +1904,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::KitchenSinkOperation,
         stubs: @stubs,
         params_class: Params::KitchenSinkOperationOutput
@@ -1966,7 +1966,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::MediaTypeHeader,
         stubs: @stubs,
         params_class: Params::MediaTypeHeaderOutput
@@ -2028,7 +2028,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::NestedAttributesOperation,
         stubs: @stubs,
         params_class: Params::NestedAttributesOperationOutput
@@ -2099,7 +2099,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::NullAndEmptyHeadersClient,
         stubs: @stubs,
         params_class: Params::NullAndEmptyHeadersClientOutput
@@ -2169,7 +2169,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::NullOperation,
         stubs: @stubs,
         params_class: Params::NullOperationOutput
@@ -2231,7 +2231,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::OmitsNullSerializesEmptyString,
         stubs: @stubs,
         params_class: Params::OmitsNullSerializesEmptyStringOutput
@@ -2291,7 +2291,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::OperationWithOptionalInputOutput,
         stubs: @stubs,
         params_class: Params::OperationWithOptionalInputOutputOutput
@@ -2354,7 +2354,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::QueryIdempotencyTokenAutoFill,
         stubs: @stubs,
         params_class: Params::QueryIdempotencyTokenAutoFillOutput
@@ -2418,7 +2418,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::QueryParamsAsStringListMap,
         stubs: @stubs,
         params_class: Params::QueryParamsAsStringListMapOutput
@@ -2477,7 +2477,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::StreamingOperation,
         stubs: @stubs,
         params_class: Params::StreamingOperationOutput
@@ -2551,7 +2551,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::TimestampFormatHeaders,
         stubs: @stubs,
         params_class: Params::TimestampFormatHeadersOutput
@@ -2615,7 +2615,7 @@ module RailsJson
       stack.use(Middleware::RequestId)
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::Operation____789BadName,
         stubs: @stubs,
         params_class: Params::Struct____789BadNameOutput

--- a/codegen/projections/rails_json/lib/rails_json/config.rb
+++ b/codegen/projections/rails_json/lib/rails_json/config.rb
@@ -9,14 +9,14 @@
 
 module RailsJson
   # @!method initialize(*options)
-  #   @option args [Hearth::HTTP::Client] :client (Hearth::HTTP::Client.new)
-  #     The HTTP Client to use for request transport.
-  #
   #   @option args [Boolean] :disable_host_prefix (false)
   #     When `true`, does not perform host prefix injection using @endpoint's hostPrefix property.
   #
   #   @option args [String] :endpoint
   #     Endpoint of the service
+  #
+  #   @option args [Hearth::HTTP::Client] :http_client (Hearth::HTTP::Client.new)
+  #     The HTTP Client to use for request transport.
   #
   #   @option args [Symbol] :log_level (:info)
   #     The default log level to use with the Logger.
@@ -37,14 +37,14 @@ module RailsJson
   #   @option args [Boolean] :validate_input (true)
   #     When `true`, request parameters are validated using the modeled shapes.
   #
-  # @!attribute client
-  #   @return [Hearth::HTTP::Client]
-  #
   # @!attribute disable_host_prefix
   #   @return [Boolean]
   #
   # @!attribute endpoint
   #   @return [String]
+  #
+  # @!attribute http_client
+  #   @return [Hearth::HTTP::Client]
   #
   # @!attribute log_level
   #   @return [Symbol]
@@ -62,9 +62,9 @@ module RailsJson
   #   @return [Boolean]
   #
   Config = ::Struct.new(
-    :client,
     :disable_host_prefix,
     :endpoint,
+    :http_client,
     :log_level,
     :logger,
     :retry_strategy,
@@ -77,9 +77,9 @@ module RailsJson
     private
 
     def validate!
-      Hearth::Validator.validate_types!(client, Hearth::HTTP::Client, context: 'options[:client]')
       Hearth::Validator.validate_types!(disable_host_prefix, TrueClass, FalseClass, context: 'options[:disable_host_prefix]')
       Hearth::Validator.validate_types!(endpoint, String, context: 'options[:endpoint]')
+      Hearth::Validator.validate_types!(http_client, Hearth::HTTP::Client, context: 'options[:http_client]')
       Hearth::Validator.validate_types!(log_level, Symbol, context: 'options[:log_level]')
       Hearth::Validator.validate_types!(logger, Logger, context: 'options[:logger]')
       Hearth::Validator.validate_types!(retry_strategy, Hearth::Retry::Strategy, context: 'options[:retry_strategy]')
@@ -89,9 +89,9 @@ module RailsJson
 
     def self.defaults
       @defaults ||= {
-        client: [Hearth::HTTP::Client.new],
         disable_host_prefix: [false],
         endpoint: [proc { |cfg| cfg[:stub_responses] ? 'http://localhost' : nil } ],
+        http_client: [Hearth::HTTP::Client.new],
         log_level: [:info],
         logger: [proc { |cfg| Logger.new($stdout, level: cfg[:log_level]) } ],
         retry_strategy: [Hearth::Retry::Standard.new],

--- a/codegen/projections/rails_json/lib/rails_json/config.rb
+++ b/codegen/projections/rails_json/lib/rails_json/config.rb
@@ -9,20 +9,20 @@
 
 module RailsJson
   # @!method initialize(*options)
+  #   @option args [Hearth::HTTP::Client] :client (Hearth::HTTP::Client.new)
+  #     The HTTP Client to use for request transport.
+  #
   #   @option args [Boolean] :disable_host_prefix (false)
   #     When `true`, does not perform host prefix injection using @endpoint's hostPrefix property.
   #
   #   @option args [String] :endpoint
   #     Endpoint of the service
   #
-  #   @option args [Boolean] :http_wire_trace (false)
-  #     Enable debug wire trace on http requests.
-  #
   #   @option args [Symbol] :log_level (:info)
-  #     Default log level to use
+  #     The default log level to use with the Logger.
   #
-  #   @option args [Logger] :logger ($stdout)
-  #     Logger to use for output
+  #   @option args [Logger] :logger (Logger.new($stdout, level: cfg.log_level))
+  #     The Logger instance to use for logging.
   #
   #   @option args [Hearth::Retry::Strategy] :retry_strategy (Hearth::Retry::Standard.new)
   #     Specifies which retry strategy class to use. Strategy classes
@@ -37,14 +37,14 @@ module RailsJson
   #   @option args [Boolean] :validate_input (true)
   #     When `true`, request parameters are validated using the modeled shapes.
   #
+  # @!attribute client
+  #   @return [Hearth::HTTP::Client]
+  #
   # @!attribute disable_host_prefix
   #   @return [Boolean]
   #
   # @!attribute endpoint
   #   @return [String]
-  #
-  # @!attribute http_wire_trace
-  #   @return [Boolean]
   #
   # @!attribute log_level
   #   @return [Symbol]
@@ -62,9 +62,9 @@ module RailsJson
   #   @return [Boolean]
   #
   Config = ::Struct.new(
+    :client,
     :disable_host_prefix,
     :endpoint,
-    :http_wire_trace,
     :log_level,
     :logger,
     :retry_strategy,
@@ -77,9 +77,9 @@ module RailsJson
     private
 
     def validate!
+      Hearth::Validator.validate_types!(client, Hearth::HTTP::Client, context: 'options[:client]')
       Hearth::Validator.validate_types!(disable_host_prefix, TrueClass, FalseClass, context: 'options[:disable_host_prefix]')
       Hearth::Validator.validate_types!(endpoint, String, context: 'options[:endpoint]')
-      Hearth::Validator.validate_types!(http_wire_trace, TrueClass, FalseClass, context: 'options[:http_wire_trace]')
       Hearth::Validator.validate_types!(log_level, Symbol, context: 'options[:log_level]')
       Hearth::Validator.validate_types!(logger, Logger, context: 'options[:logger]')
       Hearth::Validator.validate_types!(retry_strategy, Hearth::Retry::Strategy, context: 'options[:retry_strategy]')
@@ -89,9 +89,9 @@ module RailsJson
 
     def self.defaults
       @defaults ||= {
+        client: [Hearth::HTTP::Client.new],
         disable_host_prefix: [false],
         endpoint: [proc { |cfg| cfg[:stub_responses] ? 'http://localhost' : nil } ],
-        http_wire_trace: [false],
         log_level: [:info],
         logger: [proc { |cfg| Logger.new($stdout, level: cfg[:log_level]) } ],
         retry_strategy: [Hearth::Retry::Standard.new],

--- a/codegen/projections/weather/lib/weather/client.rb
+++ b/codegen/projections/weather/lib/weather/client.rb
@@ -78,7 +78,7 @@ module Weather
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::GetCity,
         stubs: @stubs,
         params_class: Params::GetCityOutput
@@ -146,7 +146,7 @@ module Weather
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::GetCityImage,
         stubs: @stubs,
         params_class: Params::GetCityImageOutput
@@ -203,7 +203,7 @@ module Weather
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::GetCurrentTime,
         stubs: @stubs,
         params_class: Params::GetCurrentTimeOutput
@@ -277,7 +277,7 @@ module Weather
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::GetForecast,
         stubs: @stubs,
         params_class: Params::GetForecastOutput
@@ -356,7 +356,7 @@ module Weather
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::ListCities,
         stubs: @stubs,
         params_class: Params::ListCitiesOutput
@@ -420,7 +420,7 @@ module Weather
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::Operation____789BadName,
         stubs: @stubs,
         params_class: Params::Struct____789BadNameOutput

--- a/codegen/projections/weather/lib/weather/client.rb
+++ b/codegen/projections/weather/lib/weather/client.rb
@@ -78,7 +78,7 @@ module Weather
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::GetCity,
         stubs: @stubs,
         params_class: Params::GetCityOutput
@@ -146,7 +146,7 @@ module Weather
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::GetCityImage,
         stubs: @stubs,
         params_class: Params::GetCityImageOutput
@@ -203,7 +203,7 @@ module Weather
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::GetCurrentTime,
         stubs: @stubs,
         params_class: Params::GetCurrentTimeOutput
@@ -277,7 +277,7 @@ module Weather
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::GetForecast,
         stubs: @stubs,
         params_class: Params::GetForecastOutput
@@ -356,7 +356,7 @@ module Weather
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::ListCities,
         stubs: @stubs,
         params_class: Params::ListCitiesOutput
@@ -420,7 +420,7 @@ module Weather
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::Operation____789BadName,
         stubs: @stubs,
         params_class: Params::Struct____789BadNameOutput

--- a/codegen/projections/weather/lib/weather/config.rb
+++ b/codegen/projections/weather/lib/weather/config.rb
@@ -9,20 +9,20 @@
 
 module Weather
   # @!method initialize(*options)
+  #   @option args [Hearth::HTTP::Client] :client (Hearth::HTTP::Client.new)
+  #     The HTTP Client to use for request transport.
+  #
   #   @option args [Boolean] :disable_host_prefix (false)
   #     When `true`, does not perform host prefix injection using @endpoint's hostPrefix property.
   #
   #   @option args [String] :endpoint
   #     Endpoint of the service
   #
-  #   @option args [Boolean] :http_wire_trace (false)
-  #     Enable debug wire trace on http requests.
-  #
   #   @option args [Symbol] :log_level (:info)
-  #     Default log level to use
+  #     The default log level to use with the Logger.
   #
-  #   @option args [Logger] :logger ($stdout)
-  #     Logger to use for output
+  #   @option args [Logger] :logger (Logger.new($stdout, level: cfg.log_level))
+  #     The Logger instance to use for logging.
   #
   #   @option args [Hearth::Retry::Strategy] :retry_strategy (Hearth::Retry::Standard.new)
   #     Specifies which retry strategy class to use. Strategy classes
@@ -37,14 +37,14 @@ module Weather
   #   @option args [Boolean] :validate_input (true)
   #     When `true`, request parameters are validated using the modeled shapes.
   #
+  # @!attribute client
+  #   @return [Hearth::HTTP::Client]
+  #
   # @!attribute disable_host_prefix
   #   @return [Boolean]
   #
   # @!attribute endpoint
   #   @return [String]
-  #
-  # @!attribute http_wire_trace
-  #   @return [Boolean]
   #
   # @!attribute log_level
   #   @return [Symbol]
@@ -62,9 +62,9 @@ module Weather
   #   @return [Boolean]
   #
   Config = ::Struct.new(
+    :client,
     :disable_host_prefix,
     :endpoint,
-    :http_wire_trace,
     :log_level,
     :logger,
     :retry_strategy,
@@ -77,9 +77,9 @@ module Weather
     private
 
     def validate!
+      Hearth::Validator.validate_types!(client, Hearth::HTTP::Client, context: 'options[:client]')
       Hearth::Validator.validate_types!(disable_host_prefix, TrueClass, FalseClass, context: 'options[:disable_host_prefix]')
       Hearth::Validator.validate_types!(endpoint, String, context: 'options[:endpoint]')
-      Hearth::Validator.validate_types!(http_wire_trace, TrueClass, FalseClass, context: 'options[:http_wire_trace]')
       Hearth::Validator.validate_types!(log_level, Symbol, context: 'options[:log_level]')
       Hearth::Validator.validate_types!(logger, Logger, context: 'options[:logger]')
       Hearth::Validator.validate_types!(retry_strategy, Hearth::Retry::Strategy, context: 'options[:retry_strategy]')
@@ -89,9 +89,9 @@ module Weather
 
     def self.defaults
       @defaults ||= {
+        client: [Hearth::HTTP::Client.new],
         disable_host_prefix: [false],
         endpoint: [proc { |cfg| cfg[:stub_responses] ? 'http://localhost' : nil } ],
-        http_wire_trace: [false],
         log_level: [:info],
         logger: [proc { |cfg| Logger.new($stdout, level: cfg[:log_level]) } ],
         retry_strategy: [Hearth::Retry::Standard.new],

--- a/codegen/projections/weather/lib/weather/config.rb
+++ b/codegen/projections/weather/lib/weather/config.rb
@@ -9,14 +9,14 @@
 
 module Weather
   # @!method initialize(*options)
-  #   @option args [Hearth::HTTP::Client] :client (Hearth::HTTP::Client.new)
-  #     The HTTP Client to use for request transport.
-  #
   #   @option args [Boolean] :disable_host_prefix (false)
   #     When `true`, does not perform host prefix injection using @endpoint's hostPrefix property.
   #
   #   @option args [String] :endpoint
   #     Endpoint of the service
+  #
+  #   @option args [Hearth::HTTP::Client] :http_client (Hearth::HTTP::Client.new)
+  #     The HTTP Client to use for request transport.
   #
   #   @option args [Symbol] :log_level (:info)
   #     The default log level to use with the Logger.
@@ -37,14 +37,14 @@ module Weather
   #   @option args [Boolean] :validate_input (true)
   #     When `true`, request parameters are validated using the modeled shapes.
   #
-  # @!attribute client
-  #   @return [Hearth::HTTP::Client]
-  #
   # @!attribute disable_host_prefix
   #   @return [Boolean]
   #
   # @!attribute endpoint
   #   @return [String]
+  #
+  # @!attribute http_client
+  #   @return [Hearth::HTTP::Client]
   #
   # @!attribute log_level
   #   @return [Symbol]
@@ -62,9 +62,9 @@ module Weather
   #   @return [Boolean]
   #
   Config = ::Struct.new(
-    :client,
     :disable_host_prefix,
     :endpoint,
+    :http_client,
     :log_level,
     :logger,
     :retry_strategy,
@@ -77,9 +77,9 @@ module Weather
     private
 
     def validate!
-      Hearth::Validator.validate_types!(client, Hearth::HTTP::Client, context: 'options[:client]')
       Hearth::Validator.validate_types!(disable_host_prefix, TrueClass, FalseClass, context: 'options[:disable_host_prefix]')
       Hearth::Validator.validate_types!(endpoint, String, context: 'options[:endpoint]')
+      Hearth::Validator.validate_types!(http_client, Hearth::HTTP::Client, context: 'options[:http_client]')
       Hearth::Validator.validate_types!(log_level, Symbol, context: 'options[:log_level]')
       Hearth::Validator.validate_types!(logger, Logger, context: 'options[:logger]')
       Hearth::Validator.validate_types!(retry_strategy, Hearth::Retry::Strategy, context: 'options[:retry_strategy]')
@@ -89,9 +89,9 @@ module Weather
 
     def self.defaults
       @defaults ||= {
-        client: [Hearth::HTTP::Client.new],
         disable_host_prefix: [false],
         endpoint: [proc { |cfg| cfg[:stub_responses] ? 'http://localhost' : nil } ],
+        http_client: [Hearth::HTTP::Client.new],
         log_level: [:info],
         logger: [proc { |cfg| Logger.new($stdout, level: cfg[:log_level]) } ],
         retry_strategy: [Hearth::Retry::Standard.new],

--- a/codegen/projections/white_label/lib/white_label/client.rb
+++ b/codegen/projections/white_label/lib/white_label/client.rb
@@ -140,7 +140,7 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::DefaultsTest,
         stubs: @stubs,
         params_class: Params::DefaultsTestOutput
@@ -200,7 +200,7 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::EndpointOperation,
         stubs: @stubs,
         params_class: Params::EndpointOperationOutput
@@ -262,7 +262,7 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::EndpointWithHostLabelOperation,
         stubs: @stubs,
         params_class: Params::EndpointWithHostLabelOperationOutput
@@ -485,7 +485,7 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::KitchenSink,
         stubs: @stubs,
         params_class: Params::KitchenSinkOutput
@@ -545,7 +545,7 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::MixinTest,
         stubs: @stubs,
         params_class: Params::MixinTestOutput
@@ -606,7 +606,7 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::PaginatorsTest,
         stubs: @stubs,
         params_class: Params::PaginatorsTestOperationOutput
@@ -667,7 +667,7 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::PaginatorsTestWithItems,
         stubs: @stubs,
         params_class: Params::PaginatorsTestWithItemsOutput
@@ -725,7 +725,7 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::StreamingOperation,
         stubs: @stubs,
         params_class: Params::StreamingOperationOutput
@@ -783,7 +783,7 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::StreamingWithLength,
         stubs: @stubs,
         params_class: Params::StreamingWithLengthOutput
@@ -842,7 +842,7 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::WaitersTest,
         stubs: @stubs,
         params_class: Params::WaitersTestOutput
@@ -904,7 +904,7 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: Hearth::HTTP::Client.new(logger: @config.logger, http_wire_trace: options.fetch(:http_wire_trace, @config.http_wire_trace)),
+        client: options.fetch(:client, @config.client),
         stub_class: Stubs::Operation____PaginatorsTestWithBadNames,
         stubs: @stubs,
         params_class: Params::Struct____PaginatorsTestWithBadNamesOutput

--- a/codegen/projections/white_label/lib/white_label/client.rb
+++ b/codegen/projections/white_label/lib/white_label/client.rb
@@ -140,7 +140,7 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::DefaultsTest,
         stubs: @stubs,
         params_class: Params::DefaultsTestOutput
@@ -200,7 +200,7 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::EndpointOperation,
         stubs: @stubs,
         params_class: Params::EndpointOperationOutput
@@ -262,7 +262,7 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::EndpointWithHostLabelOperation,
         stubs: @stubs,
         params_class: Params::EndpointWithHostLabelOperationOutput
@@ -485,7 +485,7 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::KitchenSink,
         stubs: @stubs,
         params_class: Params::KitchenSinkOutput
@@ -545,7 +545,7 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::MixinTest,
         stubs: @stubs,
         params_class: Params::MixinTestOutput
@@ -606,7 +606,7 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::PaginatorsTest,
         stubs: @stubs,
         params_class: Params::PaginatorsTestOperationOutput
@@ -667,7 +667,7 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::PaginatorsTestWithItems,
         stubs: @stubs,
         params_class: Params::PaginatorsTestWithItemsOutput
@@ -725,7 +725,7 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::StreamingOperation,
         stubs: @stubs,
         params_class: Params::StreamingOperationOutput
@@ -783,7 +783,7 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::StreamingWithLength,
         stubs: @stubs,
         params_class: Params::StreamingWithLengthOutput
@@ -842,7 +842,7 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::WaitersTest,
         stubs: @stubs,
         params_class: Params::WaitersTestOutput
@@ -904,7 +904,7 @@ module WhiteLabel
       )
       stack.use(Hearth::Middleware::Send,
         stub_responses: @config.stub_responses,
-        client: options.fetch(:client, @config.client),
+        client: options.fetch(:http_client, @config.http_client),
         stub_class: Stubs::Operation____PaginatorsTestWithBadNames,
         stubs: @stubs,
         params_class: Params::Struct____PaginatorsTestWithBadNamesOutput

--- a/codegen/projections/white_label/lib/white_label/config.rb
+++ b/codegen/projections/white_label/lib/white_label/config.rb
@@ -9,14 +9,14 @@
 
 module WhiteLabel
   # @!method initialize(*options)
-  #   @option args [Hearth::HTTP::Client] :client (Hearth::HTTP::Client.new)
-  #     The HTTP Client to use for request transport.
-  #
   #   @option args [Boolean] :disable_host_prefix (false)
   #     When `true`, does not perform host prefix injection using @endpoint's hostPrefix property.
   #
   #   @option args [String] :endpoint
   #     Endpoint of the service
+  #
+  #   @option args [Hearth::HTTP::Client] :http_client (Hearth::HTTP::Client.new)
+  #     The HTTP Client to use for request transport.
   #
   #   @option args [Symbol] :log_level (:info)
   #     The default log level to use with the Logger.
@@ -37,14 +37,14 @@ module WhiteLabel
   #   @option args [Boolean] :validate_input (true)
   #     When `true`, request parameters are validated using the modeled shapes.
   #
-  # @!attribute client
-  #   @return [Hearth::HTTP::Client]
-  #
   # @!attribute disable_host_prefix
   #   @return [Boolean]
   #
   # @!attribute endpoint
   #   @return [String]
+  #
+  # @!attribute http_client
+  #   @return [Hearth::HTTP::Client]
   #
   # @!attribute log_level
   #   @return [Symbol]
@@ -62,9 +62,9 @@ module WhiteLabel
   #   @return [Boolean]
   #
   Config = ::Struct.new(
-    :client,
     :disable_host_prefix,
     :endpoint,
+    :http_client,
     :log_level,
     :logger,
     :retry_strategy,
@@ -77,9 +77,9 @@ module WhiteLabel
     private
 
     def validate!
-      Hearth::Validator.validate_types!(client, Hearth::HTTP::Client, context: 'options[:client]')
       Hearth::Validator.validate_types!(disable_host_prefix, TrueClass, FalseClass, context: 'options[:disable_host_prefix]')
       Hearth::Validator.validate_types!(endpoint, String, context: 'options[:endpoint]')
+      Hearth::Validator.validate_types!(http_client, Hearth::HTTP::Client, context: 'options[:http_client]')
       Hearth::Validator.validate_types!(log_level, Symbol, context: 'options[:log_level]')
       Hearth::Validator.validate_types!(logger, Logger, context: 'options[:logger]')
       Hearth::Validator.validate_types!(retry_strategy, Hearth::Retry::Strategy, context: 'options[:retry_strategy]')
@@ -89,9 +89,9 @@ module WhiteLabel
 
     def self.defaults
       @defaults ||= {
-        client: [Hearth::HTTP::Client.new],
         disable_host_prefix: [false],
         endpoint: [proc { |cfg| cfg[:stub_responses] ? 'http://localhost' : nil } ],
+        http_client: [Hearth::HTTP::Client.new],
         log_level: [:info],
         logger: [proc { |cfg| Logger.new($stdout, level: cfg[:log_level]) } ],
         retry_strategy: [Hearth::Retry::Standard.new],

--- a/codegen/projections/white_label/lib/white_label/config.rb
+++ b/codegen/projections/white_label/lib/white_label/config.rb
@@ -9,20 +9,20 @@
 
 module WhiteLabel
   # @!method initialize(*options)
+  #   @option args [Hearth::HTTP::Client] :client (Hearth::HTTP::Client.new)
+  #     The HTTP Client to use for request transport.
+  #
   #   @option args [Boolean] :disable_host_prefix (false)
   #     When `true`, does not perform host prefix injection using @endpoint's hostPrefix property.
   #
   #   @option args [String] :endpoint
   #     Endpoint of the service
   #
-  #   @option args [Boolean] :http_wire_trace (false)
-  #     Enable debug wire trace on http requests.
-  #
   #   @option args [Symbol] :log_level (:info)
-  #     Default log level to use
+  #     The default log level to use with the Logger.
   #
-  #   @option args [Logger] :logger ($stdout)
-  #     Logger to use for output
+  #   @option args [Logger] :logger (Logger.new($stdout, level: cfg.log_level))
+  #     The Logger instance to use for logging.
   #
   #   @option args [Hearth::Retry::Strategy] :retry_strategy (Hearth::Retry::Standard.new)
   #     Specifies which retry strategy class to use. Strategy classes
@@ -37,14 +37,14 @@ module WhiteLabel
   #   @option args [Boolean] :validate_input (true)
   #     When `true`, request parameters are validated using the modeled shapes.
   #
+  # @!attribute client
+  #   @return [Hearth::HTTP::Client]
+  #
   # @!attribute disable_host_prefix
   #   @return [Boolean]
   #
   # @!attribute endpoint
   #   @return [String]
-  #
-  # @!attribute http_wire_trace
-  #   @return [Boolean]
   #
   # @!attribute log_level
   #   @return [Symbol]
@@ -62,9 +62,9 @@ module WhiteLabel
   #   @return [Boolean]
   #
   Config = ::Struct.new(
+    :client,
     :disable_host_prefix,
     :endpoint,
-    :http_wire_trace,
     :log_level,
     :logger,
     :retry_strategy,
@@ -77,9 +77,9 @@ module WhiteLabel
     private
 
     def validate!
+      Hearth::Validator.validate_types!(client, Hearth::HTTP::Client, context: 'options[:client]')
       Hearth::Validator.validate_types!(disable_host_prefix, TrueClass, FalseClass, context: 'options[:disable_host_prefix]')
       Hearth::Validator.validate_types!(endpoint, String, context: 'options[:endpoint]')
-      Hearth::Validator.validate_types!(http_wire_trace, TrueClass, FalseClass, context: 'options[:http_wire_trace]')
       Hearth::Validator.validate_types!(log_level, Symbol, context: 'options[:log_level]')
       Hearth::Validator.validate_types!(logger, Logger, context: 'options[:logger]')
       Hearth::Validator.validate_types!(retry_strategy, Hearth::Retry::Strategy, context: 'options[:retry_strategy]')
@@ -89,9 +89,9 @@ module WhiteLabel
 
     def self.defaults
       @defaults ||= {
+        client: [Hearth::HTTP::Client.new],
         disable_host_prefix: [false],
         endpoint: [proc { |cfg| cfg[:stub_responses] ? 'http://localhost' : nil } ],
-        http_wire_trace: [false],
         log_level: [:info],
         logger: [proc { |cfg| Logger.new($stdout, level: cfg[:log_level]) } ],
         retry_strategy: [Hearth::Retry::Standard.new],

--- a/codegen/projections/white_label/spec/client_spec.rb
+++ b/codegen/projections/white_label/spec/client_spec.rb
@@ -29,35 +29,12 @@ module WhiteLabel
       end
 
       it 'uses logger' do
-        expect(Hearth::HTTP::Client)
-          .to receive(:new)
-                .with(hash_including(logger: config.logger))
-                .and_call_original
-
         expect(Hearth::Context)
           .to receive(:new)
                 .with(hash_including(logger: config.logger))
                 .and_call_original
 
         client.kitchen_sink
-      end
-
-      it 'uses http_wire_trace from config' do
-        expect(Hearth::HTTP::Client)
-          .to receive(:new)
-                .with(hash_including(http_wire_trace: config.http_wire_trace))
-                .and_call_original
-
-        client.kitchen_sink
-      end
-
-      it 'uses http_wire_trace from options' do
-        expect(Hearth::HTTP::Client)
-          .to receive(:new)
-                .with(hash_including(http_wire_trace: true))
-                .and_call_original
-
-        client.kitchen_sink({}, http_wire_trace: true)
       end
 
       it 'uses endpoint from config' do

--- a/codegen/projections/white_label/spec/config_spec.rb
+++ b/codegen/projections/white_label/spec/config_spec.rb
@@ -9,7 +9,7 @@ module WhiteLabel
         config_keys = {
           disable_host_prefix: true,
           endpoint: 'test',
-          http_wire_trace: true,
+          client: Hearth::HTTP::Client.new,
           log_level: :debug,
           logger: Logger.new($stdout, level: :debug),
           retry_strategy: Hearth::Retry::Adaptive.new,

--- a/codegen/projections/white_label/spec/config_spec.rb
+++ b/codegen/projections/white_label/spec/config_spec.rb
@@ -9,7 +9,7 @@ module WhiteLabel
         config_keys = {
           disable_host_prefix: true,
           endpoint: 'test',
-          client: Hearth::HTTP::Client.new,
+          http_client: Hearth::HTTP::Client.new,
           log_level: :debug,
           logger: Logger.new($stdout, level: :debug),
           retry_strategy: Hearth::Retry::Adaptive.new,

--- a/codegen/smithy-ruby-codegen-test/integration-specs/client_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/client_spec.rb
@@ -29,35 +29,12 @@ module WhiteLabel
       end
 
       it 'uses logger' do
-        expect(Hearth::HTTP::Client)
-          .to receive(:new)
-                .with(hash_including(logger: config.logger))
-                .and_call_original
-
         expect(Hearth::Context)
           .to receive(:new)
                 .with(hash_including(logger: config.logger))
                 .and_call_original
 
         client.kitchen_sink
-      end
-
-      it 'uses http_wire_trace from config' do
-        expect(Hearth::HTTP::Client)
-          .to receive(:new)
-                .with(hash_including(http_wire_trace: config.http_wire_trace))
-                .and_call_original
-
-        client.kitchen_sink
-      end
-
-      it 'uses http_wire_trace from options' do
-        expect(Hearth::HTTP::Client)
-          .to receive(:new)
-                .with(hash_including(http_wire_trace: true))
-                .and_call_original
-
-        client.kitchen_sink({}, http_wire_trace: true)
       end
 
       it 'uses endpoint from config' do

--- a/codegen/smithy-ruby-codegen-test/integration-specs/config_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/config_spec.rb
@@ -9,7 +9,7 @@ module WhiteLabel
         config_keys = {
           disable_host_prefix: true,
           endpoint: 'test',
-          http_wire_trace: true,
+          client: Hearth::HTTP::Client.new,
           log_level: :debug,
           logger: Logger.new($stdout, level: :debug),
           retry_strategy: Hearth::Retry::Adaptive.new,

--- a/codegen/smithy-ruby-codegen-test/integration-specs/config_spec.rb
+++ b/codegen/smithy-ruby-codegen-test/integration-specs/config_spec.rb
@@ -9,7 +9,7 @@ module WhiteLabel
         config_keys = {
           disable_host_prefix: true,
           endpoint: 'test',
-          client: Hearth::HTTP::Client.new,
+          http_client: Hearth::HTTP::Client.new,
           log_level: :debug,
           logger: Logger.new($stdout, level: :debug),
           retry_strategy: Hearth::Retry::Adaptive.new,

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/ApplicationTransport.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/ApplicationTransport.java
@@ -101,39 +101,21 @@ public final class ApplicationTransport {
                 .render((self, ctx) -> "Hearth::HTTP::Response.new(body: response_body)")
                 .build();
 
-        ClientConfig wireTrace = (new ClientConfig.Builder())
-                .name("http_wire_trace")
-                .type("Boolean")
-                .defaultValue("false")
-                .documentation("Enable debug wire trace on http requests.")
+        ClientConfig httpClient = (new ClientConfig.Builder())
+                .name("client")
+                .type("Hearth::HTTP::Client")
+                .documentation("The HTTP Client to use for request transport.")
+                .documentationDefaultValue("Hearth::HTTP::Client.new")
                 .allowOperationOverride()
-                .build();
-
-        ClientConfig logger = (new ClientConfig.Builder())
-                .name("logger")
-                .type("Logger")
-                .documentationDefaultValue("$stdout")
                 .defaults(new ConfigProviderChain.Builder()
-                        .dynamicProvider("proc { |cfg| Logger.new($stdout, level: cfg[:log_level]) } ")
+                        .staticProvider("Hearth::HTTP::Client.new")
                         .build()
                 )
-                .documentation("Logger to use for output")
-                .build();
-
-        ClientConfig logLevel = (new ClientConfig.Builder())
-                .name("log_level")
-                .type("Symbol")
-                .defaultValue(":info")
-                .documentation("Default log level to use")
                 .build();
 
         ClientFragment client = (new ClientFragment.Builder())
-                .addConfig(wireTrace)
-                .addConfig(logger)
-                .addConfig(logLevel)
-                .render((self, ctx) -> "Hearth::HTTP::Client.new(logger: " + logger.renderGetConfigValue()
-                        + ", http_wire_trace: "
-                        + wireTrace.renderGetConfigValue() + ")")
+                .addConfig(httpClient)
+                .render((self, ctx) -> httpClient.renderGetConfigValue())
                 .build();
 
         MiddlewareList defaultMiddleware = (transport, context) -> {
@@ -155,12 +137,8 @@ public final class ApplicationTransport {
                     .klass("Hearth::HTTP::Middleware::ContentLength")
                     .operationPredicate(
                             (model, service, operation) ->
-                                    !Streaming.isNonFiniteStreaming(model,
-                                            model.expectShape(
-                                                    operation.getInputShape(),
-                                                    StructureShape.class
-                                            )
-                                    )
+                                    !Streaming.isNonFiniteStreaming(
+                                            model, model.expectShape(operation.getInputShape(), StructureShape.class))
                     )
                     .step(MiddlewareStackStep.BUILD)
                     .build()

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/ApplicationTransport.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/ApplicationTransport.java
@@ -102,7 +102,7 @@ public final class ApplicationTransport {
                 .build();
 
         ClientConfig httpClient = (new ClientConfig.Builder())
-                .name("client")
+                .name("http_client")
                 .type("Hearth::HTTP::Client")
                 .documentation("The HTTP Client to use for request transport.")
                 .documentationDefaultValue("Hearth::HTTP::Client.new")

--- a/hearth/.rubocop.yml
+++ b/hearth/.rubocop.yml
@@ -8,9 +8,9 @@ Metrics:
 
 Metrics/AbcSize:
   Exclude:
+    - 'spec/**/*.rb'
     - 'lib/hearth/http/client.rb'
 
-# For some reason, Metrics disable doesn't cover this
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*.rb'
@@ -23,7 +23,10 @@ Layout/LineLength:
   Max: 80
 
 Metrics/MethodLength:
-  Max: 15
+  Max: 20
+  Exclude:
+    - 'spec/**/*.rb'
+    - 'lib/hearth/middleware/send.rb'
 
 Metrics/ClassLength:
   Exclude:

--- a/hearth/.rubocop.yml
+++ b/hearth/.rubocop.yml
@@ -6,6 +6,10 @@ Metrics:
   Exclude:
     - 'spec/**/*.rb'
 
+Metrics/AbcSize:
+  Exclude:
+    - 'lib/hearth/http/client.rb'
+
 # For some reason, Metrics disable doesn't cover this
 Metrics/BlockLength:
   Exclude:
@@ -27,7 +31,6 @@ Metrics/ClassLength:
 
 Metrics/ParameterLists:
   Exclude:
-    - 'lib/hearth/middleware/retry.rb'
     - 'lib/hearth/middleware/send.rb'
 
 Style/Documentation:

--- a/hearth/lib/hearth/dns/host_resolver.rb
+++ b/hearth/lib/hearth/dns/host_resolver.rb
@@ -4,7 +4,7 @@ module Hearth
   module DNS
     # Resolves a host name and service to an IP address. Can be used with
     # {Hearth::HTTP::Client} host_resolver option. This implementation uses
-    # {Addrinfo#getaddrinfo} to resolve the host name.
+    # Addrinfo.getaddrinfo to resolve the host name.
     # @see https://ruby-doc.org/stdlib-3.0.2/libdoc/socket/rdoc/Addrinfo.html
     class HostResolver
       # @param [Integer] service (443)

--- a/hearth/lib/hearth/http.rb
+++ b/hearth/lib/hearth/http.rb
@@ -7,8 +7,7 @@ require_relative 'http/error_inspector'
 require_relative 'http/error_parser'
 require_relative 'http/field'
 require_relative 'http/fields'
-require_relative 'http/middleware/content_length'
-require_relative 'http/middleware/content_md5'
+require_relative 'http/middleware'
 require_relative 'http/networking_error'
 require_relative 'http/request'
 require_relative 'http/response'
@@ -16,7 +15,6 @@ require_relative 'http/response'
 module Hearth
   # HTTP namespace for HTTP specific functionality. Also includes utility
   # methods for URI escaping.
-  # @api private
   module HTTP
     class << self
       # URI escapes the given value.
@@ -26,6 +24,7 @@ module Hearth
       #
       # @param [String] value
       # @return [String] URI encoded value except for '+' and '~'.
+      # @api private
       def uri_escape(value)
         CGI.escape(value.encode('UTF-8')).gsub('+', '%20').gsub('%7E', '~')
       end
@@ -37,6 +36,7 @@ module Hearth
       #
       # @param [String] path
       # @return [String] URI encoded path except for '+' and '~'.
+      # @api private
       def uri_escape_path(path)
         path.gsub(%r{[^/]+}) { |part| uri_escape(part) }
       end

--- a/hearth/lib/hearth/http/client.rb
+++ b/hearth/lib/hearth/http/client.rb
@@ -6,19 +6,34 @@ require 'openssl'
 
 module Hearth
   module HTTP
-    # @api private
+    # An HTTP client that uses Net::HTTP to send requests.
     class Client
       # Initialize an instance of this HTTP client.
       #
       # @param [Hash] options The options for this HTTP Client
       #
       # @option options [Boolean] :debug_output (false) When `true`,
-      #   HTTP debug output will be sent to the configured logger.
-      #
-      # @option options [Logger] :logger A logger where debug output is sent.
+      #   sets an output stream to the configured Logger for debugging.
       #
       # @option options [String] :proxy A proxy to send
       #   requests through. Formatted like 'http://proxy.com:123'.
+      #
+      # @option options [Float] :open_timeout Number of seconds to
+      #   wait for the connection to open.
+      #
+      # @option options [Float] :read_timeout Number of seconds to wait
+      #   for one block to be read (via one read(2) call).
+      #
+      # @option options [Float] :keep_alive_timeout Seconds to reuse the
+      #   connection of the previous request.
+      #
+      # @option options [Float] :continue_timeout Seconds to wait for
+      #   100 Continue response.
+      #
+      # @option options [Float] :write_timeout Number of seconds to wait
+      #   for one block to be written (via one write(2) call).
+      #
+      # @option options [Float] :ssl_timeout Sets the SSL timeout seconds.
       #
       # @option options [Boolean] :verify_peer (true) When `true`,
       #   SSL peer certificates are verified when establishing a
@@ -44,11 +59,17 @@ module Hearth
       #   `#resolve_address`, returning an array of up to two IP addresses for
       #   the given hostname, one IPv6 and one IPv4, in that order.
       #   `#resolve_address` should take a nodename keyword argument and
-      #   optionally other keyword args similar to {Addrinfo#getaddrinfo}'s
+      #   optionally other keyword args similar to Addrinfo.getaddrinfo's
       #   positional parameters.
       def initialize(options = {})
         @debug_output = options[:debug_output]
         @proxy = URI(options[:proxy]) if options[:proxy]
+        @open_timeout = options[:open_timeout]
+        @read_timeout = options[:read_timeout]
+        @keep_alive_timeout = options[:keep_alive_timeout]
+        @continue_timeout = options[:continue_timeout]
+        @write_timeout = options[:write_timeout]
+        @ssl_timeout = options[:ssl_timeout]
         @verify_peer = options[:verify_peer]
         @ca_file = options[:ca_file]
         @ca_path = options[:ca_path]

--- a/hearth/lib/hearth/http/client.rb
+++ b/hearth/lib/hearth/http/client.rb
@@ -12,8 +12,8 @@ module Hearth
       #
       # @param [Hash] options The options for this HTTP Client
       #
-      # @option options [Boolean] :http_wire_trace (false) When `true`,
-      #   HTTP debug output will be sent to the `:logger`.
+      # @option options [Boolean] :debug_output (false) When `true`,
+      #   HTTP debug output will be sent to the configured logger.
       #
       # @option options [Logger] :logger A logger where debug output is sent.
       #
@@ -47,7 +47,7 @@ module Hearth
       #   optionally other keyword args similar to {Addrinfo#getaddrinfo}'s
       #   positional parameters.
       def initialize(options = {})
-        @http_wire_trace = options[:http_wire_trace]
+        @debug_output = options[:debug_output]
         @proxy = URI(options[:proxy]) if options[:proxy]
         @verify_peer = options[:verify_peer]
         @ca_file = options[:ca_file]
@@ -61,7 +61,7 @@ module Hearth
       # @return [Response]
       def transmit(request:, response:, **options)
         http = create_http(request.uri)
-        http.set_debug_output(options[:logger]) if @http_wire_trace
+        http.set_debug_output(options[:logger]) if @debug_output
 
         if request.uri.scheme == 'https'
           configure_ssl(http)

--- a/hearth/lib/hearth/http/middleware.rb
+++ b/hearth/lib/hearth/http/middleware.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative 'middleware/content_length'
+require_relative 'middleware/content_md5'
+
+module Hearth
+  module HTTP
+    # @api private
+    module Middleware; end
+  end
+end

--- a/hearth/lib/hearth/middleware/retry.rb
+++ b/hearth/lib/hearth/middleware/retry.rb
@@ -25,7 +25,6 @@ module Hearth
         @retries = 0
       end
 
-      # rubocop:disable Metrics
       def call(input, context)
         token = @retry_strategy.acquire_initial_retry_token(
           context.metadata[:retry_token_scope]
@@ -50,7 +49,6 @@ module Hearth
         end
         output
       end
-      # rubocop:enable Metrics
 
       private
 

--- a/hearth/lib/hearth/middleware/send.rb
+++ b/hearth/lib/hearth/middleware/send.rb
@@ -39,7 +39,8 @@ module Hearth
         else
           resp_or_error = @client.transmit(
             request: context.request,
-            response: context.response
+            response: context.response,
+            logger: context.logger
           )
           if resp_or_error.is_a?(Hearth::NetworkingError)
             output.error = resp_or_error

--- a/hearth/lib/hearth/middleware/send.rb
+++ b/hearth/lib/hearth/middleware/send.rb
@@ -27,7 +27,6 @@ module Hearth
       # @param input
       # @param context
       # @return [Output]
-      # rubocop:disable Metrics/MethodLength
       def call(input, context)
         output = Output.new
         if @stub_responses
@@ -80,7 +79,6 @@ module Hearth
           raise ArgumentError, 'Unsupported stub type'
         end
       end
-      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/hearth/lib/hearth/request.rb
+++ b/hearth/lib/hearth/request.rb
@@ -8,7 +8,7 @@ module Hearth
   # @api private
   class Request
     # @param [URI] uri (URI(''))
-    # @param [IO] (StringIO.new) body
+    # @param [IO] body (StringIO.new)
     def initialize(uri: URI(''), body: StringIO.new)
       @uri = uri
       @body = body

--- a/hearth/lib/hearth/retry/client_rate_limiter.rb
+++ b/hearth/lib/hearth/retry/client_rate_limiter.rb
@@ -50,7 +50,6 @@ module Hearth
         end
       end
 
-      # rubocop:disable Metrics/MethodLength
       def update_sending_rate(is_throttling_error)
         @mutex.synchronize do
           update_measured_rate
@@ -77,7 +76,6 @@ module Hearth
           token_bucket_update_rate(new_rate)
         end
       end
-      # rubocop:enable Metrics/MethodLength
 
       private
 

--- a/hearth/sig/lib/hearth/http/client.rbs
+++ b/hearth/sig/lib/hearth/http/client.rbs
@@ -1,0 +1,100 @@
+module Hearth
+  module HTTP
+    # An HTTP client that uses Net::HTTP to send requests.
+    class Client
+      # Initialize an instance of this HTTP client.
+      #
+      # @param [Hash] options The options for this HTTP Client
+      #
+      # @option options [Boolean] :debug_output (false) When `true`,
+      #   sets an output stream to the configured Logger for debugging.
+      #
+      # @option options [String] :proxy A proxy to send
+      #   requests through. Formatted like 'http://proxy.com:123'.
+      #
+      # @option options [Float] :open_timeout Number of seconds to
+      #   wait for the connection to open.
+      #
+      # @option options [Float] :read_timeout Number of seconds to wait
+      #   for one block to be read (via one read(2) call).
+      #
+      # @option options [Float] :keep_alive_timeout Seconds to reuse the
+      #   connection of the previous request.
+      #
+      # @option options [Float] :continue_timeout Seconds to wait for
+      #   100 Continue response.
+      #
+      # @option options [Float] :write_timeout Number of seconds to wait
+      #   for one block to be written (via one write(2) call).
+      #
+      # @option options [Float] :ssl_timeout Sets the SSL timeout seconds.
+      #
+      # @option options [Boolean] :verify_peer (true) When `true`,
+      #   SSL peer certificates are verified when establishing a
+      #   connection.
+      #
+      # @option options [String] :ca_file Full path to the SSL
+      #   certificate authority bundle file that should be used when
+      #   verifying peer certificates.  If you do not pass
+      #   `:ca_file` or `:ca_path` the system default
+      #   will be used if available.
+      #
+      # @option options [String] :ca_path Full path of the
+      #   directory that contains the unbundled SSL certificate
+      #   authority files for verifying peer certificates.  If you do
+      #   not pass `:ca_file` or `:ca_path` the
+      #   system default will be used if available.
+      #
+      # @option options [OpenSSL::X509::Store] :cert_store An OpenSSL X509
+      #   certificate store that contains the SSL certificate authority.
+      #
+      # @option options [#resolve_address] (nil) :host_resolver
+      #   An object, such as {Hearth::DNS::HostResolver} that responds to
+      #   `#resolve_address`, returning an array of up to two IP addresses for
+      #   the given hostname, one IPv6 and one IPv4, in that order.
+      #   `#resolve_address` should take a nodename keyword argument and
+      #   optionally other keyword args similar to {Addrinfo#getaddrinfo}'s
+      #   positional parameters.
+      def initialize: (?::Hash[untyped, untyped] options) -> void
+
+      # @param [Request] request
+      # @param [Response] response
+      # @return [Response]
+      def transmit: (request: untyped, response: untyped, **untyped options) -> untyped
+
+      private
+
+      def _transmit: (untyped http, untyped request, untyped response) -> untyped
+
+      def unpack_response: (untyped net_resp, untyped response) -> untyped
+
+      # Creates an HTTP connection to the endpoint
+      # Applies proxy if set
+      def create_http: (untyped endpoint) -> untyped
+
+      # applies ssl settings to the HTTP object
+      def configure_ssl: (untyped http) -> untyped
+
+      # Constructs and returns a Net::HTTP::Request object from
+      # a {Http::Request}.
+      # @param [Http::Request] request
+      # @return [Net::HTTP::Request]
+      def build_net_request: (untyped request) -> untyped
+
+      # Validate that fields are not trailers and return a hash of headers.
+      # @param [HTTP::Request] request
+      # @return [Hash<String, String>]
+      def net_headers_for: (untyped request) -> untyped
+
+      # @param [Http::Request] request
+      # @raise [InvalidHttpVerbError]
+      # @return Returns a base `Net::HTTP::Request` class, e.g.,
+      #   `Net::HTTP::Get`, `Net::HTTP::Post`, etc.
+      def net_http_request_class: (untyped request) -> untyped
+
+      # Extract the parts of the proxy URI
+      # @return [Array]
+      def proxy_parts: () -> ::Array[untyped]
+    end
+  end
+end

--- a/hearth/spec/hearth/http/client_spec.rb
+++ b/hearth/spec/hearth/http/client_spec.rb
@@ -7,7 +7,7 @@ module Hearth
     describe Client do
       before { WebMock.disable_net_connect! }
 
-      let(:wire_trace) { false }
+      let(:debug_output) { false }
       let(:logger) { double('logger') }
       let(:proxy) { nil }
       let(:verify_peer) { true }
@@ -18,7 +18,7 @@ module Hearth
 
       subject do
         Client.new(
-          http_wire_trace: wire_trace, logger: logger,
+          debug_output: debug_output,
           proxy: proxy,
           verify_peer: verify_peer,
           ca_file: ca_file,
@@ -285,14 +285,18 @@ module Hearth
           end
         end
 
-        context 'http_wire_trace: true' do
-          let(:wire_trace) { true }
+        context 'debug_output: true' do
+          let(:debug_output) { true }
 
           it 'sets the logger on debug_output' do
             stub_request(:any, uri.to_s)
             expect_any_instance_of(Net::HTTP)
               .to receive(:set_debug_output).with(logger)
-            subject.transmit(request: request, response: response)
+            subject.transmit(
+              request: request,
+              response: response,
+              logger: logger
+            )
           end
         end
 

--- a/hearth/spec/hearth/http/client_spec.rb
+++ b/hearth/spec/hearth/http/client_spec.rb
@@ -9,21 +9,21 @@ module Hearth
 
       let(:wire_trace) { false }
       let(:logger) { double('logger') }
-      let(:http_proxy) { nil }
-      let(:ssl_verify_peer) { true }
-      let(:ssl_ca_bundle) { nil }
-      let(:ssl_ca_directory) { nil }
-      let(:ssl_ca_store) { nil }
+      let(:proxy) { nil }
+      let(:verify_peer) { true }
+      let(:ca_file) { nil }
+      let(:ca_path) { nil }
+      let(:cert_store) { nil }
       let(:host_resolver) { nil }
 
       subject do
         Client.new(
           http_wire_trace: wire_trace, logger: logger,
-          http_proxy: http_proxy,
-          ssl_verify_peer: ssl_verify_peer,
-          ssl_ca_bundle: ssl_ca_bundle,
-          ssl_ca_directory: ssl_ca_directory,
-          ssl_ca_store: ssl_ca_store,
+          proxy: proxy,
+          verify_peer: verify_peer,
+          ca_file: ca_file,
+          ca_path: ca_path,
+          cert_store: cert_store,
           host_resolver: host_resolver
         )
       end
@@ -182,8 +182,8 @@ module Hearth
             subject.transmit(request: request, response: response)
           end
 
-          context 'ssl_verify_peer: false' do
-            let(:ssl_verify_peer) { false }
+          context 'verify_peer: false' do
+            let(:verify_peer) { false }
 
             it 'sets verify_peer to NONE' do
               stub_request(:any, uri.to_s)
@@ -196,8 +196,8 @@ module Hearth
             end
           end
 
-          context 'ssl_verify_peer: true' do
-            let(:ssl_verify_peer) { true }
+          context 'verify_peer: true' do
+            let(:verify_peer) { true }
 
             it 'sets verify_peer to VERIFY_PEER' do
               stub_request(:any, uri.to_s)
@@ -209,8 +209,8 @@ module Hearth
               subject.transmit(request: request, response: response)
             end
 
-            context 'ssl_ca_bundle' do
-              let(:ssl_ca_bundle) { 'ca_bundle' }
+            context 'ca_file' do
+              let(:ca_file) { 'ca_bundle' }
 
               it 'sets ca_file' do
                 stub_request(:any, uri.to_s)
@@ -223,8 +223,8 @@ module Hearth
               end
             end
 
-            context 'ssl_ca_directory' do
-              let(:ssl_ca_directory) { 'ca_directory' }
+            context 'ca_path' do
+              let(:ca_path) { 'ca_directory' }
 
               it 'sets ca_path' do
                 stub_request(:any, uri.to_s)
@@ -237,13 +237,13 @@ module Hearth
               end
             end
 
-            context 'ssl_ca_store' do
-              let(:ssl_ca_store) { 'ca_store' }
+            context 'cert_store' do
+              let(:cert_store) { 'cert_store' }
 
               it 'sets cert_store' do
                 stub_request(:any, uri.to_s)
                 expect_any_instance_of(Net::HTTP).to receive(:start) do |http|
-                  expect(http.cert_store).to eq 'ca_store'
+                  expect(http.cert_store).to eq 'cert_store'
                   http
                 end
 
@@ -253,8 +253,8 @@ module Hearth
           end
         end
 
-        context 'http_proxy set' do
-          let(:http_proxy) { 'http://my-proxy-host.com:88' }
+        context 'proxy set' do
+          let(:proxy) { 'http://my-proxy-host.com:88' }
           it 'sets the http proxy' do
             stub_request(:any, uri.to_s)
             expect_any_instance_of(Net::HTTP).to receive(:start) do |http|
@@ -268,7 +268,7 @@ module Hearth
           context 'user and password set on proxy' do
             let(:password) { 'pass/word' }
             let(:user) { 'my user' }
-            let(:http_proxy) do
+            let(:proxy) do
               "http://#{CGI.escape(user)}:#{CGI.escape(password)}@my-proxy-host.com:88"
             end
 

--- a/hearth/spec/hearth/middleware/send_spec.rb
+++ b/hearth/spec/hearth/middleware/send_spec.rb
@@ -13,6 +13,7 @@ module Hearth
       let(:stub_class) { double('stub_class') }
       let(:params_class) { double('params_class') }
       let(:stubs) { Hearth::Stubbing::Stubs.new }
+      let(:logger) { double('Logger') }
 
       subject do
         Send.new(
@@ -36,14 +37,16 @@ module Hearth
           Hearth::Context.new(
             request: request,
             response: response,
-            operation_name: operation
+            operation_name: operation,
+            logger: logger
           )
         end
 
         it 'sends the request and returns an output object' do
           expect(client).to receive(:transmit).with(
             request: request,
-            response: response
+            response: response,
+            logger: logger
           ).and_return(response)
 
           output = subject.call(input, context)
@@ -54,7 +57,8 @@ module Hearth
           error = Hearth::HTTP::NetworkingError.new(StandardError.new)
           expect(client).to receive(:transmit).with(
             request: request,
-            response: response
+            response: response,
+            logger: logger
           ).and_return(error)
 
           output = subject.call(input, context)


### PR DESCRIPTION
Pre-req for doing some client/connections in SRA - make http client a configurable option, and normalize the http option naming. Http client options will no longer be flat parameters on Config