### PR TITLE
Use strict_encode64

### DIFF
--- a/codegen/projections/rails_json/lib/rails_json/builders.rb
+++ b/codegen/projections/rails_json/lib/rails_json/builders.rb
@@ -155,7 +155,7 @@ module RailsJson
         data[:default_document_list] = input[:default_document_list] unless input[:default_document_list].nil?
         data[:default_null_document] = input[:default_null_document] unless input[:default_null_document].nil?
         data[:default_timestamp] = Hearth::TimeHelper.to_date_time(input[:default_timestamp]) unless input[:default_timestamp].nil?
-        data[:default_blob] = ::Base64::encode64(input[:default_blob]).strip unless input[:default_blob].nil?
+        data[:default_blob] = ::Base64::strict_encode64(input[:default_blob]).strip unless input[:default_blob].nil?
         data[:default_byte] = input[:default_byte] unless input[:default_byte].nil?
         data[:default_short] = input[:default_short] unless input[:default_short].nil?
         data[:default_integer] = input[:default_integer] unless input[:default_integer].nil?
@@ -167,7 +167,7 @@ module RailsJson
         data[:default_int_enum] = input[:default_int_enum] unless input[:default_int_enum].nil?
         data[:empty_string] = input[:empty_string] unless input[:empty_string].nil?
         data[:false_boolean] = input[:false_boolean] unless input[:false_boolean].nil?
-        data[:empty_blob] = ::Base64::encode64(input[:empty_blob]).strip unless input[:empty_blob].nil?
+        data[:empty_blob] = ::Base64::strict_encode64(input[:empty_blob]).strip unless input[:empty_blob].nil?
         data[:zero_byte] = input[:zero_byte] unless input[:zero_byte].nil?
         data[:zero_short] = input[:zero_short] unless input[:zero_short].nil?
         data[:zero_integer] = input[:zero_integer] unless input[:zero_integer].nil?
@@ -736,7 +736,7 @@ module RailsJson
         http_req.append_path('/JsonBlobs')
         http_req.headers['Content-Type'] = 'application/json'
         data = {}
-        data[:data] = ::Base64::encode64(input[:data]).strip unless input[:data].nil?
+        data[:data] = ::Base64::strict_encode64(input[:data]).strip unless input[:data].nil?
         http_req.body = StringIO.new(Hearth::JSON.dump(data))
       end
     end
@@ -839,7 +839,7 @@ module RailsJson
       def self.build(http_req, input:)
         http_req.http_method = 'GET'
         http_req.append_path('/MediaTypeHeader')
-        http_req.headers['X-Json'] = ::Base64::encode64(input[:json]).strip unless input[:json].nil? || input[:json].empty?
+        http_req.headers['X-Json'] = ::Base64::strict_encode64(input[:json]).strip unless input[:json].nil? || input[:json].empty?
       end
     end
 
@@ -854,7 +854,7 @@ module RailsJson
         when Types::MyUnion::NumberValue
           data[:number_value] = input
         when Types::MyUnion::BlobValue
-          data[:blob_value] = ::Base64::encode64(input).strip
+          data[:blob_value] = ::Base64::strict_encode64(input).strip
         when Types::MyUnion::TimestampValue
           data[:timestamp_value] = Hearth::TimeHelper.to_epoch_seconds(input).to_i
         when Types::MyUnion::EnumValue

--- a/codegen/projections/rails_json/lib/rails_json/stubs.rb
+++ b/codegen/projections/rails_json/lib/rails_json/stubs.rb
@@ -1226,7 +1226,7 @@ module RailsJson
         data = {}
         http_resp.status = 200
         http_resp.headers['Content-Type'] = 'application/json'
-        data[:data] = ::Base64::encode64(stub[:data]) unless stub[:data].nil?
+        data[:data] = ::Base64::strict_encode64(stub[:data]) unless stub[:data].nil?
         http_resp.body.write(Hearth::JSON.dump(data))
       end
     end
@@ -1449,7 +1449,7 @@ module RailsJson
       def self.stub(http_resp, stub:)
         data = {}
         http_resp.status = 200
-        http_resp.headers['X-Json'] = ::Base64::encode64(stub[:json]).strip unless stub[:json].nil? || stub[:json].empty?
+        http_resp.headers['X-Json'] = ::Base64::strict_encode64(stub[:json]).strip unless stub[:json].nil? || stub[:json].empty?
       end
     end
 
@@ -1472,7 +1472,7 @@ module RailsJson
         when Types::MyUnion::NumberValue
           data[:number_value] = stub.__getobj__
         when Types::MyUnion::BlobValue
-          data[:blob_value] = ::Base64::encode64(stub.__getobj__)
+          data[:blob_value] = ::Base64::strict_encode64(stub.__getobj__)
         when Types::MyUnion::TimestampValue
           data[:timestamp_value] = Hearth::TimeHelper.to_epoch_seconds(stub.__getobj__).to_i
         when Types::MyUnion::EnumValue
@@ -1729,7 +1729,7 @@ module RailsJson
         data[:default_document_list] = stub[:default_document_list] unless stub[:default_document_list].nil?
         data[:default_null_document] = stub[:default_null_document] unless stub[:default_null_document].nil?
         data[:default_timestamp] = Hearth::TimeHelper.to_date_time(stub[:default_timestamp]) unless stub[:default_timestamp].nil?
-        data[:default_blob] = ::Base64::encode64(stub[:default_blob]) unless stub[:default_blob].nil?
+        data[:default_blob] = ::Base64::strict_encode64(stub[:default_blob]) unless stub[:default_blob].nil?
         data[:default_byte] = stub[:default_byte] unless stub[:default_byte].nil?
         data[:default_short] = stub[:default_short] unless stub[:default_short].nil?
         data[:default_integer] = stub[:default_integer] unless stub[:default_integer].nil?
@@ -1741,7 +1741,7 @@ module RailsJson
         data[:default_int_enum] = stub[:default_int_enum] unless stub[:default_int_enum].nil?
         data[:empty_string] = stub[:empty_string] unless stub[:empty_string].nil?
         data[:false_boolean] = stub[:false_boolean] unless stub[:false_boolean].nil?
-        data[:empty_blob] = ::Base64::encode64(stub[:empty_blob]) unless stub[:empty_blob].nil?
+        data[:empty_blob] = ::Base64::strict_encode64(stub[:empty_blob]) unless stub[:empty_blob].nil?
         data[:zero_byte] = stub[:zero_byte] unless stub[:zero_byte].nil?
         data[:zero_short] = stub[:zero_short] unless stub[:zero_short].nil?
         data[:zero_integer] = stub[:zero_integer] unless stub[:zero_integer].nil?

--- a/codegen/smithy-ruby-codegen/CHANGELOG.md
+++ b/codegen/smithy-ruby-codegen/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased Changes
 ------------------
 
+* Issue - Use `strict_encode64` instead of `encode64`.
 * Issue - Fix builders when `uri` contains empty query parameter.
 * Issue - Resolve `ClientConfig` from integrations first.
 * Issue - Rename config `defaults` method to avoid name conflicts.

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/RestBuilderGeneratorBase.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/RestBuilderGeneratorBase.java
@@ -371,7 +371,7 @@ public abstract class RestBuilderGeneratorBase extends BuilderGeneratorBase {
         public Void stringShape(StringShape shape) {
             // string values with a mediaType trait are always base64 encoded.
             if (shape.hasTrait(MediaTypeTrait.class)) {
-                writer.write("$1L$3T::encode64($2L).strip unless $2L.nil? || $2L.empty?",
+                writer.write("$1L$3T::strict_encode64($2L).strip unless $2L.nil? || $2L.empty?",
                         dataSetter, inputGetter, RubyImportContainer.BASE64);
             } else {
                 writer.write("$1L$2L unless $2L.nil? || $2L.empty?", dataSetter, inputGetter);

--- a/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/RestStubsGeneratorBase.java
+++ b/codegen/smithy-ruby-codegen/src/main/java/software/amazon/smithy/ruby/codegen/generators/RestStubsGeneratorBase.java
@@ -310,7 +310,7 @@ public abstract class RestStubsGeneratorBase extends StubsGeneratorBase {
         public Void stringShape(StringShape shape) {
             // string values with a mediaType trait are always base64 encoded.
             if (shape.hasTrait(MediaTypeTrait.class)) {
-                writer.write("$1L$3T::encode64($2L).strip unless $2L.nil? || $2L.empty?",
+                writer.write("$1L$3T::strict_encode64($2L).strip unless $2L.nil? || $2L.empty?",
                         dataSetter, inputGetter, RubyImportContainer.BASE64);
             } else {
                 writer.write("$1L$2L unless $2L.nil? || $2L.empty?", dataSetter, inputGetter);

--- a/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/protocol/railsjson/generators/BuilderGenerator.java
+++ b/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/protocol/railsjson/generators/BuilderGenerator.java
@@ -234,7 +234,7 @@ public class BuilderGenerator extends RestBuilderGeneratorBase {
 
         @Override
         public Void blobShape(BlobShape shape) {
-            writer.write("$L$T::encode64($L).strip$L", dataSetter,
+            writer.write("$L$T::strict_encode64($L).strip$L", dataSetter,
                     RubyImportContainer.BASE64, inputGetter, checkRequired());
             return null;
         }

--- a/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/protocol/railsjson/generators/StubsGenerator.java
+++ b/codegen/smithy-ruby-rails-codegen/src/main/java/software/amazon/smithy/ruby/codegen/protocol/railsjson/generators/StubsGenerator.java
@@ -264,7 +264,7 @@ public class StubsGenerator extends RestStubsGeneratorBase {
 
         @Override
         public Void blobShape(BlobShape shape) {
-            writer.write("$L$T::encode64($L)$L",
+            writer.write("$L$T::strict_encode64($L)$L",
                     dataSetter, RubyImportContainer.BASE64, inputGetter, checkRequired());
             return null;
         }


### PR DESCRIPTION
*Description of changes:*
Using `Base64.encode64` can add linefeeds to the output which causes many services to raise errors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
