### PR TITLE
Update shapes spec to next instead of skip

### DIFF
--- a/gems/smithy/lib/smithy/anvil/client/request_response_example.rb
+++ b/gems/smithy/lib/smithy/anvil/client/request_response_example.rb
@@ -140,7 +140,8 @@ module Smithy
           return false if Vise::PRELUDE_SHAPES.include?(member_shape['target'])
 
           s = @shapes[member_shape['target']]
-          s['type'] == 'structure' || s['type'] == 'list' || s['type'] == 'map'
+
+          %w[structure list map].include?(s['type'])
         end
 
         def scalar_list(member_shape, indent, visited)

--- a/gems/smithy/spec/interfaces/client/shapes_spec.rb
+++ b/gems/smithy/spec/interfaces/client/shapes_spec.rb
@@ -22,13 +22,13 @@ describe 'Component: Shapes' do
 
   context 'shapes' do
     shape_tests['shapes'].each do |id, shape|
-      context "a generated shape: #{id}" do
-        next if %w[operation service].include?(shape['type'])
+      next if %w[operation service].include?(shape['type'])
 
+      context "a generated shape: #{id}" do
         let(:shape_name) { Smithy::Vise::Shape.relative_id(id) }
         let(:generated_shape) { Object.const_get("#{subject}::#{shape_name}") }
 
-        it 'is of a expected shape type and has an id' do
+        it 'is of a expected shape type and id' do
           expected_shape_type =
             Object.const_get("#{shapes_module}::#{shape['type'].camelize}Shape")
 
@@ -36,32 +36,24 @@ describe 'Component: Shapes' do
           expect(generated_shape.id).to eq(id)
         end
 
-        context 'type' do
-          next unless %w[structure union].include?(shape['type'])
-
-          it 'is set on the shape' do
+        if %w[structure union].include?(shape['type'])
+          it 'has a type set on the shape' do
             expected_type = Object.const_get("#{types_module}::#{shape_name}")
             expect(generated_shape.type).to eq(expected_type)
           end
         end
 
-        context 'traits' do
-          next if shape['traits'].nil?
-
-          it 'contains modeled traits and excludes omitted traits' do
+        if shape['traits']
+          it 'has traits and does not include omitted traits' do
             expected_traits = shape['traits'].reject { |t| t == 'smithy.api#documentation' }
             expect(generated_shape.traits).to include(expected_traits)
             expect(generated_shape.traits.keys).not_to include('smithy.api#documentation')
           end
         end
 
-        context 'members' do
-          next if shape['members'].nil?
-
-          let(:m_tests) { shape['members'] }
-
-          it 'are shapes of expected name, shape and contains traits when applicable' do
-            m_tests.each do |m_name, m_test|
+        if shape['members']
+          it 'has members' do
+            shape['members'].each do |m_name, m_test|
               m_name = m_name.underscore
               expect(generated_shape.members.keys).to include(m_name)
 
@@ -76,25 +68,19 @@ describe 'Component: Shapes' do
           end
         end
 
-        context 'a member' do
-          next if shape['member'].nil?
-
-          let(:m_test) { shape['member'] }
-
-          it 'is a shape of expected member name, shape and contains traits when applicable' do
+        if shape['member']
+          it 'has a member' do
             expect(generated_shape.member.name).to eq('member')
-            expect(generated_shape.member.shape.id).to eq(m_test['target'])
+            expect(generated_shape.member.shape.id).to eq(shape['member']['target'])
 
-            if (expected_traits = m_test['traits'])
+            if (expected_traits = shape['member']['traits'])
               expect(generated_shape.member.traits).to include(expected_traits)
             end
           end
         end
 
-        context 'key and value members' do
-          next if shape['key'].nil? && shape['value'].nil?
-
-          it 'are shapes of expected member names, shapes and contains traits when applicable' do
+        if shape['key'] && shape['value']
+          it 'has key and value members' do
             expect(generated_shape.key.name).to eq('key')
             expect(generated_shape.value.name).to eq('value')
             expect(generated_shape.key.shape.id).to eq(shape['key']['target'])


### PR DESCRIPTION
Instead of skipping unrelated shape specs, we are `next`-ing to not crowd the spec outputs.