### PR TITLE
Remove instance plugins

### DIFF
--- a/gems/smithy-client/lib/smithy-client/base.rb
+++ b/gems/smithy-client/lib/smithy-client/base.rb
@@ -59,7 +59,6 @@ module Smithy
       def build_config(plugins, options)
         config = Configuration.new
         config.add_option(:schema)
-        config.add_option(:plugins)
         plugins.each do |plugin|
           plugin.add_options(config) if plugin.respond_to?(:add_options)
         end
@@ -93,10 +92,10 @@ module Smithy
 
       class << self
         def new(options = {})
+          plugins = build_plugins
           options = options.dup
           options[:plugins]&.freeze
-          plugins = build_plugins(self.plugins + options.fetch(:plugins, []))
-          plugins = before_initialize(plugins, options)
+          before_initialize(plugins, options)
           client = allocate
           client.send(:initialize, plugins, options)
           client
@@ -201,7 +200,7 @@ module Smithy
           include(operations_module)
         end
 
-        def build_plugins(plugins)
+        def build_plugins
           plugins.map { |plugin| plugin.is_a?(Class) ? plugin.new : plugin }
         end
 

--- a/gems/smithy-client/spec/smithy-client/base_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/base_spec.rb
@@ -23,11 +23,6 @@ module Smithy
           expect(subject.config.schema).to be(client_class.schema)
         end
 
-        it 'contains instance plugins' do
-          client = client_class.new(plugins: [plugin_a])
-          expect(client.config.plugins).to include(plugin_a)
-        end
-
         it 'passes constructor args to the config' do
           expect do
             client_class.new(foo: 'bar')
@@ -179,51 +174,6 @@ module Smithy
             plugin = Object.new
             client_class.add_plugin(plugin)
             client_class.new
-          end
-        end
-
-        context 'instance level plugin' do
-          it 'instructs plugins to #before_initialize' do
-            options = { plugins: [plugin_a] }
-            expect(plugin_a).to receive(:before_initialize)
-              .with(client_class, hash_including(options))
-            client_class.new(options)
-          end
-
-          it 'instructs plugins to #add_options' do
-            expect(plugin_a).to receive(:add_options) do |config|
-              config.add_option(:foo, 'bar')
-              config.add_option(:endpoint, 'https://example.com')
-            end
-            client_class.new(endpoint: 'https://example.com', plugins: [plugin_a])
-          end
-
-          it 'instructs plugins to #add_handlers' do
-            expect(plugin_a).to receive(:add_handlers)
-              .with(kind_of(HandlerList), kind_of(Struct))
-            client_class.new(plugins: [plugin_a])
-          end
-
-          it 'instructs plugins to #after_initialize' do
-            expect(plugin_a).to receive(:after_initialize).with(kind_of(Client::Base))
-            client_class.new(plugins: [plugin_a])
-          end
-
-          it 'does not call methods that plugin does not respond to' do
-            plugin = Object.new
-            client_class.new(plugins: [plugin])
-          end
-
-          # TODO: support this?
-          it 'does not allow adding plugins from instance plugins' do
-            plugin = Class.new(Plugin) do
-              before_initialize do |_klass, options|
-                options[:plugins] << Plugin.new
-              end
-            end
-            expect do
-              client_class.new(endpoint: 'https://example.com', plugins: [plugin])
-            end.to raise_error(FrozenError)
           end
         end
       end

--- a/gems/smithy/lib/smithy/templates/client/endpoint_provider_spec.erb
+++ b/gems/smithy/lib/smithy/templates/client/endpoint_provider_spec.erb
@@ -39,11 +39,11 @@ module <%= namespace %>
 
 <% test_case.operation_inputs.each do |operation_input| -%>
       it 'produces the correct output from the client when calling <%= operation_input.operation_name %>' do
+        Client.add_plugin(stub_send)
         client = Client.new(
 <% operation_input.client_params.each do |p| -%>
           <%= p.param %>: <%= p.value %>,
 <% end -%>
-           plugins: [stub_send]
         )
 <% if test_case.expect_error? -%>
         expect do

--- a/gems/smithy/lib/smithy/templates/client/endpoint_provider_spec.erb
+++ b/gems/smithy/lib/smithy/templates/client/endpoint_provider_spec.erb
@@ -67,6 +67,7 @@ module <%= namespace %>
         expected['endpoint'].fetch('headers', {}).each do |k,v|
           expect(resp.context.request.headers[k]).to eq(v)
         end
+        Client.remove_plugin(stub_send)
 
         # TODO: expect auth
 <% end -%>


### PR DESCRIPTION
Removes instance level plugins. This simplifies the configuration experience by only allowing plugin adding and removing at the class level. Instance plugins would have to similarly support remove_plugins but also there was a nasty edge case about recursion where plugins could add other plugins, which would go away.