### PR TITLE
Implement Unions

### DIFF
--- a/gems/smithy-client/lib/smithy-client.rb
+++ b/gems/smithy-client/lib/smithy-client.rb
@@ -40,6 +40,7 @@ require_relative 'smithy-client/errors'
 require_relative 'smithy-client/schema'
 require_relative 'smithy-client/shapes'
 require_relative 'smithy-client/structure'
+require_relative 'smithy-client/union'
 
 # endpoints
 require_relative 'smithy-client/endpoint_rules'

--- a/gems/smithy-client/lib/smithy-client/shapes.rb
+++ b/gems/smithy-client/lib/smithy-client/shapes.rb
@@ -138,10 +138,10 @@ module Smithy
           @type = nil
         end
 
-        # @return [Hash<String, MemberShape>]
+        # @return [Hash<Symbol, MemberShape>]
         attr_accessor :members
 
-        # @return [Struct]
+        # @return [Class]
         attr_accessor :type
 
         # @return [MemberShape]
@@ -164,7 +164,26 @@ module Smithy
       class TimestampShape < Shape; end
 
       # Represents both Union and EventStream shapes.
-      class UnionShape < StructureShape; end
+      class UnionShape < StructureShape
+        def initialize(options = {})
+          super
+          @member_types = {}
+        end
+
+        # @return [Symbol, Class]
+        attr_accessor :member_types
+
+        # @return [MemberShape]
+        def add_member(name, shape, type, traits: {})
+          @member_types[name] = type
+          super(name, shape, traits: traits)
+        end
+
+        # @return [Class, nil]
+        def member_type(name)
+          @member_types[name]
+        end
+      end
 
       # Represents a member shape.
       class MemberShape

--- a/gems/smithy-client/lib/smithy-client/structure.rb
+++ b/gems/smithy-client/lib/smithy-client/structure.rb
@@ -9,6 +9,8 @@ module Smithy
       # @return [Hash, Structure]
       def to_h(obj = self)
         case obj
+        when Union
+          obj.to_h
         when Structure
           _to_h_structure(obj)
         when Hash

--- a/gems/smithy-client/lib/smithy-client/union.rb
+++ b/gems/smithy-client/lib/smithy-client/union.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'delegate'
+
+module Smithy
+  module Client
+    #  Top level class for all generated Union types
+    class Union < ::SimpleDelegator
+      include Structure
+
+      def to_s
+        "#<#{self.class.name} #{self.__getobj__ || 'nil'}>"
+      end
+    end
+  end
+end

--- a/gems/smithy-client/lib/smithy-client/union.rb
+++ b/gems/smithy-client/lib/smithy-client/union.rb
@@ -9,7 +9,7 @@ module Smithy
       include Structure
 
       def to_s
-        "#<#{self.class.name} #{self.__getobj__ || 'nil'}>"
+        "#<#{self.class.name} #{__getobj__ || 'nil'}>"
       end
     end
   end

--- a/gems/smithy-client/sig/smithy-client/shapes.rbs
+++ b/gems/smithy-client/sig/smithy-client/shapes.rbs
@@ -61,7 +61,7 @@ module Smithy
 
       class StructureShape < Shape
         attr_accessor members: Hash[Symbol, MemberShape]
-        attr_accessor type: Class
+        attr_accessor type: Class?
         def add_member: (Symbol, Shape, ?traits: Hash[String, untyped]) -> void
         def member?: (Symbol) -> bool
         def member: (Symbol) -> MemberShape?

--- a/gems/smithy-client/sig/smithy-client/shapes.rbs
+++ b/gems/smithy-client/sig/smithy-client/shapes.rbs
@@ -61,7 +61,7 @@ module Smithy
 
       class StructureShape < Shape
         attr_accessor members: Hash[Symbol, MemberShape]
-        attr_accessor type: untyped
+        attr_accessor type: Class
         def add_member: (Symbol, Shape, ?traits: Hash[String, untyped]) -> void
         def member?: (Symbol) -> bool
         def member: (Symbol) -> MemberShape?
@@ -71,6 +71,9 @@ module Smithy
       end
 
       class UnionShape < StructureShape
+        attr_accessor member_types: Hash[Symbol, Class]
+        def add_member: (Symbol, Shape, Class, ?traits: Hash[String, untyped]) -> void
+        def member_type: (Symbol) -> Class?
       end
 
       class MemberShape

--- a/gems/smithy-client/sig/smithy-client/union.rbs
+++ b/gems/smithy-client/sig/smithy-client/union.rbs
@@ -1,0 +1,7 @@
+module Smithy
+  module Client
+    class Union < ::SimpleDelegator
+      include Structure
+    end
+  end
+end

--- a/gems/smithy-client/spec/smithy-client/shapes_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/shapes_spec.rb
@@ -218,6 +218,34 @@ module Smithy
           end
         end
       end
+
+      describe UnionShape do
+        subject { UnionShape.new }
+
+        it 'is a subclass of Shape' do
+          expect(subject).to be_kind_of(Shape)
+        end
+
+        describe '#initialize' do
+          it 'defaults members to empty hash' do
+            expect(subject.members).to be_empty
+          end
+
+          it 'defaults member_types to empty hash' do
+            expect(subject.member_types).to be_empty
+          end
+        end
+
+        describe '#add_member' do
+          let(:member_type) { Class.new }
+
+          it 'adds a member with its type' do
+            subject.add_member(:foo, StringShape.new, member_type)
+            expect(subject.members[:foo]).to be_kind_of(MemberShape)
+            expect(subject.member_types[:foo]).to be(member_type)
+          end
+        end
+      end
     end
   end
 end

--- a/gems/smithy-client/spec/smithy-client/structure_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/structure_spec.rb
@@ -17,9 +17,9 @@ module Smithy
         end
       end
 
-      let(:test_union_class) { Class.new(Union) }
+      let(:union_class) { Class.new(Union) }
       let(:struct_value_class) do
-        Class.new(test_union_class) do
+        Class.new(union_class) do
           def to_h
             { struct_value: super(__getobj__) }
           end

--- a/gems/smithy-client/spec/smithy-client/structure_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/structure_spec.rb
@@ -10,9 +10,19 @@ module Smithy
           :hash_value,
           :value,
           :some_object,
+          :union_value,
           keyword_init: true
         ) do
           include Structure
+        end
+      end
+
+      let(:test_union_class) { Class.new(Union) }
+      let(:struct_value_class) do
+        Class.new(test_union_class) do
+          def to_h
+            { struct_value: super(__getobj__) }
+          end
         end
       end
 
@@ -24,6 +34,7 @@ module Smithy
             structure.new(value: 'bar')
           ],
           hash_value: { key: structure.new(value: 'value') },
+          union_value: struct_value_class.new(structure.new(value: 'value')),
           value: 'value',
           some_object: Object.new
         )
@@ -40,6 +51,7 @@ module Smithy
             hash_value: {
               key: { value: 'value' }
             },
+            union_value: { struct_value: { value: 'value' } },
             value: 'value',
             some_object: subject.some_object
           }

--- a/gems/smithy-client/spec/smithy-client/union_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/union_spec.rb
@@ -3,9 +3,9 @@
 module Smithy
   module Client
     describe Union do
-      let(:test_union_class) { Class.new(Union) }
+      let(:union_class) { Class.new(Union) }
       let(:string_value_class) do
-        Class.new(test_union_class) do
+        Class.new(union_class) do
           def to_h
             { string_value: super(__getobj__) }
           end

--- a/gems/smithy-client/spec/smithy-client/union_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/union_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Smithy
+  module Client
+    class TestUnion < Union
+      class StringValue < TestUnion
+        def to_h
+          { string_value: super(__getobj__) }
+        end
+      end
+    end
+
+    describe Union do
+      subject { TestUnion::StringValue.new('union') }
+
+      it 'uses simple delegator and structure' do
+        expect(subject).to be_a(SimpleDelegator)
+        expect(subject).to be_a(Structure)
+      end
+
+      describe '#to_h' do
+        it 'serializes the value to a hash' do
+          expect(subject.to_h).to eq(string_value: 'union')
+        end
+      end
+
+      describe '#to_s' do
+        it 'returns a string representation' do
+          expect(subject.to_s)
+            .to eq('#<Smithy::Client::TestUnion::StringValue union>')
+        end
+      end
+    end
+  end
+end

--- a/gems/smithy-client/spec/smithy-client/union_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/union_spec.rb
@@ -2,16 +2,22 @@
 
 module Smithy
   module Client
-    class TestUnion < Union
-      class StringValue < TestUnion
-        def to_h
-          { string_value: super(__getobj__) }
+    describe Union do
+      let(:test_union_class) { Class.new(Union) }
+      let(:string_value_class) do
+        Class.new(test_union_class) do
+          def to_h
+            { string_value: super(__getobj__) }
+          end
+
+          # anonymous class, need a class name to test to_s
+          def self.name
+            'TestUnion::StringValue'
+          end
         end
       end
-    end
 
-    describe Union do
-      subject { TestUnion::StringValue.new('union') }
+      subject { string_value_class.new('union') }
 
       it 'uses simple delegator and structure' do
         expect(subject).to be_a(SimpleDelegator)
@@ -27,7 +33,7 @@ module Smithy
       describe '#to_s' do
         it 'returns a string representation' do
           expect(subject.to_s)
-            .to eq('#<Smithy::Client::TestUnion::StringValue union>')
+            .to eq('#<TestUnion::StringValue union>')
         end
       end
     end

--- a/gems/smithy/lib/smithy/templates/client/types.erb
+++ b/gems/smithy/lib/smithy/templates/client/types.erb
@@ -8,6 +8,7 @@ module <%= namespace %>
 <% types.each do |type| -%>
 
     <%= type.documentation %>
+<% if type.type == 'structure' -%>
     <%= type.name %> = Struct.new(
 <% type.member_names.each do |member| -%>
       :<%= member %>,
@@ -16,6 +17,27 @@ module <%= namespace %>
     ) do
       include Smithy::Client::Structure
     end
+<% elsif type.type == 'union' -%>
+    class <%= type.name %> < Smithy::Client::Union
+<% type.members.each do |member| %>
+      class <%= member.name.camelize  %> < <%= type.name %>
+        def to_h
+          { <%= member.name.underscore %>: super(__getobj__) }
+        end
+      end
+<% end -%>
+
+      class Unknown < <%= type.name %>
+        def initialize(name:, value:)
+          super({name: name || 'Unknown', value: value})
+        end
+
+        def to_h
+          { unknown: super(__getobj__) }
+        end
+      end
+    end
+<% end -%>
 <% end -%>
 
   end

--- a/gems/smithy/lib/smithy/templates/client/types_rbs.erb
+++ b/gems/smithy/lib/smithy/templates/client/types_rbs.erb
@@ -2,6 +2,7 @@ module <%= namespace %>
   module Types
 <% types.each do |type| -%>
 
+<% if type.type == 'structure' -%>
     class <%= type.name %>
       include Smithy::Client::Structure
 
@@ -16,7 +17,18 @@ module <%= namespace %>
       attr_accessor <%= member.name %>: <%= member.rbs_type %>?
 <% end -%>
     end
+<% elsif type.type == 'union' -%>
+    class <%= type.name %> < Smithy::Client::Union
+<% type.members.each do |member| %>
+      class <%= member.name.camelize  %> < <%= type.name %>
+      end
 <% end -%>
 
+      class Unknown < <%= type.name %>
+        def initialize: (name: String?, value: untyped?) -> void
+      end
+    end
+<% end -%>
+<% end -%>
   end
 end

--- a/gems/smithy/lib/smithy/views/client/request_response_example.rb
+++ b/gems/smithy/lib/smithy/views/client/request_response_example.rb
@@ -114,7 +114,8 @@ module Smithy
         def union(union_shape, indent, visited)
           lines = []
           lines << '{'
-          union_shape['members']&.first&.tap do |member_name, member_shape|
+          lines << "#{indent}  # One of:"
+          union_shape['members']&.each_pair do |member_name, member_shape|
             lines << member(member_name, member_shape, indent, visited)
           end
           lines.last.chomp!(',') if lines.last.end_with?(',')

--- a/gems/smithy/lib/smithy/views/client/request_response_example.rb
+++ b/gems/smithy/lib/smithy/views/client/request_response_example.rb
@@ -74,7 +74,7 @@ module Smithy
           when 'list' then list(shape, indent, visited)
           when 'map' then map(shape, indent, visited)
           when 'structure' then structure(shape, indent, visited)
-          when 'union' then 'TODO: union'
+          when 'union' then union(shape, indent, visited)
           else raise "unsupported shape type: #{shape['type'].inspect}"
           end
         end
@@ -104,6 +104,17 @@ module Smithy
           lines = []
           lines << '{'
           structure_shape['members']&.each_pair do |member_name, member_shape|
+            lines << member(member_name, member_shape, indent, visited)
+          end
+          lines.last.chomp!(',') if lines.last.end_with?(',')
+          lines << "#{indent}}"
+          lines.join("\n")
+        end
+
+        def union(union_shape, indent, visited)
+          lines = []
+          lines << '{'
+          union_shape['members']&.first&.tap do |member_name, member_shape|
             lines << member(member_name, member_shape, indent, visited)
           end
           lines.last.chomp!(',') if lines.last.end_with?(',')

--- a/gems/smithy/lib/smithy/views/client/types.rb
+++ b/gems/smithy/lib/smithy/views/client/types.rb
@@ -45,7 +45,7 @@ module Smithy
 
           def members
             @shape['members']
-              .map { |name, member| Member.new(name, member['target'], Model.shape(@model, member['target'])) }
+              .map { |name, member| Member.new(@model, name, member['target']) }
           end
 
           def type
@@ -55,10 +55,10 @@ module Smithy
 
         # @api private
         class Member
-          def initialize(name, id, shape)
+          def initialize(model, name, id)
             @name = name
             @id = id
-            @shape = shape
+            @shape = Model.shape(model, id)
           end
 
           attr_reader :name, :id, :shape

--- a/gems/smithy/lib/smithy/views/client/types.rb
+++ b/gems/smithy/lib/smithy/views/client/types.rb
@@ -20,14 +20,15 @@ module Smithy
             .new(@model)
             .shapes_for(@plan.service)
             .select { |_key, shape| %w[structure union].include?(shape['type']) }
-            .map { |id, structure| Type.new(id, structure) }
+            .map { |id, shape| Type.new(@model, id, shape) }
         end
 
         # @api private
         class Type
-          def initialize(id, structure)
+          def initialize(model, id, shape)
+            @model = model
             @id = id
-            @structure = structure
+            @shape = shape
           end
 
           def documentation
@@ -39,8 +40,28 @@ module Smithy
           end
 
           def member_names
-            @structure['members'].keys.map(&:underscore)
+            @shape['members'].keys.map(&:underscore)
           end
+
+          def members
+            @shape['members']
+              .map { |name, member| Member.new(name, member['target'], Model.shape(@model, member['target'])) }
+          end
+
+          def type
+            @shape['type']
+          end
+        end
+
+        # @api private
+        class Member
+          def initialize(name, id, shape)
+            @name = name
+            @id = id
+            @shape = shape
+          end
+
+          attr_reader :name, :id, :shape
         end
       end
     end

--- a/gems/smithy/lib/smithy/views/client/types_rbs.rb
+++ b/gems/smithy/lib/smithy/views/client/types_rbs.rb
@@ -25,9 +25,9 @@ module Smithy
 
         # @api private
         class Type
-          def initialize(model, id, structure)
+          def initialize(model, id, shape)
             @id = id
-            @structure = structure
+            @shape = shape
             @model = model
           end
 
@@ -36,9 +36,13 @@ module Smithy
           end
 
           def members
-            @structure['members'].map do |name, member|
+            @shape['members'].map do |name, member|
               Member.new(@model, name, member)
             end
+          end
+
+          def type
+            @shape['type']
           end
         end
 

--- a/gems/smithy/spec/fixtures/all_shapes/model.json
+++ b/gems/smithy/spec/fixtures/all_shapes/model.json
@@ -164,11 +164,14 @@
                 "string": {
                     "target": "smithy.api#String"
                 },
-                "integer": {
-                    "target": "smithy.api#Integer"
-                },
                 "structure": {
                     "target": "smithy.ruby.tests#Structure"
+                },
+                "simpleList": {
+                    "target": "smithy.ruby.tests#SimpleList"
+                },
+                "simpleMap": {
+                    "target": "smithy.ruby.tests#SimpleMap"
                 },
                 "complexList": {
                     "target": "smithy.ruby.tests#ComplexList"

--- a/gems/smithy/spec/fixtures/all_shapes/model.json
+++ b/gems/smithy/spec/fixtures/all_shapes/model.json
@@ -166,6 +166,15 @@
                 },
                 "integer": {
                     "target": "smithy.api#Integer"
+                },
+                "structure": {
+                    "target": "smithy.ruby.tests#Structure"
+                },
+                "complexList": {
+                    "target": "smithy.ruby.tests#ComplexList"
+                },
+                "complexMap": {
+                    "target": "smithy.ruby.tests#ComplexMap"
                 }
             }
         }

--- a/gems/smithy/spec/fixtures/all_shapes/model.smithy
+++ b/gems/smithy/spec/fixtures/all_shapes/model.smithy
@@ -75,8 +75,9 @@ map ComplexMap {
 
 union Union {
     string: String,
-    integer: Integer
     structure: Structure
+    simpleList: SimpleList
+    simpleMap: SimpleMap
     complexList: ComplexList
     complexMap: ComplexMap
 }

--- a/gems/smithy/spec/fixtures/all_shapes/model.smithy
+++ b/gems/smithy/spec/fixtures/all_shapes/model.smithy
@@ -76,4 +76,7 @@ map ComplexMap {
 union Union {
     string: String,
     integer: Integer
+    structure: Structure
+    complexList: ComplexList
+    complexMap: ComplexMap
 }

--- a/gems/smithy/spec/interfaces/client/client_syntax_example_spec.rb
+++ b/gems/smithy/spec/interfaces/client/client_syntax_example_spec.rb
@@ -46,7 +46,9 @@ describe 'Component: Client: Request/Response Syntax Examples' do
           structure: {
             member: "String"
           },
-          union: TODO: union
+          union: {
+            string: "String"
+          }
         }
         options = {}
         output = client.operation(params, options)
@@ -86,7 +88,9 @@ describe 'Component: Client: Request/Response Syntax Examples' do
           structure: {
             member: "String"
           },
-          union: TODO: union
+          union: {
+            string: "String"
+          }
         }
     EXAMPLE
     client_file = File.join(@tmpdir, 'lib', 'all_shapes', 'client.rb')

--- a/gems/smithy/spec/interfaces/client/client_syntax_example_spec.rb
+++ b/gems/smithy/spec/interfaces/client/client_syntax_example_spec.rb
@@ -47,7 +47,25 @@ describe 'Component: Client: Request/Response Syntax Examples' do
             member: "String"
           },
           union: {
-            string: "String"
+            # One of:
+            string: "String",
+            structure: {
+              member: "String"
+            },
+            simple_list: ["String"],
+            simple_map: {
+              "String" => "String"
+            },
+            complex_list: [
+              {
+                member: "String"
+              }
+            ],
+            complex_map: {
+              "String" => {
+                member: "String"
+              }
+            }
           }
         }
         options = {}
@@ -89,7 +107,25 @@ describe 'Component: Client: Request/Response Syntax Examples' do
             member: "String"
           },
           union: {
-            string: "String"
+            # One of:
+            string: "String",
+            structure: {
+              member: "String"
+            },
+            simple_list: ["String"],
+            simple_map: {
+              "String" => "String"
+            },
+            complex_list: [
+              {
+                member: "String"
+              }
+            ],
+            complex_map: {
+              "String" => {
+                member: "String"
+              }
+            }
           }
         }
     EXAMPLE

--- a/gems/smithy/spec/interfaces/client/shapes_spec.rb
+++ b/gems/smithy/spec/interfaces/client/shapes_spec.rb
@@ -193,6 +193,15 @@ describe 'Component: Shapes' do
       it 'is an instance of UnionShape' do
         expect(subject::Union).to be_a(shapes_module::UnionShape)
       end
+
+      it 'has a type' do
+        expect(subject::Union.type).to eq(ShapeService::Types::Union)
+      end
+
+      it 'has members with types' do
+        expect(subject::Union.member(:list)).to be_a(shapes_module::MemberShape)
+        expect(subject::Union.member_type(:list)).to eq(ShapeService::Types::Union::List)
+      end
     end
   end
 

--- a/gems/smithy/spec/interfaces/client/types_spec.rb
+++ b/gems/smithy/spec/interfaces/client/types_spec.rb
@@ -4,27 +4,46 @@ describe 'Component: Types' do
   %i[schema client].each do |plan_type|
     context "#{plan_type} generator" do
       before(:all) do
-        @tmpdir = SpecHelper.generate(['Weather'], plan_type)
+        @tmpdir = SpecHelper.generate(['AllShapes'], plan_type)
       end
 
       after(:all) do
-        SpecHelper.cleanup(['Weather'], @tmpdir)
+        SpecHelper.cleanup(['AllShapes'], @tmpdir)
       end
 
       it 'generates a types module' do
-        expect(Weather::Types).to be_a(Module)
+        expect(AllShapes::Types).to be_a(Module)
       end
 
-      it 'has structures as structs' do
-        expect(Weather::Types::CityCoordinates.new).to be_a(Struct)
+      it 'has structures as structs that include Structure' do
+        expect(AllShapes::Types::Structure).to be < Struct
+        expect(AllShapes::Types::Structure).to include(Smithy::Client::Structure)
+      end
+
+      it 'has unions that define member subclasses' do
+        expect(AllShapes::Types::Union).to be < Smithy::Client::Union
+        expect(AllShapes::Types::Union::Structure).to be < AllShapes::Types::Union
       end
 
       it 'supports nested to_h' do
-        coordinates = Weather::Types::CityCoordinates.new(latitude: 1.0, longitude: 2.0)
-        get_city_output = Weather::Types::GetCityOutput.new(name: 'Winchester', coordinates: coordinates)
+        structure = AllShapes::Types::Structure.new(member: 'member')
+        simple_list = ['value1']
+        complex_list = [structure]
+        union = AllShapes::Types::Union::Structure.new(structure)
+        input_output = AllShapes::Types::OperationInputOutput.new(
+          string: 'string',
+          simple_list: simple_list,
+          complex_list: complex_list,
+          union: union
+        )
 
-        expected = { name: 'Winchester', coordinates: { latitude: 1.0, longitude: 2.0 } }
-        actual = get_city_output.to_h
+        expected = {
+          string: 'string',
+          simple_list: ['value1'],
+          complex_list: [{member: 'member'}],
+          union: {structure: {member: 'member'}}
+        }
+        actual = input_output.to_h
         expect(actual).to eq(expected)
       end
     end

--- a/gems/smithy/spec/interfaces/client/types_spec.rb
+++ b/gems/smithy/spec/interfaces/client/types_spec.rb
@@ -40,8 +40,8 @@ describe 'Component: Types' do
         expected = {
           string: 'string',
           simple_list: ['value1'],
-          complex_list: [{member: 'member'}],
-          union: {structure: {member: 'member'}}
+          complex_list: [{ member: 'member' }],
+          union: { structure: { member: 'member' } }
         }
         actual = input_output.to_h
         expect(actual).to eq(expected)


### PR DESCRIPTION
*Description of changes:*
Implements generation of tagged Unions following an approach similiar to Java/Hearth Smithy-Ruby: a "sealed classes" like approach with delegation.

Note: The to_h method needs to be generated on each member subclass because we don't want active-support as a dependnecy runtime.  If we did have it runtime, the Smithy::Client::Union class could define a to_h method that would do something like: `{}.tap { |h| h[self.class.name.split(::).last.underscore] = super(__getob__)`

The weather service in projections does not have any union types, so below is code generated for the `all_shapes` fixture which defines the following union:

```smithy
union Union {
    string: String,
    integer: Integer,
    structure: Structure,
    complexList: ComplexList,
    complexMap: ComplexMap
}
```

And generates the following in types.rb:
```rb
    class Union < Smithy::Client::Union

      class String < Union
        def to_h
          { string: super(__getobj__) }
        end
      end

      class Integer < Union
        def to_h
          { integer: super(__getobj__) }
        end
      end

      class Structure < Union
        def to_h
          { structure: super(__getobj__) }
        end
      end

      class ComplexList < Union
        def to_h
          { complex_list: super(__getobj__) }
        end
      end

      class ComplexMap < Union
        def to_h
          { complex_map: super(__getobj__) }
        end
      end

      class Unknown < Union
        def initialize(name:, value:)
          super({name: name || 'Unknown', value: value})
        end

        def to_h
          { unknown: super(__getobj__) }
        end
      end
    end
```

And generates the following in shapes.rb:
```ruby
    Union = UnionShape.new(id: 'smithy.ruby.tests#Union')

    Union.add_member(:string, Prelude::String, Types::Union::String)
    Union.add_member(:integer, Prelude::Integer, Types::Union::Integer)
    Union.add_member(:structure, Structure, Types::Union::Structure)
    Union.add_member(:complex_list, ComplexList, Types::Union::ComplexList)
    Union.add_member(:complex_map, ComplexMap, Types::Union::ComplexMap)
    Union.type = Types::Union
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
