### PR TITLE
Use camelize on class names

### DIFF
--- a/gems/smithy/lib/smithy/generators/client.rb
+++ b/gems/smithy/lib/smithy/generators/client.rb
@@ -64,7 +64,7 @@ module Smithy
       def rbs_files
         Enumerator.new do |e|
           e.yield "sig/#{@gem_name}.rbs", Views::Client::ModuleRbs.new(@plan).render
-          e.yield 'sig/client.rbs', Views::Client::ClientRbs.new(@plan).render
+          e.yield 'sig/client.rbs', Views::Client::ClientRbs.new(@plan, code_generated_plugins).render
           e.yield 'sig/errors.rbs', Views::Client::ErrorsRbs.new(@plan).render
           e.yield 'sig/endpoint_parameters.rbs', Views::Client::EndpointParametersRbs.new(@plan).render
           e.yield 'sig/endpoint_provider.rbs', Views::Client::EndpointProviderRbs.new(@plan).render

--- a/gems/smithy/lib/smithy/views/client/client_rbs.rb
+++ b/gems/smithy/lib/smithy/views/client/client_rbs.rb
@@ -36,8 +36,6 @@ module Smithy
 
         private
 
-        private
-
         def plugins(plan, code_generated_plugins)
           define_namespaces
           code_generated_plugins.each do |plugin|

--- a/gems/smithy/lib/smithy/views/client/client_rbs.rb
+++ b/gems/smithy/lib/smithy/views/client/client_rbs.rb
@@ -5,10 +5,10 @@ module Smithy
     module Client
       # @api private
       class ClientRbs < View
-        def initialize(plan)
+        def initialize(plan, code_generated_plugins)
           @plan = plan
           @model = plan.model
-          @plugins = PluginList.new(plan)
+          @plugins = plugins(plan, code_generated_plugins)
 
           super()
         end
@@ -35,6 +35,25 @@ module Smithy
         end
 
         private
+
+        private
+
+        def plugins(plan, code_generated_plugins)
+          define_namespaces
+          code_generated_plugins.each do |plugin|
+            Object.module_eval(plugin.source)
+          end
+          PluginList.new(plan).to_a + code_generated_plugins.to_a
+        end
+
+        def define_namespaces
+          parent = Object
+          namespace.split('::') do |mod|
+            child = mod
+            parent.const_set(child, ::Module.new) unless parent.const_defined?(child)
+            parent = parent.const_get(child)
+          end
+        end
 
         def rbs_type(option)
           return option.rbs_type if option.rbs_type

--- a/gems/smithy/lib/smithy/views/client/errors.rb
+++ b/gems/smithy/lib/smithy/views/client/errors.rb
@@ -38,7 +38,7 @@ module Smithy
           end
 
           def name
-            Model::Shape.name(@id)
+            Model::Shape.name(@id).camelize
           end
 
           def retryable?

--- a/gems/smithy/lib/smithy/views/client/shapes.rb
+++ b/gems/smithy/lib/smithy/views/client/shapes.rb
@@ -66,7 +66,7 @@ module Smithy
         def build_shape(id, shape)
           Shape.new(
             id: id,
-            name: Model::Shape.name(id),
+            name: Model::Shape.name(id).camelize,
             type: shape_type_from_type(shape['type']),
             traits: filter_traits(shape['traits']),
             members: build_member_shapes(shape)

--- a/gems/smithy/lib/smithy/views/client/types.rb
+++ b/gems/smithy/lib/smithy/views/client/types.rb
@@ -35,7 +35,7 @@ module Smithy
           end
 
           def name
-            Model::Shape.name(@id)
+            Model::Shape.name(@id).camelize
           end
 
           def member_names

--- a/gems/smithy/lib/smithy/views/client/types_rbs.rb
+++ b/gems/smithy/lib/smithy/views/client/types_rbs.rb
@@ -32,7 +32,7 @@ module Smithy
           end
 
           def name
-            Model::Shape.name(@id)
+            Model::Shape.name(@id).camelize
           end
 
           def members

--- a/projections/weather/sig/client.rbs
+++ b/projections/weather/sig/client.rbs
@@ -1,6 +1,8 @@
 module Weather
   class Client < Smithy::Client::Base
     def self.new: (
+      ?endpoint: String,
+      ?endpoint_provider: Weather::EndpointProvider,
       ?http_ca_file: String,
       ?http_ca_path: String,
       ?http_cert: OpenSSL::X509::Certificate,

--- a/projections/weather/sig/client.rbs
+++ b/projections/weather/sig/client.rbs
@@ -1,8 +1,6 @@
 module Weather
   class Client < Smithy::Client::Base
     def self.new: (
-      ?endpoint: String,
-      ?endpoint_provider: Weather::EndpointProvider,
       ?http_ca_file: String,
       ?http_ca_path: String,
       ?http_cert: OpenSSL::X509::Certificate,
@@ -29,7 +27,7 @@ module Weather
       def coordinates: () -> Types::CityCoordinates?
     end
       def get_city: (
-          ?city_id: String
+        ?city_id: String
       ) -> _GetCityResponse
       | (?Hash[Symbol, untyped], ?Hash[Symbol, untyped]) -> _GetCityResponse
 
@@ -44,7 +42,7 @@ module Weather
       def chance_of_rain: () -> Float?
     end
       def get_forecast: (
-          ?city_id: String
+        ?city_id: String
       ) -> _GetForecastResponse
       | (?Hash[Symbol, untyped], ?Hash[Symbol, untyped]) -> _GetForecastResponse
 
@@ -54,8 +52,8 @@ module Weather
       def items: () -> Array[Types::CitySummary]?
     end
       def list_cities: (
-          ?next_token: String,
-          ?page_size: Integer
+        ?next_token: String,
+        ?page_size: Integer
       ) -> _ListCitiesResponse
       | (?Hash[Symbol, untyped], ?Hash[Symbol, untyped]) -> _ListCitiesResponse
   end


### PR DESCRIPTION

*Description of changes:*
Applies `camelize` to all generated class/constant names - in the future we may need a view utility to handle shape IDs such as `__123Struct` and to handle name conflicts (ie, a reserved word list).  


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
