### PR TITLE
Service-less schema generation

### DIFF
--- a/gems/smithy/lib/smithy/generators/schema.rb
+++ b/gems/smithy/lib/smithy/generators/schema.rb
@@ -33,6 +33,8 @@ module Smithy
 
           source_files.each { |file, content| e.yield file, content }
           e.yield "lib/#{@gem_name}/customizations.rb", Views::Client::Customizations.new.render
+
+          rbs_files.each { |file, content| e.yield file, content }
         end
       end
 
@@ -48,6 +50,7 @@ module Smithy
         Enumerator.new do |e|
           e.yield "sig/#{@gem_name}.rbs", Views::Client::ModuleRbs.new(@plan).render
           e.yield 'sig/types.rbs', Views::Client::TypesRbs.new(@plan).render
+          e.yield 'sig/shapes.rbs', Views::Client::ShapesRbs.new(@plan).render
         end
       end
 

--- a/gems/smithy/lib/smithy/model/service_index.rb
+++ b/gems/smithy/lib/smithy/model/service_index.rb
@@ -15,15 +15,21 @@ module Smithy
       # @param [Hash] service Service shape
       # @return [Hash<String, Hash>] The operations for the service.
       def operations_for(service)
-        @operations_for ||= begin
-          shapes = @service_parser.operations_for(service)
-          shapes.sort_by { |k, _v| k }.to_h
+        if service
+          @operations_for ||= begin
+            shapes = @service_parser.operations_for(service)
+            shapes.sort_by { |k, _v| k }.to_h
+          end
+        else
+          @model['shapes'].select { |_id, shape| shape['type'] == 'operation' }
         end
       end
 
-      # @param [Hash] service Service shape
+      # @param [Hash, nil] service Service shape
       # @return [Hash<String, Hash>] The shapes for the service.
       def shapes_for(service)
+        return @model['shapes'] unless service
+
         @shapes_for ||= begin
           shapes = {}
           parse_errors(service, shapes)

--- a/gems/smithy/lib/smithy/plan.rb
+++ b/gems/smithy/lib/smithy/plan.rb
@@ -37,7 +37,7 @@ module Smithy
     # @return [Symbol] The type of code to generate.
     attr_reader :type
 
-    # @return [Hash<String, Hash>] The service shape for the shapes.
+    # @return [Hash<String, Hash>, nil] The service shape for the shapes.
     attr_reader :service
 
     # @return [String] The name of the service.

--- a/gems/smithy/lib/smithy/templates/client/shapes.erb
+++ b/gems/smithy/lib/smithy/templates/client/shapes.erb
@@ -21,11 +21,13 @@ module <%= module_name %>
 
 <% end -%>
     SCHEMA = Smithy::Client::Schema.new do |schema|
+<% if service_shape -%>
       schema.service = ServiceShape.new(
         id: "<%= service_shape.id %>",
         version: "<%= service_shape.version %>",
         traits: <%= service_shape.traits %>
       )
+<% end -%>
 <% operation_shapes.each do |shape| -%>
       schema.add_operation(:<%= shape.name %>, OperationShape.new do |operation|
         operation.id = "<%= shape.id %>"

--- a/gems/smithy/lib/smithy/views/client/shapes.rb
+++ b/gems/smithy/lib/smithy/views/client/shapes.rb
@@ -24,6 +24,8 @@ module Smithy
         end
 
         def service_shape
+          return if @service_shape.nil?
+
           ServiceShape.new(
             id: @service_shape.keys.first,
             traits: filter_traits(@service_shape.values.first['traits']),
@@ -118,7 +120,7 @@ module Smithy
         end
 
         def shape_type_from_type(type)
-          msg = "Unsupported shape type: `#{type}'"
+          msg = "Unsupported shape type: `#{type}`"
           raise ArgumentError, msg unless SHAPE_TYPES_MAP.include?(type)
 
           SHAPE_TYPES_MAP[type]

--- a/gems/smithy/lib/smithy/weld.rb
+++ b/gems/smithy/lib/smithy/weld.rb
@@ -16,7 +16,7 @@ module Smithy
     end
 
     # Called to determine if the weld should be applied for this model.
-    # @param [Hash] service Service shape
+    # @param [Hash, nil] service Service shape
     # @return [Boolean] (true) True if the weld should be applied, false otherwise.
     def for?(service) # rubocop:disable Lint/UnusedMethodArgument
       true

--- a/gems/smithy/lib/smithy/weld.rb
+++ b/gems/smithy/lib/smithy/weld.rb
@@ -8,6 +8,7 @@ module Smithy
 
     # @param [Plan] plan The plan that is being executed.
     def initialize(plan)
+      @plan = plan
       # Necessary for Thor::Base and Thor::Actions
       self.options = { force: true, quiet: plan.quiet }
       self.destination_root = plan.destination_root

--- a/gems/smithy/lib/smithy/welds/endpoints.rb
+++ b/gems/smithy/lib/smithy/welds/endpoints.rb
@@ -6,6 +6,8 @@ module Smithy
     class Endpoints < Weld
       def pre_process(model)
         id, service = model['shapes'].select { |_k, s| s['type'] == 'service' }.first
+        return unless service
+
         return if service['traits'] && service['traits']['smithy.rules#endpointRuleSet']
 
         say_status :insert, "Adding default endpoint rules to #{id}", :yellow

--- a/gems/smithy/lib/smithy/welds/rubocop.rb
+++ b/gems/smithy/lib/smithy/welds/rubocop.rb
@@ -10,13 +10,17 @@ module Smithy
       ].freeze
 
       def for?(service)
-        namespace = Model::Shape.namespace(service.keys.first).to_s
-        TEST_NAMESPACES.none? { |test_namespace| namespace.match?(test_namespace) }
+        if service.nil?
+          @plan.model['shapes'].none? { |id, _shape| TEST_NAMESPACES.any? { |namespace| namespace.match?(id) } }
+        else
+          namespace = Model::Shape.namespace(service.keys.first).to_s
+          TEST_NAMESPACES.none? { |test_namespace| namespace.match?(test_namespace) }
+        end
       end
 
       def post_process(_artifacts)
         require 'rubocop'
-        puts "Running RuboCop --autocorrect-all on #{destination_root}"
+        say_status :insert, "Running RuboCop --autocorrect-all on #{destination_root}", @plan.quiet
         rubocop = ::RuboCop::CLI.new
         args = [
           '--autocorrect-all',

--- a/gems/smithy/spec/fixtures/no_service/model.json
+++ b/gems/smithy/spec/fixtures/no_service/model.json
@@ -1,4 +1,171 @@
 {
     "smithy": "2.0",
-    "shapes": {}
+    "shapes": {
+        "smithy.ruby.tests#BigDecimal": {
+            "type": "bigDecimal"
+        },
+        "smithy.ruby.tests#BigInteger": {
+            "type": "bigInteger"
+        },
+        "smithy.ruby.tests#Blob": {
+            "type": "blob"
+        },
+        "smithy.ruby.tests#Boolean": {
+            "type": "boolean"
+        },
+        "smithy.ruby.tests#Byte": {
+            "type": "byte"
+        },
+        "smithy.ruby.tests#Document": {
+            "type": "document"
+        },
+        "smithy.ruby.tests#Double": {
+            "type": "double"
+        },
+        "smithy.ruby.tests#Enum": {
+            "type": "enum",
+            "members": {
+                "FOO": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "bar"
+                    }
+                }
+            }
+        },
+        "smithy.ruby.tests#Float": {
+            "type": "float"
+        },
+        "smithy.ruby.tests#IntEnum": {
+            "type": "intEnum",
+            "members": {
+                "BAZ": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": 1
+                    }
+                }
+            }
+        },
+        "smithy.ruby.tests#Integer": {
+            "type": "integer"
+        },
+        "smithy.ruby.tests#List": {
+            "type": "list",
+            "member": {
+                "target": "smithy.ruby.tests#String"
+            }
+        },
+        "smithy.ruby.tests#Long": {
+            "type": "long"
+        },
+        "smithy.ruby.tests#Map": {
+            "type": "map",
+            "key": {
+                "target": "smithy.ruby.tests#String"
+            },
+            "value": {
+                "target": "smithy.ruby.tests#String"
+            }
+        },
+        "smithy.ruby.tests#Operation": {
+            "type": "operation",
+            "input": {
+                "target": "smithy.ruby.tests#OperationInputOutput"
+            },
+            "output": {
+                "target": "smithy.ruby.tests#OperationInputOutput"
+            }
+        },
+        "smithy.ruby.tests#OperationInputOutput": {
+            "type": "structure",
+            "members": {
+                "blob": {
+                    "target": "smithy.ruby.tests#Blob"
+                },
+                "boolean": {
+                    "target": "smithy.ruby.tests#Boolean"
+                },
+                "string": {
+                    "target": "smithy.ruby.tests#String"
+                },
+                "byte": {
+                    "target": "smithy.ruby.tests#Byte"
+                },
+                "short": {
+                    "target": "smithy.ruby.tests#Short"
+                },
+                "integer": {
+                    "target": "smithy.ruby.tests#Integer"
+                },
+                "long": {
+                    "target": "smithy.ruby.tests#Long"
+                },
+                "float": {
+                    "target": "smithy.ruby.tests#Float"
+                },
+                "double": {
+                    "target": "smithy.ruby.tests#Double"
+                },
+                "bigInteger": {
+                    "target": "smithy.ruby.tests#BigInteger"
+                },
+                "bigDecimal": {
+                    "target": "smithy.ruby.tests#BigDecimal"
+                },
+                "timestamp": {
+                    "target": "smithy.ruby.tests#Timestamp"
+                },
+                "document": {
+                    "target": "smithy.ruby.tests#Document"
+                },
+                "enum": {
+                    "target": "smithy.ruby.tests#Enum"
+                },
+                "intEnum": {
+                    "target": "smithy.ruby.tests#IntEnum"
+                },
+                "list": {
+                    "target": "smithy.ruby.tests#List"
+                },
+                "map": {
+                    "target": "smithy.ruby.tests#Map"
+                },
+                "structure": {
+                    "target": "smithy.ruby.tests#Structure"
+                },
+                "union": {
+                    "target": "smithy.ruby.tests#Union"
+                }
+            }
+        },
+        "smithy.ruby.tests#Short": {
+            "type": "short"
+        },
+        "smithy.ruby.tests#String": {
+            "type": "string"
+        },
+        "smithy.ruby.tests#Structure": {
+            "type": "structure",
+            "members": {
+                "member": {
+                    "target": "smithy.ruby.tests#String"
+                }
+            }
+        },
+        "smithy.ruby.tests#Timestamp": {
+            "type": "timestamp"
+        },
+        "smithy.ruby.tests#Union": {
+            "type": "union",
+            "members": {
+                "string": {
+                    "target": "smithy.ruby.tests#String"
+                },
+                "structure": {
+                    "target": "smithy.ruby.tests#Structure"
+                }
+            }
+        }
+    }
 }

--- a/gems/smithy/spec/fixtures/no_service/model.smithy
+++ b/gems/smithy/spec/fixtures/no_service/model.smithy
@@ -1,3 +1,85 @@
 $version: "2"
 
 namespace smithy.ruby.tests
+
+operation Operation {
+  input: OperationInputOutput
+  output: OperationInputOutput
+}
+
+structure OperationInputOutput {
+  // https://smithy.io/2.0/spec/simple-types.html
+  blob: Blob
+  boolean: Boolean
+  string: String
+  byte: Byte
+  short: Short
+  integer: Integer
+  long: Long
+  float: Float
+  double: Double
+  bigInteger: BigInteger
+  bigDecimal: BigDecimal
+  timestamp: Timestamp
+  document: Document
+  enum: Enum
+  intEnum: IntEnum
+
+  // https://smithy.io/2.0/spec/aggregate-types.html
+  list: List
+  map: Map
+  structure: Structure
+  union: Union
+}
+
+blob Blob
+
+boolean Boolean
+
+string String
+
+byte Byte
+
+short Short
+
+integer Integer
+
+long Long
+
+float Float
+
+double Double
+
+bigInteger BigInteger
+
+bigDecimal BigDecimal
+
+timestamp Timestamp
+
+document Document
+
+enum Enum {
+  FOO = "bar"
+}
+
+intEnum IntEnum {
+  BAZ = 1
+}
+
+list List {
+  member: String
+}
+
+map Map {
+  key: String
+  value: String
+}
+
+union Union {
+  string: String
+  structure: Structure
+}
+
+structure Structure {
+  member: String
+}

--- a/gems/smithy/spec/interfaces/schema/service_less_schema_spec.rb
+++ b/gems/smithy/spec/interfaces/schema/service_less_schema_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+describe 'Service-Less Schema', rbs_test: true do
+  before(:all) do
+    @tmpdir = SpecHelper.generate(['NoService'], :schema, fixture: 'no_service')
+  end
+
+  after(:all) do
+    SpecHelper.cleanup(['NoService'], @tmpdir)
+  end
+
+  it 'generates a shapes module' do
+    expect(NoService::Shapes).to be_a(Module)
+  end
+
+  it 'generates shapes' do
+    expect(NoService::Shapes.constants)
+      .to include(
+        :List, :Enum, :BigDecimal, :BigInteger, :Blob, :Integer, :Byte,
+        :Document, :Double, :Long, :Map, :IntEnum, :OperationInputOutput,
+        :Float, :Timestamp, :Short, :Boolean, :Union, :String, :Structure
+      )
+  end
+
+  it 'generates a schema with operations and no service' do
+    expect(NoService::Shapes::SCHEMA).to be_a(Smithy::Client::Schema)
+    expect(NoService::Shapes::SCHEMA.service).to be_nil
+    expect(NoService::Shapes::SCHEMA.operations).to include(operation: be_a(Smithy::Client::Shapes::OperationShape))
+  end
+end

--- a/gems/smithy/spec/smithy/plan_spec.rb
+++ b/gems/smithy/spec/smithy/plan_spec.rb
@@ -35,8 +35,28 @@ module Smithy
       context 'no service shapes' do
         let(:fixture) { File.expand_path('../fixtures/no_service/model.json', __dir__.to_s) }
 
-        it 'raises an error' do
-          expect { subject }.to raise_error('No service shape found')
+        context 'type: client' do
+          let(:type) { :client }
+          it 'raises an error' do
+            expect { subject }.to raise_error('No service shape found')
+          end
+        end
+
+        context 'type: schema' do
+          let(:type) { :schema }
+
+          context 'missing name' do
+            it 'raises an error' do
+              expect { subject }.to raise_error('Missing name')
+            end
+          end
+
+          context 'name set' do
+            let(:options) { { gem_version: '0.1.0', name: 'name' } }
+            it 'resolves service to nil' do
+              expect(subject.service).to be_nil
+            end
+          end
         end
       end
 

--- a/gems/smithy/spec/spec_helper.rb
+++ b/gems/smithy/spec/spec_helper.rb
@@ -66,6 +66,7 @@ module SpecHelper
 
     def create_plan(modules, model, type, options)
       plan_options = {
+        name: modules.last,
         module_name: modules.join('::'),
         gem_version: options.fetch(:gem_version, '0.1.0'),
         destination_root: options.fetch(:destination_root, Dir.mktmpdir),


### PR DESCRIPTION
*Description of changes:*
Generate schemas when the model does not have a service.  This functionality is useful for open-world SERDE.

Key decisions:
* missing service is represented by `nil`
* welds must all correctly handle nil service
* ServiceIndex for operations_for and shapes_for will return all operations/shapes when the provided service is nil.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
