### PR TITLE
Backport endpoint provider parameters unused variable fix

### DIFF
--- a/gems/smithy/lib/smithy/templates/client/endpoint_provider.erb
+++ b/gems/smithy/lib/smithy/templates/client/endpoint_provider.erb
@@ -9,10 +9,6 @@ module <%= module_name %>
     # @return [Smithy::Client::EndpointRules::Endpoint]
     # @raise [ArgumentError]
     def resolve_endpoint(parameters)
-<% parameters.each do |p| -%>
-      <%= p.name %> = parameters.<%= p.name %>
-<% end -%>
-
 <%= endpoint_rules_code %>
     end
   end

--- a/gems/smithy/lib/smithy/views/client/endpoint_provider.rb
+++ b/gems/smithy/lib/smithy/views/client/endpoint_provider.rb
@@ -170,11 +170,7 @@ module Smithy
         def str(str)
           if str.is_a?(Hash)
             if str['ref']
-              if @assigned_variables.include?(str['ref'])
-                str['ref'].underscore
-              else
-                "parameters.#{str['ref'].underscore}"
-              end
+              variable(str['ref'])
             elsif str['fn']
               function(str)
             else
@@ -196,13 +192,7 @@ module Smithy
 
         def template_replace(value)
           indexes = value.split('#')
-          variable = indexes.shift
-          res =
-            if @assigned_variables.include?(variable)
-              variable.underscore
-            else
-              "parameters.#{variable.underscore}"
-            end
+          res = variable(indexes.shift)
           res + indexes.map do |index|
             "['#{index}']"
           end.join
@@ -216,11 +206,7 @@ module Smithy
         def fn_arg(arg)
           if arg.is_a?(Hash)
             if arg['ref']
-              if @assigned_variables.include?(arg['ref'])
-                arg['ref'].underscore
-              else
-                "parameters.#{arg['ref'].underscore}"
-              end
+              variable(arg['ref'])
             elsif arg['fn']
               function(arg)
             else
@@ -230,6 +216,14 @@ module Smithy
             template_str(arg)
           else
             arg
+          end
+        end
+
+        def variable(variable)
+          if @assigned_variables.include?(variable)
+            variable.underscore
+          else
+            "parameters.#{variable.underscore}"
           end
         end
 

--- a/projections/weather/lib/weather/endpoint_provider.rb
+++ b/projections/weather/lib/weather/endpoint_provider.rb
@@ -9,9 +9,7 @@ module Weather
     # @return [Smithy::Client::EndpointRules::Endpoint]
     # @raise [ArgumentError]
     def resolve_endpoint(parameters)
-      endpoint = parameters.endpoint
-
-      return Smithy::Client::EndpointRules::Endpoint.new(uri: endpoint) if Smithy::Client::EndpointRules.set?(endpoint)
+      return Smithy::Client::EndpointRules::Endpoint.new(uri: parameters.endpoint) if Smithy::Client::EndpointRules.set?(parameters.endpoint)
 
       raise ArgumentError, 'Endpoint is not set - you must configure an endpoint.'
     end


### PR DESCRIPTION
Uses `parameter.<param>` in code rather than assigns outside.