### PR TITLE
Retry errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
       - decaf
 
 env:
+  CI: true
   latest_ruby_version: 3.4
 
 jobs:

--- a/gems/smithy-client/lib/smithy-client.rb
+++ b/gems/smithy-client/lib/smithy-client.rb
@@ -22,12 +22,14 @@ require_relative 'smithy-client/param_converter'
 require_relative 'smithy-client/param_validator'
 require_relative 'smithy-client/plugin'
 require_relative 'smithy-client/plugin_list'
+require_relative 'smithy-client/retry'
 require_relative 'smithy-client/input'
 require_relative 'smithy-client/output'
 require_relative 'smithy-client/base'
 
 # client http
 
+require_relative 'smithy-client/http/error_inspector'
 require_relative 'smithy-client/http/headers'
 require_relative 'smithy-client/http/response'
 require_relative 'smithy-client/http/request'

--- a/gems/smithy-client/lib/smithy-client/handler_context.rb
+++ b/gems/smithy-client/lib/smithy-client/handler_context.rb
@@ -20,6 +20,7 @@ module Smithy
         @config = options[:config]
         @request = options[:request] || HTTP::Request.new
         @response = options[:response] || HTTP::Response.new
+        @retries = 0
         @metadata = {}
       end
 
@@ -43,6 +44,9 @@ module Smithy
 
       # @return [Response]
       attr_accessor :response
+
+      # @return [Integer]
+      attr_accessor :retries
 
       # @return [Hash]
       attr_reader :metadata

--- a/gems/smithy-client/lib/smithy-client/http/error_inspector.rb
+++ b/gems/smithy-client/lib/smithy-client/http/error_inspector.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'time'
+
+module Smithy
+  module Client
+    module HTTP
+      # An HTTP error inspector, using hints from status code and headers.
+      class ErrorInspector
+        def initialize(error, http_response)
+          @error = error
+          @http_response = http_response
+        end
+
+        def retryable?
+          (modeled_retryable? ||
+            throttling? ||
+            transient? ||
+            server?) &&
+            # IO does not respond to #truncate and is not rewindable
+            @http_response.body.respond_to?(:truncate)
+        end
+
+        def error_type
+          if transient?
+            'Transient'
+          elsif throttling?
+            'Throttling'
+          elsif server?
+            'ServerError'
+          elsif client?
+            'ClientError'
+          else
+            'Unknown'
+          end
+        end
+
+        def hints
+          hints = {}
+          if (retry_after = retry_after_hint)
+            hints[:retry_after] = retry_after
+          end
+          hints
+        end
+
+        private
+
+        def transient?
+          @error.is_a?(NetworkingError)
+        end
+
+        def throttling?
+          @http_response.status_code == 429 || modeled_throttling?
+        end
+
+        def server?
+          (500..599).cover?(@http_response.status_code)
+        end
+
+        def client?
+          (400..499).cover?(@http_response.status_code)
+        end
+
+        def modeled_retryable?
+          @error.is_a?(Errors::ServiceError) && @error.retryable?
+        end
+
+        def modeled_throttling?
+          modeled_retryable? && @error.throttling?
+        end
+
+        def retry_after_hint
+          retry_after = @http_response.headers['retry-after']
+          Integer(retry_after)
+        rescue ArgumentError # string is present, assume it is a date
+          begin
+            Time.parse(retry_after) - Time.now
+          rescue ArgumentError # empty string, somehow
+            nil
+          end
+        rescue TypeError # header is not present
+          nil
+        end
+      end
+    end
+  end
+end

--- a/gems/smithy-client/lib/smithy-client/plugins/net_http.rb
+++ b/gems/smithy-client/lib/smithy-client/plugins/net_http.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'smithy-client/net_http/handler'
+require_relative '../net_http/handler'
 
 module Smithy
   module Client
@@ -156,9 +156,7 @@ module Smithy
             A proxy to send requests through. Formatted like 'http://proxy.com:123'.
           DOCS
 
-        def add_handlers(handlers, _config)
-          handlers.add(Smithy::Client::NetHTTP::Handler, step: :send)
-        end
+        handler(Client::NetHTTP::Handler, step: :send)
       end
     end
   end

--- a/gems/smithy-client/lib/smithy-client/plugins/retry_errors.rb
+++ b/gems/smithy-client/lib/smithy-client/plugins/retry_errors.rb
@@ -15,7 +15,7 @@ module Smithy
           doc_type: 'String, Class',
           docstring: <<~DOCS)
             The retry strategy to use when retrying errors. This can be one of the following:
-            * `standard` - A standardized set of retry rules across the AWS SDKs. This includes support
+            * `standard` - A standardized retry strategy used by the AWS SDKs. This includes support
               for retry quotas, which limit the number of unsuccessful retries a client can make.
             * `adaptive` - An experimental retry strategy that includes all the functionality of the
               `standard` strategy along with automatic client side throttling. This is a provisional
@@ -38,6 +38,7 @@ module Smithy
         option(
           :retry_backoff,
           default: Retry::EXPONENTIAL_BACKOFF,
+          doc_default: 'Smithy::Client::Retry::EXPONENTIAL_BACKOFF',
           doc_type: 'lambda',
           docstring: <<~DOCS)
             A callable object that calculates a backoff delay for a retry attempt. The callable
@@ -50,9 +51,9 @@ module Smithy
           default: true,
           doc_type: 'Boolean',
           docstring: <<~DOCS)
-            When true, the request will sleep until there is sufficient client side capacity
-            to retry the request. When false, the request will raise `RetryCapacityNotAvailableError`
-            and will not retry instead of sleeping.
+            When true, the request will sleep until there is sufficient client side capacity to retry
+            the request. When false, the request will raise a `CapacityNotAvailableError` and will
+            not retry instead of sleeping.
           DOCS
 
         def after_initialize(client)

--- a/gems/smithy-client/lib/smithy-client/plugins/retry_errors.rb
+++ b/gems/smithy-client/lib/smithy-client/plugins/retry_errors.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'pathname'
+
+require_relative '../retry/handler'
+
+module Smithy
+  module Client
+    module Plugins
+      # @api private
+      class RetryErrors < Plugin
+        option(
+          :retry_strategy,
+          default: 'standard',
+          doc_type: 'String, Class',
+          docstring: <<~DOCS)
+            The retry strategy to use when retrying errors. This can be one of the following:
+            * `standard` - A standardized set of retry rules across the AWS SDKs. This includes support
+              for retry quotas, which limit the number of unsuccessful retries a client can make.
+            * `adaptive` - An experimental retry strategy that includes all the functionality of the
+              `standard` strategy along with automatic client side throttling. This is a provisional
+              strategy that may change behavior in the future.
+
+            In addition to these canned strategies, a custom retry strategy can be provided by passing
+            a class that implements the following methods:
+            * `acquire_initial_retry_token(token_scope)`
+            * `refresh_retry_token(retry_token, error_info)`
+            * `record_success(retry_token)`
+          DOCS
+
+        option(
+          :retry_max_attempts,
+          default: 3,
+          doc_type: Integer,
+          docstring: <<~DOCS)
+            The maximum number attempts that will be made for a single request, including
+            the initial attempt. Used in the `standard` and `adaptive` retry strategies.
+          DOCS
+
+        option(
+          :retry_backoff,
+          default: Retry::EXPONENTIAL_BACKOFF,
+          doc_type: 'lambda',
+          docstring: <<~DOCS)
+            A callable object that calculates a backoff delay for a retry attempt. The callable
+            should accept a single argument, `attempts`, that represents the number of attempts
+            that have been made. Used in the `standard` and `adaptive` retry strategies.
+          DOCS
+
+        option(
+          :adaptive_retry_wait_to_fill,
+          default: true,
+          doc_type: 'Boolean',
+          docstring: <<~DOCS)
+            When true, the request will sleep until there is sufficient client side capacity
+            to retry the request. When false, the request will raise `RetryCapacityNotAvailableError`
+            and will not retry instead of sleeping.
+          DOCS
+
+        def after_initialize(client)
+          config = client.config
+          config.retry_strategy =
+            case config.retry_strategy
+            when 'standard'
+              Retry::Standard.new(
+                max_attempts: config.retry_max_attempts,
+                backoff: config.retry_backoff
+              )
+            when 'adaptive'
+              Retry::Adaptive.new(
+                max_attempts: config.retry_max_attempts,
+                backoff: config.retry_backoff,
+                wait_to_fill: config.adaptive_retry_wait_to_fill
+              )
+            else
+              config.retry_strategy
+            end
+        end
+
+        handler(Client::Retry::Handler, step: :retry)
+      end
+    end
+  end
+end

--- a/gems/smithy-client/lib/smithy-client/plugins/retry_errors.rb
+++ b/gems/smithy-client/lib/smithy-client/plugins/retry_errors.rb
@@ -20,12 +20,10 @@ module Smithy
             * `adaptive` - An experimental retry strategy that includes all the functionality of the
               `standard` strategy along with automatic client side throttling. This is a provisional
               strategy that may change behavior in the future.
-
-            In addition to these canned strategies, a custom retry strategy can be provided by passing
-            a class that implements the following methods:
-            * `acquire_initial_retry_token(token_scope)`
-            * `refresh_retry_token(retry_token, error_info)`
-            * `record_success(retry_token)`
+            * Any instance of a class that implements the following methods:
+              - `acquire_initial_retry_token(token_scope)`
+              - `refresh_retry_token(retry_token, error_info)`
+              - `record_success(retry_token)`
           DOCS
 
         option(

--- a/gems/smithy-client/lib/smithy-client/plugins/stub_responses.rb
+++ b/gems/smithy-client/lib/smithy-client/plugins/stub_responses.rb
@@ -16,12 +16,15 @@ module Smithy
             @see Stubs
           DOCS
 
+        # @api private
         option(:stubber, default: Stubbing::Stubber)
-
+        # @api private
         option(:stubs) { {} }
+        # @api private
         option(:stubs_mutex) { Mutex.new }
-
+        # @api private
         option(:api_requests) { [] }
+        # @api private
         option(:api_requests_mutex) { Mutex.new }
 
         def add_handlers(handlers, config)

--- a/gems/smithy-client/lib/smithy-client/plugins/stub_responses.rb
+++ b/gems/smithy-client/lib/smithy-client/plugins/stub_responses.rb
@@ -40,6 +40,12 @@ module Smithy
           options[:endpoint_provider] ||= Stubbing::EndpointProvider.new
         end
 
+        def after_initialize(client)
+          return unless client.config.stub_responses
+
+          client.handlers.remove(Retry::Handler)
+        end
+
         # Returns a registered stubbed response instead of a real response.
         # @api private
         class StubHandler < Client::Handler

--- a/gems/smithy-client/lib/smithy-client/retry.rb
+++ b/gems/smithy-client/lib/smithy-client/retry.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative 'retry/adaptive'
+require_relative 'retry/client_rate_limiter'
+require_relative 'retry/quota'
+require_relative 'retry/standard'
+
+module Smithy
+  module Client
+    module Retry
+      # The maximum backoff delay for retrying requests.
+      MAX_BACKOFF = 20
+
+      # Raised when the adaptive retry strategy is unable to acquire capacity.
+      class CapacityNotAvailableError < RuntimeError; end
+
+      # The default backoff for retrying requests.
+      EXPONENTIAL_BACKOFF = lambda do |attempts|
+        [Kernel.rand * (2**attempts), MAX_BACKOFF].min || 0
+      end
+
+      # Represents a token that can be used to retry an operation.
+      class Token
+        def initialize(retry_count: 0, retry_delay: 0)
+          @retry_count = retry_count
+          @retry_delay = retry_delay
+        end
+
+        # The number of times the operation has been retried.
+        # @return [Integer]
+        attr_accessor :retry_count
+
+        # The delay before the next retry.
+        # @return [Numeric]
+        attr_accessor :retry_delay
+      end
+    end
+  end
+end

--- a/gems/smithy-client/lib/smithy-client/retry.rb
+++ b/gems/smithy-client/lib/smithy-client/retry.rb
@@ -11,9 +11,6 @@ module Smithy
       # The maximum backoff delay for retrying requests.
       MAX_BACKOFF = 20
 
-      # Raised when the adaptive retry strategy is unable to acquire capacity.
-      class CapacityNotAvailableError < RuntimeError; end
-
       # The default backoff for retrying requests.
       EXPONENTIAL_BACKOFF = lambda do |attempts|
         [Kernel.rand * (2**attempts), MAX_BACKOFF].min || 0
@@ -21,9 +18,9 @@ module Smithy
 
       # Represents a token that can be used to retry an operation.
       class Token
-        def initialize(retry_count: 0, retry_delay: 0)
-          @retry_count = retry_count
-          @retry_delay = retry_delay
+        def initialize
+          @retry_count = 0
+          @retry_delay = 0
         end
 
         # The number of times the operation has been retried.

--- a/gems/smithy-client/lib/smithy-client/retry/adaptive.rb
+++ b/gems/smithy-client/lib/smithy-client/retry/adaptive.rb
@@ -34,7 +34,7 @@ module Smithy
 
         def acquire_initial_retry_token(_token_scope = nil)
           @client_rate_limiter.token_bucket_acquire(1, wait_to_fill: @wait_to_fill)
-          Token.new(retry_count: 0)
+          Token.new
         end
 
         def refresh_retry_token(retry_token, error_info)

--- a/gems/smithy-client/lib/smithy-client/retry/adaptive.rb
+++ b/gems/smithy-client/lib/smithy-client/retry/adaptive.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Smithy
+  module Client
+    module Retry
+      # Adaptive retry strategy for retrying requests.
+      class Adaptive
+        # @option [#call] :backoff (EXPONENTIAL_BACKOFF) A callable object that
+        #  calculates a backoff delay for a retry attempt.
+        # @option [Integer] :max_attempts (3) The maximum number of attempts that
+        #  will be made for a single request, including the initial attempt.
+        # @option [Boolean] :wait_to_fill When true, the request will sleep until
+        #  there is sufficient client side capacity to retry the request. When
+        #  false, the request will raise a `CapacityNotAvailableError` and will
+        #  not retry instead of sleeping.
+        def initialize(options = {})
+          super()
+          @backoff = options[:backoff] || EXPONENTIAL_BACKOFF
+          @max_attempts = options[:max_attempts] || 3
+          @wait_to_fill = options[:wait_to_fill] || true
+          @client_rate_limiter = ClientRateLimiter.new
+          @quota = Quota.new
+          @capacity_amount = 0
+        end
+
+        # @return [#call]
+        attr_reader :backoff
+
+        # @return [Integer]
+        attr_reader :max_attempts
+
+        # @return [Boolean]
+        attr_reader :wait_to_fill
+
+        def acquire_initial_retry_token(_token_scope = nil)
+          @client_rate_limiter.token_bucket_acquire(1, wait_to_fill: @wait_to_fill)
+          Token.new(retry_count: 0)
+        end
+
+        def refresh_retry_token(retry_token, error_info)
+          return unless error_info.retryable?
+
+          @client_rate_limiter.update_sending_rate(
+            error_info.error_type == 'Throttling'
+          )
+          return if retry_token.retry_count >= @max_attempts - 1
+
+          @capacity_amount = @quota.checkout_capacity(error_info)
+          return unless @capacity_amount.positive?
+
+          delay = error_info.hints[:retry_after]
+          delay ||= @backoff.call(retry_token.retry_count)
+          retry_token.retry_count += 1
+          retry_token.retry_delay = delay
+          retry_token
+        end
+
+        def record_success(retry_token)
+          @client_rate_limiter.update_sending_rate(false)
+          @quota.release(@capacity_amount)
+          retry_token
+        end
+      end
+    end
+  end
+end

--- a/gems/smithy-client/lib/smithy-client/retry/client_rate_limiter.rb
+++ b/gems/smithy-client/lib/smithy-client/retry/client_rate_limiter.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+module Smithy
+  module Client
+    module Retry
+      # Used only in 'adaptive' retry mode
+      # @api private
+      class ClientRateLimiter
+        MIN_CAPACITY = 1
+        MIN_FILL_RATE = 0.5
+        SMOOTH = 0.8
+        # How much to scale back after a throttling response
+        BETA = 0.7
+        # Controls how aggressively we scale up after being throttled
+        SCALE_CONSTANT = 0.4
+
+        def initialize
+          @mutex = Mutex.new
+          @fill_rate = nil
+          @max_capacity = nil
+          @current_capacity = 0
+          @last_timestamp = nil
+          @enabled = false
+          @measured_tx_rate = 0
+          @last_tx_rate_bucket = monotonic_seconds
+          @request_count = 0
+          @last_max_rate = 0
+          @last_throttle_time = monotonic_seconds
+          @calculated_rate = nil
+        end
+
+        def token_bucket_acquire(amount, wait_to_fill: true)
+          # Client side throttling is not enabled until we see a
+          # throttling error
+          return unless @enabled
+
+          @mutex.synchronize do
+            token_bucket_refill
+
+            # Next see if we have enough capacity for the requested amount
+            while @current_capacity < amount
+              raise CapacityNotAvailableError unless wait_to_fill
+
+              @mutex.sleep((amount - @current_capacity) / @fill_rate)
+              token_bucket_refill
+            end
+            @current_capacity -= amount
+          end
+        end
+
+        def update_sending_rate(is_throttling_error)
+          @mutex.synchronize do
+            update_measured_rate
+
+            if is_throttling_error
+              # The fill_rate is from the token bucket
+              @last_max_rate = rate_to_use
+              calculate_time_window
+              @last_throttle_time = monotonic_seconds
+              @calculated_rate = cubic_throttle(rate_to_use)
+              @enabled = true
+            else
+              calculate_time_window
+              @calculated_rate = cubic_success(monotonic_seconds)
+            end
+
+            new_rate = [@calculated_rate, 2 * @measured_tx_rate].min
+            token_bucket_update_rate(new_rate)
+          end
+        end
+
+        private
+
+        def monotonic_seconds
+          Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        end
+
+        def token_bucket_refill
+          timestamp = monotonic_seconds
+          unless @last_timestamp
+            @last_timestamp = timestamp
+            return
+          end
+
+          fill_amount = (timestamp - @last_timestamp) * @fill_rate
+          @current_capacity = [@max_capacity, @current_capacity + fill_amount].min
+          @last_timestamp = timestamp
+        end
+
+        def token_bucket_update_rate(new_rps)
+          # Refill based on our current rate before we update to the
+          # new fill rate
+          token_bucket_refill
+          @fill_rate = [new_rps, MIN_FILL_RATE].max
+          @max_capacity = [new_rps, MIN_CAPACITY].max
+          # When we scale down we can't have a current capacity that exceeds our
+          # max_capacity.
+          @current_capacity = [@current_capacity, @max_capacity].min
+        end
+
+        def update_measured_rate
+          t = monotonic_seconds
+          time_bucket = (t * 2).floor / 2.0
+          @request_count += 1
+          return unless time_bucket > @last_tx_rate_bucket
+
+          current_rate = @request_count / (time_bucket - @last_tx_rate_bucket)
+          @measured_tx_rate = (current_rate * SMOOTH) + (@measured_tx_rate * (1 - SMOOTH))
+          @request_count = 0
+          @last_tx_rate_bucket = time_bucket
+        end
+
+        def calculate_time_window
+          # This is broken out into a separate calculation because it only
+          # gets updated when @last_max_rate changes so it can be cached.
+          base = ((@last_max_rate * (1 - BETA)) / SCALE_CONSTANT)
+          @time_window = base**(1.0 / 3)
+        end
+
+        def cubic_success(timestamp)
+          dt = timestamp - @last_throttle_time
+          (SCALE_CONSTANT * ((dt - @time_window)**3)) + @last_max_rate
+        end
+
+        def cubic_throttle(rate_to_use)
+          rate_to_use * BETA
+        end
+
+        def rate_to_use
+          if @enabled
+            [@measured_tx_rate, @fill_rate].min
+          else
+            @measured_tx_rate
+          end
+        end
+      end
+    end
+  end
+end

--- a/gems/smithy-client/lib/smithy-client/retry/client_rate_limiter.rb
+++ b/gems/smithy-client/lib/smithy-client/retry/client_rate_limiter.rb
@@ -3,6 +3,9 @@
 module Smithy
   module Client
     module Retry
+      # Raised when the adaptive retry strategy is unable to acquire capacity.
+      class CapacityNotAvailableError < RuntimeError; end
+
       # Used only in 'adaptive' retry mode
       # @api private
       class ClientRateLimiter

--- a/gems/smithy-client/lib/smithy-client/retry/handler.rb
+++ b/gems/smithy-client/lib/smithy-client/retry/handler.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'pathname'
+
+module Smithy
+  module Client
+    module Retry
+      # @api private
+      class Handler < Client::Handler
+        def call(context)
+          retry_strategy = context.config.retry_strategy
+          token = retry_strategy.acquire_initial_retry_token(nil)
+          handle(context, retry_strategy, token)
+        end
+
+        private
+
+        def handle(context, retry_strategy, token)
+          output = @handler.call(context)
+          if (error = output.error)
+            return output unless retryable?(context.request)
+
+            error_info = HTTP::ErrorInspector.new(error, context.response)
+            token = retry_strategy.refresh_retry_token(token, error_info)
+            return output unless token
+
+            Kernel.sleep(token.retry_delay)
+          else
+            retry_strategy.record_success(token)
+            return output
+          end
+
+          reset_request(context)
+          reset_response(context, output)
+          context.retries += 1
+          handle(context, retry_strategy, token)
+        end
+
+        def retryable?(request)
+          # IO responds to #rewind however it returns an illegal seek error
+          request.body.respond_to?(:rewind) && !request.body.instance_of?(IO)
+        end
+
+        def reset_request(context)
+          request = context.request
+          request.body.rewind
+        end
+
+        def reset_response(context, output)
+          context.response.reset
+          output.error = nil
+        end
+      end
+    end
+  end
+end

--- a/gems/smithy-client/lib/smithy-client/retry/quota.rb
+++ b/gems/smithy-client/lib/smithy-client/retry/quota.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module Smithy
+  module Client
+    module Retry
+      # @api private
+      # Used in 'standard' and 'adaptive' retry modes.
+      class Quota
+        INITIAL_RETRY_TOKENS = 500
+        RETRY_COST = 5
+        NO_RETRY_INCREMENT = 1
+        TIMEOUT_RETRY_COST = 10
+
+        def initialize
+          @mutex = Mutex.new
+          @max_capacity = INITIAL_RETRY_TOKENS
+          @available_capacity = @max_capacity
+        end
+
+        # Check if there is sufficient capacity to retry and return it.
+        # If there is insufficient capacity, return 0
+        # @return [Integer] The amount of capacity checked out
+        def checkout_capacity(error_info)
+          @mutex.synchronize do
+            capacity_amount =
+              if error_info.error_type == 'Transient'
+                TIMEOUT_RETRY_COST
+              else
+                RETRY_COST
+              end
+
+            # unable to acquire capacity
+            return 0 if capacity_amount > @available_capacity
+
+            @available_capacity -= capacity_amount
+            capacity_amount
+          end
+        end
+
+        # capacity_amount refers to the amount of capacity requested from
+        # the last retry.  It can either be RETRY_COST, TIMEOUT_RETRY_COST,
+        # or unset.
+        def release(capacity_amount)
+          # Implementation note:  The release() method is called for
+          # every API call.  In the common case where the request is
+          # successful and we're at full capacity, we can avoid locking.
+          # We can't exceed max capacity so there's no work we have to do.
+          return if @available_capacity == @max_capacity
+
+          @mutex.synchronize do
+            @available_capacity += capacity_amount || NO_RETRY_INCREMENT
+            @available_capacity = [@available_capacity, @max_capacity].min
+          end
+        end
+      end
+    end
+  end
+end

--- a/gems/smithy-client/lib/smithy-client/retry/standard.rb
+++ b/gems/smithy-client/lib/smithy-client/retry/standard.rb
@@ -24,7 +24,7 @@ module Smithy
         attr_reader :max_attempts
 
         def acquire_initial_retry_token(_token_scope = nil)
-          Token.new(retry_count: 0)
+          Token.new
         end
 
         def refresh_retry_token(retry_token, error_info)

--- a/gems/smithy-client/lib/smithy-client/retry/standard.rb
+++ b/gems/smithy-client/lib/smithy-client/retry/standard.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Smithy
+  module Client
+    module Retry
+      # Standard retry strategy for retrying requests.
+      class Standard
+        # @option [#call] :backoff (EXPONENTIAL_BACKOFF) A callable object that
+        #  calculates a backoff delay for a retry attempt.
+        # @option [Integer] :max_attempts (3) The maximum number of attempts that
+        #  will be made for a single request, including the initial attempt.
+        def initialize(options = {})
+          super()
+          @backoff = options[:backoff] || EXPONENTIAL_BACKOFF
+          @max_attempts = options[:max_attempts] || 3
+          @quota = Quota.new
+          @capacity_amount = 0
+        end
+
+        # @return [#call]
+        attr_reader :backoff
+
+        # @return [Integer]
+        attr_reader :max_attempts
+
+        def acquire_initial_retry_token(_token_scope = nil)
+          Token.new(retry_count: 0)
+        end
+
+        def refresh_retry_token(retry_token, error_info)
+          return unless error_info.retryable?
+
+          return if retry_token.retry_count >= @max_attempts - 1
+
+          @capacity_amount = @quota.checkout_capacity(error_info)
+          return unless @capacity_amount.positive?
+
+          delay = error_info.hints[:retry_after]
+          delay ||= @backoff.call(retry_token.retry_count)
+          retry_token.retry_count += 1
+          retry_token.retry_delay = delay
+          retry_token
+        end
+
+        def record_success(retry_token)
+          @quota.release(@capacity_amount)
+          retry_token
+        end
+      end
+    end
+  end
+end

--- a/gems/smithy-client/lib/smithy-client/stubbing/stubber.rb
+++ b/gems/smithy-client/lib/smithy-client/stubbing/stubber.rb
@@ -9,7 +9,7 @@ module Smithy
         def self.stub_data(_operation, data)
           resp = HTTP::Response.new
           resp.status_code = 200
-          resp.body = StringIO.new(data)
+          resp.body = StringIO.new(data.to_json)
           resp
         end
 

--- a/gems/smithy-client/lib/smithy-client/stubbing/stubber.rb
+++ b/gems/smithy-client/lib/smithy-client/stubbing/stubber.rb
@@ -6,19 +6,17 @@ module Smithy
       # Default stubber when stubbing is configured.
       # @api private
       module Stubber
-        def self.stub_data(_operation, _data)
+        def self.stub_data(_operation, data)
           resp = HTTP::Response.new
           resp.status_code = 200
-          resp.headers['Stubbed-Header'] = 'stubbed-header-value'
-          resp.body = StringIO.new('stubbed-data')
+          resp.body = StringIO.new(data)
           resp
         end
 
-        def self.stub_error(_error_code)
+        def self.stub_error(error_code)
           resp = HTTP::Response.new
           resp.status_code = 500
-          resp.headers['Stubbed-Header'] = 'stubbed-header-value'
-          resp.body = StringIO.new('stubbed-error-body')
+          resp.body = StringIO.new(error_code)
           resp
         end
       end

--- a/gems/smithy-client/sig/smithy-client/handler_context.rbs
+++ b/gems/smithy-client/sig/smithy-client/handler_context.rbs
@@ -9,6 +9,7 @@ module Smithy
       attr_accessor config: Struct[untyped]?
       attr_accessor request: HTTP::Request | untyped
       attr_accessor response: HTTP::Response | untyped
+      attr_accessor retries: Integer
       attr_reader metadata: Hash[untyped, untyped]
       def []: (untyped) -> untyped
       def []=: (untyped, untyped) -> untyped

--- a/gems/smithy-client/spec/smithy-client/handler_context_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/handler_context_spec.rb
@@ -90,6 +90,12 @@ module Smithy
         end
       end
 
+      describe '#retries' do
+        it 'defaults to 0' do
+          expect(subject.retries).to eq(0)
+        end
+      end
+
       context 'metadata' do
         it 'returns nil for non-set keys' do
           expect(subject[:color]).to be(nil)

--- a/gems/smithy-client/spec/smithy-client/handler_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/handler_spec.rb
@@ -5,7 +5,7 @@ require_relative '../spec_helper'
 module Smithy
   module Client
     describe Handler do
-      let(:context) { double('RequestContext') }
+      let(:context) { double('HandlerContext') }
       let(:response) { double('Response') }
       let(:handler) { double('Handler', call: response) }
 

--- a/gems/smithy-client/spec/smithy-client/http/error_inspector_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/http/error_inspector_spec.rb
@@ -138,7 +138,7 @@ module Smithy
 
             context 'header is nil' do
               it 'no hint' do
-                http_response.headers['retry-after'] = nil
+                http_response.headers.delete('retry-after')
                 expect(subject.hints.key?(:retry_after)).to eq(false)
               end
             end

--- a/gems/smithy-client/spec/smithy-client/http/error_inspector_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/http/error_inspector_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+module Smithy
+  module Client
+    module HTTP
+      describe ErrorInspector do
+        let(:error) do
+          Errors::ServiceError.new(HandlerContext.new, 'error', {})
+        end
+        let(:status_code) { 404 }
+        let(:http_response) { HTTP::Response.new(status_code: status_code) }
+
+        subject { ErrorInspector.new(error, http_response) }
+
+        describe '#retryable?' do
+          it 'does not retry basic errors' do
+            expect(subject.retryable?).to be false
+          end
+
+          context 'error is a server error' do
+            let(:status_code) { 500 }
+
+            it 'returns true' do
+              expect(subject.retryable?).to be true
+            end
+          end
+
+          context 'error is modeled as retryable' do
+            before { allow(error).to receive(:retryable?).and_return(true) }
+
+            it 'returns true' do
+              expect(subject.retryable?).to be true
+            end
+          end
+
+          context 'error has 429 status code' do
+            let(:status_code) { 429 }
+
+            it 'returns true' do
+              expect(subject.retryable?).to be true
+            end
+          end
+
+          context 'error is modeled as throttling' do
+            before do
+              allow(error).to receive(:retryable?).and_return(true)
+              allow(error).to receive(:throttling?).and_return(true)
+            end
+
+            it 'returns true' do
+              expect(subject.retryable?).to be true
+            end
+          end
+
+          context 'error is transient' do
+            let(:error) { NetworkingError.new(StandardError.new) }
+
+            it 'returns true' do
+              expect(subject.retryable?).to be true
+            end
+          end
+        end
+
+        describe '#error_type' do
+          context 'transient error' do
+            let(:error) { NetworkingError.new(StandardError.new) }
+
+            it 'returns Transient' do
+              expect(subject.error_type).to eq 'Transient'
+            end
+          end
+
+          context 'throttling error' do
+            context 'error has 429 status code' do
+              let(:status_code) { 429 }
+
+              it 'returns Throttling' do
+                expect(subject.error_type).to eq 'Throttling'
+              end
+            end
+
+            context 'error is modeled as throttling' do
+              before do
+                allow(error).to receive(:retryable?).and_return(true)
+                allow(error).to receive(:throttling?).and_return(true)
+              end
+
+              it 'returns Throttling' do
+                expect(subject.error_type).to eq 'Throttling'
+              end
+            end
+          end
+
+          context 'server error' do
+            let(:status_code) { 500 }
+
+            it 'returns ServerError' do
+              expect(subject.error_type).to eq 'ServerError'
+            end
+          end
+
+          context 'client error' do
+            let(:status_code) { 404 }
+
+            it 'returns ServerError' do
+              expect(subject.error_type).to eq 'ClientError'
+            end
+          end
+
+          context 'unknown type error' do
+            let(:status_code) { 307 }
+
+            it 'returns ServerError' do
+              expect(subject.error_type).to eq 'Unknown'
+            end
+          end
+        end
+
+        describe '#hints' do
+          context 'retry_after_hint' do
+            context 'header is an integer' do
+              it 'hint returns an integer delay' do
+                http_response.headers['retry-after'] = '123'
+                expect(subject.hints[:retry_after]).to eq(123)
+              end
+            end
+
+            context 'header is a date' do
+              let(:time) { Time.new(2023, 1, 24) }
+              let(:retry_after_time) { (time + 123).httpdate }
+
+              it 'hint returns an integer delay' do
+                http_response.headers['retry-after'] = retry_after_time
+                allow(Time).to receive(:now).and_return(time)
+                expect(subject.hints[:retry_after]).to eq(123)
+              end
+            end
+
+            context 'header is nil' do
+              it 'no hint' do
+                http_response.headers['retry-after'] = nil
+                expect(subject.hints.key?(:retry_after)).to eq(false)
+              end
+            end
+
+            context 'header is an empty string' do
+              it 'no hint' do
+                http_response.headers['retry-after'] = ''
+                expect(subject.hints.key?(:retry_after)).to eq(false)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/gems/smithy-client/spec/smithy-client/plugins/retry_errors_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/retry_errors_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+
+require 'smithy-client/plugins/retry_errors'
+
+module Smithy
+  module Client
+    module Plugins
+      describe RetryErrors do
+        let(:sample_service) { ClientHelper.sample_service }
+        let(:client_class) { sample_service.const_get(:Client) }
+        let(:client) { client_class.new(stub_responses: true) }
+
+        it 'adds a :retry_strategy option to config' do
+          expect(client.config).to respond_to(:retry_strategy)
+        end
+
+        it 'adds a :retry_max_attempts option to config' do
+          expect(client.config).to respond_to(:retry_max_attempts)
+        end
+
+        it 'adds a :retry_backoff option to config' do
+          expect(client.config).to respond_to(:retry_backoff)
+        end
+
+        it 'adds an :adaptive_retry_wait_to_fill option to config' do
+          expect(client.config).to respond_to(:adaptive_retry_wait_to_fill)
+        end
+
+        it 'creates a Standard retry strategy from a string' do
+          client = client_class.new(retry_strategy: 'standard')
+          expect(client.config.retry_strategy).to be_a(Retry::Standard)
+        end
+
+        it 'creates an Adaptive retry strategy from a string' do
+          client = client_class.new(retry_strategy: 'adaptive')
+          expect(client.config.retry_strategy).to be_a(Retry::Adaptive)
+        end
+
+        it 'uses a custom retry strategy' do
+          retry_strategy = double('CustomRetryStrategy')
+          client = client_class.new(retry_strategy: retry_strategy)
+          expect(client.config.retry_strategy).to be(retry_strategy)
+        end
+
+        it 'passes flat options to the standard retry strategy class' do
+          client = client_class.new(
+            retry_strategy: 'standard',
+            retry_max_attempts: 5,
+            retry_backoff: 2
+          )
+          expect(client.config.retry_max_attempts).to eq(5)
+          expect(client.config.retry_backoff).to eq(2)
+          retry_strategy = client.config.retry_strategy
+          expect(retry_strategy.max_attempts).to eq(5)
+          expect(retry_strategy.backoff).to eq(2)
+        end
+
+        it 'passes flat options to the adaptive retry strategy class' do
+          client = client_class.new(
+            retry_strategy: 'adaptive',
+            retry_max_attempts: 5,
+            retry_backoff: 2,
+            adaptive_retry_wait_to_fill: 5
+          )
+          expect(client.config.retry_max_attempts).to eq(5)
+          expect(client.config.retry_backoff).to eq(2)
+          expect(client.config.adaptive_retry_wait_to_fill).to eq(5)
+          retry_strategy = client.config.retry_strategy
+          expect(retry_strategy.max_attempts).to eq(5)
+          expect(retry_strategy.backoff).to eq(2)
+          expect(retry_strategy.wait_to_fill).to eq(5)
+        end
+
+        it 'adds the handler' do
+          expect(client.handlers).to include(Retry::Handler)
+        end
+      end
+    end
+  end
+end

--- a/gems/smithy-client/spec/smithy-client/plugins/retry_errors_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/retry_errors_spec.rb
@@ -10,7 +10,7 @@ module Smithy
       describe RetryErrors do
         let(:sample_service) { ClientHelper.sample_service }
         let(:client_class) { sample_service.const_get(:Client) }
-        let(:client) { client_class.new(stub_responses: true) }
+        let(:client) { client_class.new }
 
         it 'adds a :retry_strategy option to config' do
           expect(client.config).to respond_to(:retry_strategy)
@@ -75,6 +75,11 @@ module Smithy
 
         it 'adds the handler' do
           expect(client.handlers).to include(Retry::Handler)
+        end
+
+        it 'does not add the handler if :stub_responses is enabled' do
+          client = client_class.new(stub_responses: true)
+          expect(client.handlers).not_to include(Retry::Handler)
         end
       end
     end

--- a/gems/smithy-client/spec/smithy-client/retry/client_rate_limiter_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/retry/client_rate_limiter_spec.rb
@@ -1,0 +1,220 @@
+# frozen_string_literal: true
+
+module Smithy
+  module Client
+    module Retry
+      describe ClientRateLimiter do
+        let(:mutex) { subject.instance_variable_get(:@mutex) }
+
+        ######
+        # Cubic Calculator tests
+        #  Inspired by: https://github.com/jamesls/botocore/blob/f6bec32a13d6b45d29dc054726edd3c1cdf99b26/tests/unit/retries/test_throttling.py
+        it 'sets the time window correctly from max rate' do
+          subject.instance_variable_set(:@last_max_rate, 10)
+          subject.send(:calculate_time_window)
+          expect(subject.instance_variable_get(:@time_window))
+            .to be_within(0.1).of(1.9)
+        end
+
+        it 'decreases rate by beta when throttled' do
+          rate_when_throttled = 8
+          new_rate = subject.send(
+            :cubic_throttle, rate_when_throttled
+          )
+          expect(new_rate).to eq(rate_when_throttled * 0.7)
+        end
+
+        it 'should match beta decrease' do
+          stub_const('Smithy::Client::Retry::ClientRateLimiter::BETA', 0.6)
+          subject.instance_variable_set(:@last_max_rate, 10)
+
+          new_rate = subject.send(:cubic_throttle, 10)
+          subject.instance_variable_set(:@last_throttle_time, 1)
+          subject.send(:calculate_time_window)
+          expect(new_rate).to eq(6.0)
+
+          new_rate = subject.send(:cubic_success, 1)
+          expect(new_rate).to be_within(0.1).of(6.0)
+        end
+
+        #######
+        # Rate Clocker tests
+        # Inspired by: https://github.com/jamesls/botocore/blob/f6bec32a13d6b45d29dc054726edd3c1cdf99b26/tests/unit/retries/test_adaptive.py#L91
+        it 'updates rate if after bucket range' do
+          subject.instance_variable_set(:@last_tx_rate_bucket, 0)
+          allow(Process).to receive(:clock_gettime)
+            .with(Process::CLOCK_MONOTONIC).and_return(1)
+
+          subject.send(:update_measured_rate)
+          # This should be 1 * 0.8 + 0 * 0.2, or just 0.8
+          expect(subject.instance_variable_get(:@measured_tx_rate))
+            .to be_within(0.1).of(0.8)
+        end
+
+        it 'can measure a constant rate' do
+          subject.instance_variable_set(:@last_tx_rate_bucket, 0)
+
+          # send a constant 2 TPS
+          (1..8).each do |t|
+            allow(Process).to receive(:clock_gettime)
+              .with(Process::CLOCK_MONOTONIC).and_return(t / 2.0)
+            subject.send(:update_measured_rate)
+          end
+
+          expect(subject.instance_variable_get(:@measured_tx_rate))
+            .to be_within(0.1).of(2.0)
+
+          # if we now wait 10 seconds (0.1 TPS)
+          # our rate is somewhere between 2 TPS and 0.1 TPS
+          allow(Process).to receive(:clock_gettime)
+            .with(Process::CLOCK_MONOTONIC).and_return(14)
+          subject.send(:update_measured_rate)
+          rate = subject.instance_variable_get(:@measured_tx_rate)
+          expect(rate).to be_between(0.1, 2)
+        end
+
+        #######
+        # Token Bucket Tests
+        # Inspired by: https://github.com/jamesls/botocore/blob/f6bec32a13d6b45d29dc054726edd3c1cdf99b26/tests/unit/retries/test_bucket.py
+        it 'can acquire amount' do
+          subject.instance_variable_set(:@enabled, true)
+          allow(Process).to receive(:clock_gettime)
+            .with(Process::CLOCK_MONOTONIC).and_return(0)
+          subject.send(:token_bucket_update_rate, 10)
+
+          # Request tokens every second which is well below max 10 TPS fill rate
+          expect(mutex).not_to receive(:sleep)
+          (1..5).each do |t|
+            allow(Process).to receive(:clock_gettime)
+              .with(Process::CLOCK_MONOTONIC).and_return(t)
+            subject.token_bucket_acquire(1)
+          end
+        end
+
+        it 'waits until capacity is available to acquire a token' do
+          subject.instance_variable_set(:@enabled, true)
+          allow(Process).to receive(:clock_gettime)
+            .with(Process::CLOCK_MONOTONIC).and_return(0)
+          subject.send(:token_bucket_update_rate, 10)
+          subject.instance_variable_set(:@max_capacity, 100)
+
+          expect(mutex).to receive(:sleep).with(10) # 100 / fill_rate = 10
+          allow(Process).to receive(:clock_gettime)
+            .with(Process::CLOCK_MONOTONIC).and_return(0, 10)
+          subject.token_bucket_acquire(100, wait_to_fill: true)
+        end
+
+        it 'raises CapacityNotAvailableError when it fails to acquire a token' do
+          subject.instance_variable_set(:@enabled, true)
+          allow(Process).to receive(:clock_gettime)
+            .with(Process::CLOCK_MONOTONIC).and_return(0)
+          subject.send(:token_bucket_update_rate, 10)
+
+          expect { subject.token_bucket_acquire(100, wait_to_fill: false) }
+            .to raise_error(CapacityNotAvailableError)
+        end
+
+        it 'can retrieve at max send rate' do
+          subject.instance_variable_set(:@enabled, true)
+          allow(Process).to receive(:clock_gettime)
+            .with(Process::CLOCK_MONOTONIC).and_return(0)
+          subject.send(:token_bucket_update_rate, 10)
+
+          # Request a new token every 100ms (10 TPS) for 2 seconds.
+          expect(mutex).not_to receive(:sleep)
+          20.times do |t|
+            allow(Process).to receive(:clock_gettime)
+              .with(Process::CLOCK_MONOTONIC).and_return(1 + (0.1 * t))
+            subject.token_bucket_acquire(1)
+          end
+        end
+
+        it 'wont set rate below the min fill rate' do
+          subject.instance_variable_set(:@enabled, true)
+          subject.send(:token_bucket_update_rate, 0.1)
+
+          expect(subject.instance_variable_get(:@fill_rate))
+            .to eq(Retry::ClientRateLimiter::MIN_FILL_RATE)
+        end
+
+        it 'acquires a token only when enabled' do
+          subject.instance_variable_set(:@enabled, false)
+          expect(mutex).not_to receive(:sleep)
+          subject.token_bucket_acquire(1)
+        end
+
+        it 'enables the token bucket on throttling errors' do
+          subject.update_sending_rate(true)
+          expect(subject.instance_variable_get(:@enabled)).to be(true)
+        end
+
+        context 'thread safety', slow: true do
+          it 'can change max rate while blocking' do
+            # This isn't a stress test - we just verify we can change the
+            # rate while we acquire a token
+            subject.instance_variable_set(:@enabled, true)
+            # Set a rate to 0.5 (the min rate).  This means it will take
+            # 2 seconds to acquire a single token
+            subject.send(:token_bucket_update_rate, 0.5)
+
+            # Start a thread to acquire a token
+            test_thread = Thread.new do
+              subject.token_bucket_acquire(1)
+            end
+
+            # ensure the new thread has a chance to start
+            sleep(0.1)
+
+            # Now in the main thread, update the rate to something really quick.
+            # This should let us get a token back very quickly (~0.01 seconds)
+            mutex.synchronize do
+              subject.send(:token_bucket_update_rate, 100)
+            end
+            start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+            subject.token_bucket_acquire(1)
+            main_thread_time =
+              Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+
+            test_thread.join # wait for the first thread to finish
+            test_thread_time =
+              Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+
+            expect(main_thread_time).to be < 0.1
+            expect(test_thread_time).to be > 1.0
+          end
+
+          it 'doesnt starve any threads during a stress test' do
+            subject.instance_variable_set(:@enabled, true)
+            subject.send(:token_bucket_update_rate, 500)
+
+            shutdown_threads = false
+            threads = []
+            n_test_threads = 5
+            acquisitions = Array.new(n_test_threads, 0)
+
+            n_test_threads.times do |i|
+              threads << Thread.new do
+                until shutdown_threads
+                  subject.token_bucket_acquire(1)
+                  acquisitions[i] += 1
+                end
+              end
+            end
+
+            # Increase this to stress test more locally
+            sleep(1)
+            shutdown_threads = true
+            threads.each(&:join)
+
+            # We can't really rely on any guarantees about evenly distributing
+            # thread acquisitions. But we can sanity check that our implementation
+            # isn't drastically starving a thread.
+            # Check that no thread has at least one acquisition
+            mean = acquisitions.reduce(:+).to_f / acquisitions.size
+            expect(acquisitions.all? { |x| x > 0.1 * mean }).to be true
+          end
+        end
+      end
+    end
+  end
+end

--- a/gems/smithy-client/spec/smithy-client/retry/handler_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/retry/handler_spec.rb
@@ -1,0 +1,312 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+require_relative '../../support/retry_errors_helper'
+
+require 'smithy-client/plugins/retry_errors'
+
+module Smithy
+  module Client
+    module Retry
+      describe Handler do
+        let(:config) do
+          config = Smithy::Client::Configuration.new
+          config.add_option(:service)
+          Plugins::RetryErrors.new.add_options(config)
+          config.build!
+        end
+
+        let(:output) { Output.new(context: HandlerContext.new(config: config)) }
+        let(:service_error) { Errors::ServiceError.new(nil, nil, nil) }
+
+        let(:retry_strategy) { config.retry_strategy }
+        let(:quota) { retry_strategy.instance_variable_get(:@quota) }
+        let(:client_rate_limiter) { retry_strategy.instance_variable_get(:@client_rate_limiter) }
+
+        subject { Retry::Handler.new }
+
+        context 'standard mode' do
+          before(:each) do
+            config.retry_strategy = Retry::Standard.new
+            allow(Kernel).to receive(:rand).and_return(1)
+          end
+
+          it 'retry eventually succeeds' do
+            test_case_def = [
+              {
+                response: { status_code: 500, error: service_error },
+                expect: { available_capacity: 495, retries: 1, delay: 1 }
+              },
+              {
+                response: { status_code: 500, error: service_error },
+                expect: { available_capacity: 490, retries: 2, delay: 2 }
+              },
+              {
+                response: { status_code: 200, error: nil },
+                expect: { available_capacity: 495, retries: 2 }
+              } # success
+            ]
+
+            handle_with_retry(test_case_def)
+          end
+
+          it 'fails due to max attempts reached' do
+            test_case_def = [
+              {
+                response: { status_code: 500, error: service_error },
+                expect: { available_capacity: 495, retries: 1, delay: 1 }
+              },
+              {
+                response: { status_code: 500, error: service_error },
+                expect: { available_capacity: 490, retries: 2, delay: 2 }
+              },
+              {
+                response: { status_code: 500, error: service_error },
+                expect: { available_capacity: 490, retries: 2 }
+              } # failure
+            ]
+
+            handle_with_retry(test_case_def)
+          end
+
+          it 'fails due to retry quota reached after a single retry' do
+            quota.instance_variable_set(:@available_capacity, 5)
+
+            test_case_def = [
+              {
+                response: { status_code: 500, error: service_error },
+                expect: { available_capacity: 0, retries: 1, delay: 1 }
+              },
+              {
+                response: { status_code: 500, error: service_error },
+                expect: { available_capacity: 0, retries: 1 }
+              }
+            ]
+
+            handle_with_retry(test_case_def)
+          end
+
+          it 'does not retry if the retry quota is 0' do
+            quota.instance_variable_set(:@available_capacity, 0)
+
+            test_case_def = [
+              {
+                response: { status_code: 500, error: service_error },
+                expect: { available_capacity: 0, retries: 0 }
+              }
+            ]
+
+            handle_with_retry(test_case_def)
+          end
+
+          it 'uses exponential backoff timing' do
+            retry_strategy.instance_variable_set(:@max_attempts, 5)
+
+            test_case_def = [
+              {
+                response: { status_code: 500, error: service_error },
+                expect: { available_capacity: 495, retries: 1, delay: 1 }
+              },
+              {
+                response: { status_code: 500, error: service_error },
+                expect: { available_capacity: 490, retries: 2, delay: 2 }
+              },
+              {
+                response: { status_code: 500, error: service_error },
+                expect: { available_capacity: 485, retries: 3, delay: 4 }
+              },
+              {
+                response: { status_code: 500, error: service_error },
+                expect: { available_capacity: 480, retries: 4, delay: 8 }
+              },
+              {
+                response: { status_code: 500, error: service_error },
+                expect: { available_capacity: 480, retries: 4 }
+              }
+            ]
+
+            handle_with_retry(test_case_def)
+          end
+
+          it 'does not exceed the max backoff time' do
+            retry_strategy.instance_variable_set(:@max_attempts, 5)
+            stub_const('Smithy::Client::Retry::MAX_BACKOFF', 3)
+
+            test_case_def = [
+              {
+                response: { status_code: 500, error: service_error },
+                expect: { available_capacity: 495, retries: 1, delay: 1 }
+              },
+              {
+                response: { status_code: 500, error: service_error },
+                expect: { available_capacity: 490, retries: 2, delay: 2 }
+              },
+              {
+                response: { status_code: 500, error: service_error },
+                expect: { available_capacity: 485, retries: 3, delay: 3 }
+              },
+              {
+                response: { status_code: 500, error: service_error },
+                expect: { available_capacity: 480, retries: 4, delay: 3 }
+              },
+              {
+                response: { status_code: 500, error: service_error },
+                expect: { available_capacity: 480, retries: 4 }
+              }
+            ]
+
+            handle_with_retry(test_case_def)
+          end
+
+          it 'fails due to retry quota bucket exhaustion' do
+            config.retry_max_attempts = 5
+            quota.instance_variable_set(:@available_capacity, 10)
+
+            test_case_def = [
+              {
+                response: { status_code: 500, error: service_error },
+                expect: { available_capacity: 5, retries: 1, delay: 1 }
+              },
+              {
+                response: { status_code: 502, error: service_error },
+                expect: { available_capacity: 0, retries: 2, delay: 2 }
+              },
+              {
+                response: { status_code: 503, error: service_error },
+                expect: { available_capacity: 0, retries: 2 }
+              }
+            ]
+
+            handle_with_retry(test_case_def)
+          end
+
+          it 'recovers after successful responses' do
+            config.retry_max_attempts = 5
+            quota.instance_variable_set(:@available_capacity, 15)
+
+            test_case_def = [
+              {
+                response: { status_code: 500, error: service_error },
+                expect: { available_capacity: 10, retries: 1, delay: 1 }
+              },
+              {
+                response: { status_code: 502, error: service_error },
+                expect: { available_capacity: 5, retries: 2, delay: 2 }
+              },
+              {
+                response: { status_code: 200, error: nil },
+                expect: { available_capacity: 10, retries: 2 }
+              }
+            ]
+            handle_with_retry(test_case_def)
+
+            test_case_post_success = [
+              {
+                response: { status_code: 500, error: service_error },
+                expect: { available_capacity: 5, retries: 1, delay: 1 }
+              },
+              {
+                response: { status_code: 200, error: nil },
+                expect: { available_capacity: 10, retries: 1 }
+              }
+            ]
+            reset_request
+            handle_with_retry(test_case_post_success)
+          end
+        end
+
+        context 'adaptive mode' do
+          before(:each) do
+            config.retry_strategy = Retry::Adaptive.new
+            client_rate_limiter.instance_variable_set(:@last_throttle_time, 5)
+            # Needs to be smaller than 't' in the iterations
+            client_rate_limiter.instance_variable_set(:@last_tx_rate_bucket, 4.5)
+            client_rate_limiter.instance_variable_set(:@last_max_rate, 10)
+          end
+
+          it 'verifies cubic calculations for successes' do
+            successes = [
+              {
+                response: { status_code: 200, error: nil, timestamp: 5 },
+                expect: { calculated_rate: 7.0 }
+              },
+              {
+                response: { status_code: 200, error: nil, timestamp: 6 },
+                expect: { calculated_rate: 9.6 }
+              },
+              {
+                response: { status_code: 200, error: nil, timestamp: 7 },
+                expect: { calculated_rate: 10.0 }
+              },
+              {
+                response: { status_code: 200, error: nil, timestamp: 8 },
+                expect: { calculated_rate: 10.45 }
+              },
+              {
+                response: { status_code: 200, error: nil, timestamp: 9 },
+                expect: { calculated_rate: 13.4 }
+              },
+              {
+                response: { status_code: 200, error: nil, timestamp: 10 },
+                expect: { calculated_rate: 21.2 }
+              },
+              {
+                response: { status_code: 200, error: nil, timestamp: 11 },
+                expect: { calculated_rate: 36.4 }
+              }
+            ]
+
+            # Have to run the method each time because there are no failures
+            successes.each { |success| handle_with_retry([success]) }
+          end
+
+          it 'verifies success and throttling behavior' do
+            client_rate_limiter.instance_variable_set(:@last_throttle_time, 0)
+            # Needs to be smaller than 't' in the iterations
+            client_rate_limiter.instance_variable_set(:@last_tx_rate_bucket, 0)
+            client_rate_limiter.instance_variable_set(:@last_max_rate, 0)
+
+            def success(timestamp, measured_tx_rate, fill_rate)
+              [{
+                response: { status_code: 200, error: nil, timestamp: timestamp },
+                expect: { fill_rate: fill_rate, measured_tx_rate: measured_tx_rate }
+              }]
+            end
+
+            def throttle(timestamp, measured_tx_rate, fill_rate)
+              [{
+                response: { status_code: 429, error: service_error, timestamp: timestamp },
+                expect: { fill_rate: fill_rate, measured_tx_rate: measured_tx_rate }
+              }]
+            end
+
+            handle_with_retry success(0.2, 0.0, 0.5)
+            handle_with_retry success(0.4, 0.0, 0.5)
+            handle_with_retry success(0.6, 4.8, 0.5)
+            handle_with_retry success(0.8, 4.8, 0.5)
+            handle_with_retry success(1.0, 4.16, 0.5)
+            handle_with_retry success(1.2, 4.16, 0.69)
+            handle_with_retry success(1.4, 4.16, 1.10)
+            handle_with_retry success(1.6, 5.63, 1.63)
+            handle_with_retry success(1.8, 5.63, 2.33)
+
+            handle_with_retry throttle(2.0, 4.32, 3.02) +
+                              success(2.2, 4.32, 3.48)
+
+            handle_with_retry success(2.4, 4.32, 3.82)
+
+            # the token bucket need additional capacity to fulfill this request
+            client_rate_limiter.instance_variable_set(:@current_capacity, 10)
+            handle_with_retry success(2.6, 5.66, 4.05)
+
+            handle_with_retry success(2.8, 5.66, 4.20)
+            handle_with_retry success(3.0, 4.33, 4.28)
+
+            handle_with_retry throttle(3.2, 4.33, 2.99) +
+                              success(3.4, 4.32, 3.45)
+          end
+        end
+      end
+    end
+  end
+end

--- a/gems/smithy-client/spec/smithy-client/retry/handler_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/retry/handler_spec.rb
@@ -8,7 +8,7 @@ require 'smithy-client/plugins/retry_errors'
 module Smithy
   module Client
     module Retry
-      describe Handler do
+      describe Handler, rbs_test: :skip do
         let(:config) do
           config = Smithy::Client::Configuration.new
           config.add_option(:service)

--- a/gems/smithy-client/spec/smithy-client/retry/quota_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/retry/quota_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Smithy
+  module Client
+    module Retry
+      describe Quota do
+        describe '#checkout_capacity' do
+          let(:error) { double('ErrorInspector', error_type: 'ServerError') }
+
+          it 'returns the requested capacity when available' do
+            initial_capacity = subject.instance_variable_get(:@available_capacity)
+
+            checked_out_capacity = subject.checkout_capacity(error)
+            expect(checked_out_capacity).to eq(Retry::Quota::RETRY_COST)
+
+            expect(subject.instance_variable_get(:@available_capacity))
+              .to eq(initial_capacity - checked_out_capacity)
+          end
+
+          it 'checks out the timeout cost when the error is a networking error' do
+            error = double('ErrorInspector', error_type: 'Transient')
+
+            checked_out_capacity = subject.checkout_capacity(error)
+            expect(checked_out_capacity)
+              .to eq(Retry::Quota::TIMEOUT_RETRY_COST)
+          end
+
+          it 'returns 0 when there is insufficient capacity' do
+            subject.instance_variable_set(:@available_capacity, 1)
+
+            expect(subject.checkout_capacity(error)).to eq(0)
+          end
+        end
+
+        describe '#release' do
+          it 'releases the capacity back to available capacity' do
+            subject.instance_variable_set(:@available_capacity, 0)
+
+            subject.release(1)
+
+            expect(subject.instance_variable_get(:@available_capacity)).to be 1
+          end
+
+          it 'releases NO_RETRY_INCREMENT back to available capacity when ' \
+             'capacity_amount is not set' do
+            subject.instance_variable_set(:@available_capacity, 0)
+
+            subject.release(nil)
+
+            expect(subject.instance_variable_get(:@available_capacity))
+              .to be Retry::Quota::NO_RETRY_INCREMENT
+          end
+
+          it 'does not increase available_capacity above max_capacity' do
+            subject.instance_variable_set(
+              :@available_capacity,
+              subject.instance_variable_get(:@max_capacity) - 1
+            )
+
+            subject.release(2)
+
+            expect(subject.instance_variable_get(:@available_capacity))
+              .to be subject.instance_variable_get(:@max_capacity)
+          end
+        end
+      end
+    end
+  end
+end

--- a/gems/smithy-client/spec/spec_helper.rb
+++ b/gems/smithy-client/spec/spec_helper.rb
@@ -6,6 +6,8 @@ require 'simplecov'
 SimpleCov.start do
   add_filter '/spec/'
   add_filter 'gems/smithy/'
+  add_filter 'gems/smithy-cbor/'
+  add_filter 'gems/smithy-schema/'
 end
 
 require 'smithy'

--- a/gems/smithy-client/spec/support/retry_errors_helper.rb
+++ b/gems/smithy-client/spec/support/retry_errors_helper.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+# Sets up the handler to run retry tests by calling either the send_handler or passed block.
+# `subject` and `output` must be defined outside this helper
+def handle(send_handler = nil, &block)
+  allow(Kernel).to receive(:sleep)
+  subject.handler = send_handler || block
+  subject.call(output.context)
+end
+
+# A helper method to test Standard and Adaptive tests
+# Expects a test case defined as a Hash with response and expect keys.
+# response: Hash with status_code and error
+# expect: delay, available_capacity, retries, calculated_rate, measured_tx_rate, fill_rate
+def handle_with_retry(test_cases)
+  i = 0
+  handle do |_context|
+    apply_delay(test_cases[i])
+    apply_expectations(test_cases[i - 1]) if i.positive?
+
+    setup_next_response(test_cases[i])
+
+    i += 1
+    output
+  end
+
+  expect(i).to(
+    eq(test_cases.size),
+    "Wrong number of retries. Handler was called #{i} times but " \
+    "#{test_cases.size} test cases were defined."
+  )
+
+  apply_expectations(test_cases[i - 1])
+end
+
+# Reset the request context for a subsequent call
+def reset_request
+  output.context.retries = 0
+end
+
+# apply a delay to the current test case
+# See handle_with_retry for test case definition
+def apply_delay(test_case)
+  expected = test_case[:expect]
+  return unless expected[:delay]
+
+  expect(Kernel).to receive(:sleep).with(expected[:delay])
+end
+
+# apply the expectations from a previous test case
+# See handle_with_retry for test case definition
+def apply_expectations(test_case)
+  expected = test_case[:expect]
+  if expected[:available_capacity]
+    expect(quota.instance_variable_get(:@available_capacity))
+      .to eq(expected[:available_capacity])
+  end
+
+  expect(output.context.retries).to eq(expected[:retries]) if expected[:retries]
+
+  if expected[:calculated_rate]
+    expect(client_rate_limiter.instance_variable_get(:@calculated_rate))
+      .to be_within(0.2).of(expected[:calculated_rate])
+  end
+  if expected[:measured_tx_rate]
+    expect(client_rate_limiter.instance_variable_get(:@measured_tx_rate))
+      .to be_within(0.1).of(expected[:measured_tx_rate])
+  end
+  if expected[:fill_rate]
+    expect(client_rate_limiter.instance_variable_get(:@fill_rate))
+      .to be_within(0.1).of(expected[:fill_rate])
+  end
+end
+
+# See handle_with_retry for test case definition
+def setup_next_response(test_case)
+  response = test_case[:response]
+  output.context.response.status_code = response[:status_code]
+  output.error = response[:error]
+
+  allow(Process).to receive(:clock_gettime).and_return(response[:timestamp]) if response[:timestamp]
+end

--- a/gems/smithy-client/spec/support/retry_errors_helper.rb
+++ b/gems/smithy-client/spec/support/retry_errors_helper.rb
@@ -66,10 +66,10 @@ def apply_expectations(test_case)
     expect(client_rate_limiter.instance_variable_get(:@measured_tx_rate))
       .to be_within(0.1).of(expected[:measured_tx_rate])
   end
-  if expected[:fill_rate]
-    expect(client_rate_limiter.instance_variable_get(:@fill_rate))
-      .to be_within(0.1).of(expected[:fill_rate])
-  end
+  return unless expected[:fill_rate]
+
+  expect(client_rate_limiter.instance_variable_get(:@fill_rate))
+    .to be_within(0.1).of(expected[:fill_rate])
 end
 
 # See handle_with_retry for test case definition

--- a/gems/smithy/lib/smithy/templates/client/endpoint_plugin.erb
+++ b/gems/smithy/lib/smithy/templates/client/endpoint_plugin.erb
@@ -56,9 +56,7 @@ module <%= module_name %>
         end
       end
 
-      def add_handlers(handlers, _config)
-        handlers.add(Handler, step: :build, priority: 75)
-      end
+      handler(Handler, priority: 75)
     end
   end
 end

--- a/gems/smithy/lib/smithy/welds/plugins.rb
+++ b/gems/smithy/lib/smithy/welds/plugins.rb
@@ -7,6 +7,7 @@ require 'smithy-client/plugins/param_converter'
 require 'smithy-client/plugins/param_validator'
 require 'smithy-client/plugins/raise_response_errors'
 require 'smithy-client/plugins/response_target'
+require 'smithy-client/plugins/retry_errors'
 require 'smithy-client/plugins/stub_responses'
 
 module Smithy
@@ -18,36 +19,20 @@ module Smithy
         true
       end
 
-      # rubocop:disable Metrics/MethodLength
       def plugins
+        base_path = 'smithy-client/plugins'
         {
-          Smithy::Client::Plugins::ContentLength => {
-            require_path: 'smithy-client/plugins/content_length'
-          },
-          Smithy::Client::Plugins::Logging => {
-            require_path: 'smithy-client/plugins/logging'
-          },
-          Smithy::Client::Plugins::NetHTTP => {
-            require_path: 'smithy-client/plugins/net_http'
-          },
-          Smithy::Client::Plugins::ParamConverter => {
-            require_path: 'smithy-client/plugins/param_converter'
-          },
-          Smithy::Client::Plugins::ParamValidator => {
-            require_path: 'smithy-client/plugins/param_validator'
-          },
-          Smithy::Client::Plugins::RaiseResponseErrors => {
-            require_path: 'smithy-client/plugins/raise_response_errors'
-          },
-          Smithy::Client::Plugins::ResponseTarget => {
-            require_path: 'smithy-client/plugins/response_target'
-          },
-          Smithy::Client::Plugins::StubResponses => {
-            require_path: 'smithy-client/plugins/stub_responses'
-          }
+          Smithy::Client::Plugins::ContentLength => { require_path: "#{base_path}/content_length" },
+          Smithy::Client::Plugins::Logging => { require_path: "#{base_path}/logging" },
+          Smithy::Client::Plugins::NetHTTP => { require_path: "#{base_path}/net_http" },
+          Smithy::Client::Plugins::ParamConverter => { require_path: "#{base_path}/param_converter" },
+          Smithy::Client::Plugins::ParamValidator => { require_path: "#{base_path}/param_validator" },
+          Smithy::Client::Plugins::RaiseResponseErrors => { require_path: "#{base_path}/raise_response_errors" },
+          Smithy::Client::Plugins::ResponseTarget => { require_path: "#{base_path}/response_target" },
+          Smithy::Client::Plugins::RetryErrors => { require_path: "#{base_path}/retry_errors" },
+          Smithy::Client::Plugins::StubResponses => { require_path: "#{base_path}/stub_responses" }
         }
       end
-      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/projections/shapes/lib/shapes/client.rb
+++ b/projections/shapes/lib/shapes/client.rb
@@ -34,9 +34,9 @@ module ShapeService
 
     # @param options [Hash] Client options
     # @option options [Boolean] :adaptive_retry_wait_to_fill (true)
-    #  When true, the request will sleep until there is sufficient client side capacity
-    #  to retry the request. When false, the request will raise `RetryCapacityNotAvailableError`
-    #  and will not retry instead of sleeping.
+    #  When true, the request will sleep until there is sufficient client side capacity to retry
+    #  the request. When false, the request will raise a `CapacityNotAvailableError` and will
+    #  not retry instead of sleeping.
     # @option options [Boolean] :convert_params (true)
     #  When `true`, request parameters are coerced into the required types.
     # @option options [String] :endpoint
@@ -108,7 +108,7 @@ module ShapeService
     # @option options [Boolean] :raise_response_errors (true)
     #  When `true`, response errors are raised. When `false`, the error is placed on the
     #  output in the {Smithy::Client::Output#error error accessor}.
-    # @option options [lambda] :retry_backoff (#<Proc:0x000000011dffeb00 /Users/mamuller/workplace/smithy-ruby/gems/smithy-client/lib/smithy-client/retry.rb:18 (lambda)>)
+    # @option options [lambda] :retry_backoff (Smithy::Client::Retry::EXPONENTIAL_BACKOFF)
     #  A callable object that calculates a backoff delay for a retry attempt. The callable
     #  should accept a single argument, `attempts`, that represents the number of attempts
     #  that have been made. Used in the `standard` and `adaptive` retry strategies.
@@ -117,7 +117,7 @@ module ShapeService
     #  the initial attempt. Used in the `standard` and `adaptive` retry strategies.
     # @option options [String, Class] :retry_strategy (standard)
     #  The retry strategy to use when retrying errors. This can be one of the following:
-    #  * `standard` - A standardized set of retry rules across the AWS SDKs. This includes support
+    #  * `standard` - A standardized retry strategy used by the AWS SDKs. This includes support
     #    for retry quotas, which limit the number of unsuccessful retries a client can make.
     #  * `adaptive` - An experimental retry strategy that includes all the functionality of the
     #    `standard` strategy along with automatic client side throttling. This is a provisional

--- a/projections/shapes/lib/shapes/client.rb
+++ b/projections/shapes/lib/shapes/client.rb
@@ -10,6 +10,7 @@ require 'smithy-client/plugins/param_converter'
 require 'smithy-client/plugins/param_validator'
 require 'smithy-client/plugins/raise_response_errors'
 require 'smithy-client/plugins/response_target'
+require 'smithy-client/plugins/retry_errors'
 require 'smithy-client/plugins/stub_responses'
 
 module ShapeService
@@ -28,9 +29,14 @@ module ShapeService
     add_plugin(Smithy::Client::Plugins::ParamValidator)
     add_plugin(Smithy::Client::Plugins::RaiseResponseErrors)
     add_plugin(Smithy::Client::Plugins::ResponseTarget)
+    add_plugin(Smithy::Client::Plugins::RetryErrors)
     add_plugin(Smithy::Client::Plugins::StubResponses)
 
     # @param options [Hash] Client options
+    # @option options [Boolean] :adaptive_retry_wait_to_fill (true)
+    #  When true, the request will sleep until there is sufficient client side capacity
+    #  to retry the request. When false, the request will raise `RetryCapacityNotAvailableError`
+    #  and will not retry instead of sleeping.
     # @option options [Boolean] :convert_params (true)
     #  When `true`, request parameters are coerced into the required types.
     # @option options [String] :endpoint
@@ -102,6 +108,24 @@ module ShapeService
     # @option options [Boolean] :raise_response_errors (true)
     #  When `true`, response errors are raised. When `false`, the error is placed on the
     #  output in the {Smithy::Client::Output#error error accessor}.
+    # @option options [lambda] :retry_backoff (#<Proc:0x000000011dffeb00 /Users/mamuller/workplace/smithy-ruby/gems/smithy-client/lib/smithy-client/retry.rb:18 (lambda)>)
+    #  A callable object that calculates a backoff delay for a retry attempt. The callable
+    #  should accept a single argument, `attempts`, that represents the number of attempts
+    #  that have been made. Used in the `standard` and `adaptive` retry strategies.
+    # @option options [Integer] :retry_max_attempts (3)
+    #  The maximum number attempts that will be made for a single request, including
+    #  the initial attempt. Used in the `standard` and `adaptive` retry strategies.
+    # @option options [String, Class] :retry_strategy (standard)
+    #  The retry strategy to use when retrying errors. This can be one of the following:
+    #  * `standard` - A standardized set of retry rules across the AWS SDKs. This includes support
+    #    for retry quotas, which limit the number of unsuccessful retries a client can make.
+    #  * `adaptive` - An experimental retry strategy that includes all the functionality of the
+    #    `standard` strategy along with automatic client side throttling. This is a provisional
+    #    strategy that may change behavior in the future.
+    #  * Any instance of a class that implements the following methods:
+    #    - `acquire_initial_retry_token(token_scope)`
+    #    - `refresh_retry_token(retry_token, error_info)`
+    #    - `record_success(retry_token)`
     # @option options [Boolean] :stub_responses
     #  When true, the client will return stubbed responses instead of networking requests.
     #  By default fake responses are generated and returned. You can specify the response data

--- a/projections/shapes/lib/shapes/plugins/endpoint.rb
+++ b/projections/shapes/lib/shapes/plugins/endpoint.rb
@@ -48,9 +48,7 @@ module ShapeService
         end
       end
 
-      def add_handlers(handlers, _config)
-        handlers.add(Handler, step: :build, priority: 75)
-      end
+      handler(Handler, priority: 75)
     end
   end
 end

--- a/projections/shapes/sig/client.rbs
+++ b/projections/shapes/sig/client.rbs
@@ -3,6 +3,7 @@ module ShapeService
     include Smithy::Client::Stubs
 
     def self.new: (
+      ?adaptive_retry_wait_to_fill: bool,
       ?convert_params: bool,
       ?endpoint: String,
       ?endpoint_provider: ShapeService::EndpointProvider,
@@ -23,6 +24,9 @@ module ShapeService
       ?log_level: Symbol,
       ?logger: Logger,
       ?raise_response_errors: bool,
+      ?retry_backoff: lambda,
+      ?retry_max_attempts: Integer,
+      ?retry_strategy: String | Class,
       ?stub_responses: bool,
       ?validate_params: bool,
     ) -> void

--- a/projections/weather/lib/weather/client.rb
+++ b/projections/weather/lib/weather/client.rb
@@ -34,9 +34,9 @@ module Weather
 
     # @param options [Hash] Client options
     # @option options [Boolean] :adaptive_retry_wait_to_fill (true)
-    #  When true, the request will sleep until there is sufficient client side capacity
-    #  to retry the request. When false, the request will raise `RetryCapacityNotAvailableError`
-    #  and will not retry instead of sleeping.
+    #  When true, the request will sleep until there is sufficient client side capacity to retry
+    #  the request. When false, the request will raise a `CapacityNotAvailableError` and will
+    #  not retry instead of sleeping.
     # @option options [Boolean] :convert_params (true)
     #  When `true`, request parameters are coerced into the required types.
     # @option options [String] :endpoint
@@ -108,7 +108,7 @@ module Weather
     # @option options [Boolean] :raise_response_errors (true)
     #  When `true`, response errors are raised. When `false`, the error is placed on the
     #  output in the {Smithy::Client::Output#error error accessor}.
-    # @option options [lambda] :retry_backoff (#<Proc:0x000000011e46e938 /Users/mamuller/workplace/smithy-ruby/gems/smithy-client/lib/smithy-client/retry.rb:18 (lambda)>)
+    # @option options [lambda] :retry_backoff (Smithy::Client::Retry::EXPONENTIAL_BACKOFF)
     #  A callable object that calculates a backoff delay for a retry attempt. The callable
     #  should accept a single argument, `attempts`, that represents the number of attempts
     #  that have been made. Used in the `standard` and `adaptive` retry strategies.
@@ -117,7 +117,7 @@ module Weather
     #  the initial attempt. Used in the `standard` and `adaptive` retry strategies.
     # @option options [String, Class] :retry_strategy (standard)
     #  The retry strategy to use when retrying errors. This can be one of the following:
-    #  * `standard` - A standardized set of retry rules across the AWS SDKs. This includes support
+    #  * `standard` - A standardized retry strategy used by the AWS SDKs. This includes support
     #    for retry quotas, which limit the number of unsuccessful retries a client can make.
     #  * `adaptive` - An experimental retry strategy that includes all the functionality of the
     #    `standard` strategy along with automatic client side throttling. This is a provisional

--- a/projections/weather/lib/weather/client.rb
+++ b/projections/weather/lib/weather/client.rb
@@ -10,6 +10,7 @@ require 'smithy-client/plugins/param_converter'
 require 'smithy-client/plugins/param_validator'
 require 'smithy-client/plugins/raise_response_errors'
 require 'smithy-client/plugins/response_target'
+require 'smithy-client/plugins/retry_errors'
 require 'smithy-client/plugins/stub_responses'
 
 module Weather
@@ -28,9 +29,14 @@ module Weather
     add_plugin(Smithy::Client::Plugins::ParamValidator)
     add_plugin(Smithy::Client::Plugins::RaiseResponseErrors)
     add_plugin(Smithy::Client::Plugins::ResponseTarget)
+    add_plugin(Smithy::Client::Plugins::RetryErrors)
     add_plugin(Smithy::Client::Plugins::StubResponses)
 
     # @param options [Hash] Client options
+    # @option options [Boolean] :adaptive_retry_wait_to_fill (true)
+    #  When true, the request will sleep until there is sufficient client side capacity
+    #  to retry the request. When false, the request will raise `RetryCapacityNotAvailableError`
+    #  and will not retry instead of sleeping.
     # @option options [Boolean] :convert_params (true)
     #  When `true`, request parameters are coerced into the required types.
     # @option options [String] :endpoint
@@ -102,6 +108,24 @@ module Weather
     # @option options [Boolean] :raise_response_errors (true)
     #  When `true`, response errors are raised. When `false`, the error is placed on the
     #  output in the {Smithy::Client::Output#error error accessor}.
+    # @option options [lambda] :retry_backoff (#<Proc:0x000000011e46e938 /Users/mamuller/workplace/smithy-ruby/gems/smithy-client/lib/smithy-client/retry.rb:18 (lambda)>)
+    #  A callable object that calculates a backoff delay for a retry attempt. The callable
+    #  should accept a single argument, `attempts`, that represents the number of attempts
+    #  that have been made. Used in the `standard` and `adaptive` retry strategies.
+    # @option options [Integer] :retry_max_attempts (3)
+    #  The maximum number attempts that will be made for a single request, including
+    #  the initial attempt. Used in the `standard` and `adaptive` retry strategies.
+    # @option options [String, Class] :retry_strategy (standard)
+    #  The retry strategy to use when retrying errors. This can be one of the following:
+    #  * `standard` - A standardized set of retry rules across the AWS SDKs. This includes support
+    #    for retry quotas, which limit the number of unsuccessful retries a client can make.
+    #  * `adaptive` - An experimental retry strategy that includes all the functionality of the
+    #    `standard` strategy along with automatic client side throttling. This is a provisional
+    #    strategy that may change behavior in the future.
+    #  * Any instance of a class that implements the following methods:
+    #    - `acquire_initial_retry_token(token_scope)`
+    #    - `refresh_retry_token(retry_token, error_info)`
+    #    - `record_success(retry_token)`
     # @option options [Boolean] :stub_responses
     #  When true, the client will return stubbed responses instead of networking requests.
     #  By default fake responses are generated and returned. You can specify the response data

--- a/projections/weather/lib/weather/plugins/endpoint.rb
+++ b/projections/weather/lib/weather/plugins/endpoint.rb
@@ -48,9 +48,7 @@ module Weather
         end
       end
 
-      def add_handlers(handlers, _config)
-        handlers.add(Handler, step: :build, priority: 75)
-      end
+      handler(Handler, priority: 75)
     end
   end
 end

--- a/projections/weather/sig/client.rbs
+++ b/projections/weather/sig/client.rbs
@@ -3,6 +3,7 @@ module Weather
     include Smithy::Client::Stubs
 
     def self.new: (
+      ?adaptive_retry_wait_to_fill: bool,
       ?convert_params: bool,
       ?endpoint: String,
       ?endpoint_provider: Weather::EndpointProvider,
@@ -23,6 +24,9 @@ module Weather
       ?log_level: Symbol,
       ?logger: Logger,
       ?raise_response_errors: bool,
+      ?retry_backoff: lambda,
+      ?retry_max_attempts: Integer,
+      ?retry_strategy: String | Class,
       ?stub_responses: bool,
       ?validate_params: bool,
     ) -> void

--- a/smithy-build.json
+++ b/smithy-build.json
@@ -7,7 +7,15 @@
                     "command": ["smithy-ruby", "smith", "client", "--gem-name=weather", "--gem-version=1.0.0", "--destination-root=../../../../projections/weather"]
                 }
             },
-            "imports": ["model/weather.smithy"]
+            "imports": ["model/weather.smithy"],
+            "transforms": [
+                {
+                    "name": "includeServices",
+                    "args": {
+                        "services": ["example.weather#Weather"]
+                    }
+                }
+            ]
         },
         "shapes": {
             "plugins": {
@@ -15,7 +23,15 @@
                     "command": ["smithy-ruby", "smith", "client", "--gem-name=shapes", "--gem-version=1.0.0", "--destination-root=../../../../projections/shapes"]
                 }
             },
-            "imports": ["model/shapes.smithy"]
+            "imports": ["model/shapes.smithy"],
+            "transforms": [
+                {
+                    "name": "includeServices",
+                    "args": {
+                        "services": ["smithy.ruby.tests#ShapeService"]
+                    }
+                }
+            ]
         }
     }
 }

--- a/tasks/smithy-client.rake
+++ b/tasks/smithy-client.rake
@@ -6,6 +6,7 @@ namespace 'smithy-client' do
   RSpec::Core::RakeTask.new do |t|
     t.pattern = 'gems/smithy-client/spec/**/*_spec.rb'
     t.rspec_opts = '--format documentation'
+    t.rspec_opts += ' --tag ~slow:true' unless ENV['CI']
   end
 
   desc 'Run RBS validation and spy tests.'


### PR DESCRIPTION
Adds the retry errors plugin with two retry strategies: standard and adaptive. Allows configuration as a string with flat options or a custom class. Passes the tests in the design.

Code is based off a hybrid of v3 and hearth v4.