### PR TITLE
Populate input defaults as a plugin

### DIFF
--- a/gems/smithy-cbor/lib/smithy-cbor/decoder.rb
+++ b/gems/smithy-cbor/lib/smithy-cbor/decoder.rb
@@ -171,7 +171,7 @@ module Smithy
         end
       end
 
-      def read_boolean
+      def read_boolean # rubocop:disable Naming/PredicateMethod
         _major_type, add_info = read_info
         case add_info
         when 20 then false

--- a/gems/smithy-client/lib/smithy-client.rb
+++ b/gems/smithy-client/lib/smithy-client.rb
@@ -11,6 +11,7 @@ require 'smithy-schema'
 
 require_relative 'smithy-client/block_io'
 require_relative 'smithy-client/configuration'
+require_relative 'smithy-client/default_params'
 require_relative 'smithy-client/dynamic_errors'
 require_relative 'smithy-client/endpoint_rules'
 require_relative 'smithy-client/handler'

--- a/gems/smithy-client/lib/smithy-client/default_params.rb
+++ b/gems/smithy-client/lib/smithy-client/default_params.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'base64'
+require 'time'
+
+module Smithy
+  module Client
+    # @api private
+    class DefaultParams
+      include Schema::Shapes
+
+      def initialize(ref)
+        @ref = ref
+      end
+
+      # @param [Hash] params
+      # @return [Hash]
+      def apply(params)
+        structure(@ref, params)
+      end
+
+      private
+
+      def shape(ref, value)
+        case ref.shape
+        when ListShape then list(ref, value)
+        when MapShape then map(ref, value)
+        when StructureShape then structure(ref, value)
+        else value
+        end
+      end
+
+      def list(ref, values)
+        return if values.nil?
+
+        shape = ref.shape
+        values.each do |value|
+          shape(shape.member, value)
+        end
+        values
+      end
+
+      def map(ref, values)
+        return if values.nil?
+
+        shape = ref.shape
+        values.each_pair do |_key, value|
+          shape(shape.value, value)
+        end
+        values
+      end
+
+      def structure(ref, values)
+        return if values.nil?
+
+        ref.shape.members.each do |member_name, member_ref|
+          value = values[member_name]
+          value ||= default(member_ref) if default?(ref, member_ref.traits)
+          next if value.nil?
+
+          values[member_name] = shape(member_ref, value)
+        end
+        values
+      end
+
+      def default?(ref, traits)
+        # skip defaults for top level members
+        return false if ref == @ref
+
+        traits.include?('smithy.api#default') && !traits.include?('smithy.api#clientOptional')
+      end
+
+      def default(ref)
+        trait = ref.traits['smithy.api#default']
+        case ref.shape
+        when BlobShape then Base64.strict_decode64(trait)
+        when TimestampShape
+          case trait
+          when String then Time.parse(trait)
+          when Integer then Time.at(trait)
+          else raise ArgumentError, "Invalid default value for Timestamp: #{trait.inspect}"
+          end
+        else trait
+        end
+      end
+    end
+  end
+end

--- a/gems/smithy-client/lib/smithy-client/default_params.rb
+++ b/gems/smithy-client/lib/smithy-client/default_params.rb
@@ -56,7 +56,7 @@ module Smithy
         ref.shape.members.each do |member_name, member_ref|
           value = values[member_name]
           value ||= default(member_ref) if default?(ref, member_ref.traits)
-          next if value.nil?
+          next if value.nil? && !default?(ref, member_ref.traits) # default can have nil values
 
           values[member_name] = shape(member_ref, value)
         end
@@ -71,16 +71,19 @@ module Smithy
       end
 
       def default(ref)
-        trait = ref.traits['smithy.api#default']
+        default = ref.traits['smithy.api#default']
         case ref.shape
-        when BlobShape then Base64.strict_decode64(trait)
-        when TimestampShape
-          case trait
-          when String then Time.parse(trait)
-          when Integer then Time.at(trait)
-          else raise ArgumentError, "Invalid default value for Timestamp: #{trait.inspect}"
-          end
-        else trait
+        when BlobShape then Base64.strict_decode64(default)
+        when TimestampShape then timestamp_default(default)
+        else default
+        end
+      end
+
+      def timestamp_default(default)
+        case default
+        when String then Time.parse(default)
+        when Integer then Time.at(default)
+        else raise ArgumentError, "Invalid default value for Timestamp: #{default.inspect}"
         end
       end
     end

--- a/gems/smithy-client/lib/smithy-client/handler_context.rb
+++ b/gems/smithy-client/lib/smithy-client/handler_context.rb
@@ -7,7 +7,7 @@ module Smithy
       # @option options [Symbol] :operation_name (nil)
       # @option options [OperationShape] :operation (nil)
       # @option options [Base] :client (nil)
-      # @option options [Hash, Struct] :params ({})
+      # @option options [Hash] :params ({})
       # @option options [Configuration] :config (nil)
       # @option options [Request] :request (HTTP::Request.new)
       # @option options [Response] :response (HTTP::Response.new)
@@ -33,7 +33,7 @@ module Smithy
       # @return [Base]
       attr_accessor :client
 
-      # @return [Hash, Struct] The request parameters as a Hash or a Struct.
+      # @return [Hash] The request parameters as a Hash.
       attr_accessor :params
 
       # @return [Struct] The client configuration.

--- a/gems/smithy-client/lib/smithy-client/param_converter.rb
+++ b/gems/smithy-client/lib/smithy-client/param_converter.rb
@@ -15,9 +15,8 @@ module Smithy
       @mutex = Mutex.new
       @converters = Hash.new { |h, k| h[k] = {} }
 
-      def initialize(schema, convert_structures: true)
-        @schema = schema
-        @convert_structures = convert_structures
+      def initialize(ref)
+        @ref = ref
         @opened_files = []
       end
 
@@ -26,7 +25,7 @@ module Smithy
       # @param [Hash] params
       # @return [Hash]
       def convert(params)
-        structure(@schema, params)
+        structure(@ref, params)
       end
 
       def close_opened_files
@@ -68,36 +67,28 @@ module Smithy
 
       def structure(ref, values)
         values = c(ref, values)
-        return if values.nil?
-
-        type = @convert_structures ? ref.shape.type.new : values
-        return type unless values.respond_to?(:each_pair)
+        return values unless values.respond_to?(:each_pair)
 
         values.each_pair do |k, v|
           next if v.nil?
           next unless ref.shape.member?(k)
 
-          type[k] = shape(ref.shape.member(k), v)
+          values[k] = shape(ref.shape.member(k), v)
         end
-        type
+        values
       end
 
-      def union(ref, values) # rubocop:disable Metrics/AbcSize
+      def union(ref, values)
         values = c(ref, values)
-        return if values.nil?
 
         if values.is_a?(Schema::Union)
-          name, member_ref = ref.shape.member_by_type(values.class)
-          member_type = ref.shape.member_type(name)
-          member_type.new(shape(member_ref, values.value))
+          _name, member_ref = ref.shape.member_by_type(values.class)
+          values = shape(member_ref, values)
         else
           key, value = values.first
-          return { key => shape(ref.shape.member(key), value) } unless @convert_structures
-          return unless ref.shape.member?(key)
-
-          member_type = ref.shape.member_type(key)
-          member_type.new(shape(ref.shape.member(key), value))
+          values[key] = shape(ref.shape.member(key), value)
         end
+        values
       end
 
       class << self

--- a/gems/smithy-client/lib/smithy-client/param_validator.rb
+++ b/gems/smithy-client/lib/smithy-client/param_validator.rb
@@ -10,8 +10,8 @@ module Smithy
 
       EXPECTED_GOT = 'expected %s to be %s, got class %s instead.'
 
-      def initialize(schema, validate_required: true)
-        @schema = schema
+      def initialize(ref, validate_required: true)
+        @ref = ref
         @validate_required = validate_required
       end
 
@@ -21,7 +21,7 @@ module Smithy
       # @raise [ArgumentError] if the params are invalid
       def validate!(params, context: 'params')
         errors = []
-        structure(@schema, params, errors, context)
+        structure(@ref, params, errors, context)
         raise ArgumentError, error_messages(errors) unless errors.empty?
       end
 

--- a/gems/smithy-client/lib/smithy-client/plugins/default_params.rb
+++ b/gems/smithy-client/lib/smithy-client/plugins/default_params.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Smithy
+  module Client
+    module Plugins
+      # @api private
+      class DefaultParams < Plugin
+        def add_handlers(handlers, _config)
+          handlers.add(Handler, step: :initialize)
+        end
+
+        # @api private
+        class Handler < Client::Handler
+          def call(context)
+            Client::DefaultParams.new(context.operation.input).apply(context.params)
+            @handler.call(context)
+          end
+        end
+      end
+    end
+  end
+end

--- a/gems/smithy-client/lib/smithy-client/stubbing/data_applicator.rb
+++ b/gems/smithy-client/lib/smithy-client/stubbing/data_applicator.rb
@@ -8,12 +8,12 @@ module Smithy
       class DataApplicator
         include Smithy::Schema::Shapes
 
-        def initialize(schema)
-          @schema = schema
+        def initialize(ref)
+          @ref = ref
         end
 
         def apply(data, stub)
-          structure(@schema, data, stub)
+          structure(@ref, data, stub)
         end
 
         private

--- a/gems/smithy-client/lib/smithy-client/stubbing/empty_stub.rb
+++ b/gems/smithy-client/lib/smithy-client/stubbing/empty_stub.rb
@@ -10,13 +10,13 @@ module Smithy
       class EmptyStub
         include Smithy::Schema::Shapes
 
-        def initialize(schema)
-          @schema = schema
+        def initialize(ref)
+          @ref = ref
         end
 
         # @return [Schema::Structure, Schema::EmptyStructure]
         def stub
-          structure(@schema, [])
+          structure(@ref, [])
         end
 
         private
@@ -53,15 +53,13 @@ module Smithy
           klass.new(value)
         end
 
-        def scalar(ref) # rubocop:disable Metrics/CyclomaticComplexity
+        def scalar(ref)
           case ref.shape
           when BigDecimalShape then BigDecimal(0)
-          when BlobShape then 'blob'
+          when BlobShape, EnumShape, StringShape then ref.member_name
           when BooleanShape then false
-          when EnumShape then 'enum'
           when IntegerShape, IntEnumShape then 0
           when FloatShape then 0.0
-          when StringShape then 'string'
           when TimestampShape then Time.now
           end
         end

--- a/gems/smithy-client/lib/smithy-client/stubbing/stub_data.rb
+++ b/gems/smithy-client/lib/smithy-client/stubbing/stub_data.rb
@@ -7,16 +7,16 @@ module Smithy
       # @api private
       class StubData
         def initialize(operation)
-          @schema = operation.output
+          @output = operation.output
         end
 
         # @param [Hash] params
         # @return [Structure]
         def stub(params = {})
-          stub = EmptyStub.new(@schema).stub
-          data = ParamConverter.new(@schema, convert_structures: false).convert(params)
-          ParamValidator.new(@schema, validate_required: false).validate!(data, context: 'stub')
-          DataApplicator.new(@schema).apply(data, stub)
+          stub = EmptyStub.new(@output).stub
+          data = ParamConverter.new(@output).convert(params)
+          ParamValidator.new(@output, validate_required: false).validate!(data, context: 'stub')
+          DataApplicator.new(@output).apply(data, stub)
           stub
         end
       end

--- a/gems/smithy-client/lib/smithy-client/stubs.rb
+++ b/gems/smithy-client/lib/smithy-client/stubs.rb
@@ -203,7 +203,7 @@ module Smithy
 
       def data_to_http_resp(operation_name, data)
         operation = @config.service.operation(operation_name)
-        data = ParamConverter.new(operation.output, convert_structures: false).convert(data)
+        data = ParamConverter.new(operation.output).convert(data)
         ParamValidator.new(operation.output, validate_required: false).validate!(data, context: 'stub')
         @config.protocol.stub_data(@config.service, operation, data)
       end

--- a/gems/smithy-client/lib/smithy-client/util.rb
+++ b/gems/smithy-client/lib/smithy-client/util.rb
@@ -4,7 +4,7 @@ module Smithy
   module Client
     # @api private
     module Util
-      def self.str_to_bool(str)
+      def self.str_to_bool(str) # rubocop:disable Naming/PredicateMethod
         case str
         when 'true' then true
         when 'false' then false

--- a/gems/smithy-client/sig/smithy-client/handler_context.rbs
+++ b/gems/smithy-client/sig/smithy-client/handler_context.rbs
@@ -5,7 +5,7 @@ module Smithy
       attr_accessor operation_name: (Symbol | String)?
       attr_accessor operation: Schema::Shapes::OperationShape?
       attr_accessor client: Base?
-      attr_accessor params: (Hash[Symbol | String, untyped] | Schema::Structure)
+      attr_accessor params: Hash[Symbol | String, untyped]
       attr_accessor config: Struct[untyped]?
       attr_accessor request: HTTP::Request | untyped
       attr_accessor response: HTTP::Response | untyped

--- a/gems/smithy-client/spec/smithy-client/default_params_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/default_params_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+
+module Smithy
+  module Client
+    describe DefaultParams do
+      let(:shapes) { SchemaHelper.sample_shapes }
+      let(:sample_client) { ClientHelper.sample_client(shapes: shapes) }
+      let(:service_shape) { sample_client.const_get(:Schema).const_get(:SampleSchema) }
+
+      let(:structure_members) { shapes['smithy.ruby.tests#Structure']['members'] }
+
+      def validate(params, expected)
+        input = service_shape.operation(:operation).input
+        DefaultParams.new(input).apply(params)
+        expect(params).to eq(expected)
+      end
+
+      it 'does not apply top-level defaults' do
+        structure_members['string']['traits'] = { 'smithy.api#default' => 'string' }
+        validate({}, {})
+      end
+
+      it 'does not apply client optional defaults' do
+        structure_members['string']['traits'] = {
+          'smithy.api#default' => 'string',
+          'smithy.api#clientOptional' => {}
+        }
+        validate({ structure: {} }, { structure: {} })
+      end
+
+      it 'applies recursive defaults' do
+        structure_members['string']['traits'] = { 'smithy.api#default' => 'string' }
+        validate(
+          { structure: { structure: {} } },
+          { structure: { string: 'string', structure: { string: 'string' } } }
+        )
+      end
+
+      it 'applies a blob default' do
+        structure_members['blob']['traits'] = { 'smithy.api#default' => 'YmxvYg==' }
+        validate({ structure: {} }, { structure: { blob: 'blob' } })
+      end
+
+      it 'applies an int enum default' do
+        structure_members['intEnum']['traits'] = { 'smithy.api#default' => 123 }
+        validate({ structure: {} }, { structure: { int_enum: 123 } })
+      end
+
+      context 'documents' do
+        it 'applies a null default' do
+          structure_members['document']['traits'] = { 'smithy.api#default' => nil }
+          validate({ structure: {} }, { structure: { document: nil } })
+        end
+
+        it 'applies a true default' do
+          structure_members['document']['traits'] = { 'smithy.api#default' => true }
+          validate({ structure: {} }, { structure: { document: true } })
+        end
+
+        it 'applies a false default' do
+          structure_members['document']['traits'] = { 'smithy.api#default' => false }
+          validate({ structure: {} }, { structure: { document: false } })
+        end
+
+        it 'applies a string default' do
+          structure_members['document']['traits'] = { 'smithy.api#default' => 'string' }
+          validate({ structure: {} }, { structure: { document: 'string' } })
+        end
+
+        it 'applies an integer default' do
+          structure_members['document']['traits'] = { 'smithy.api#default' => 123 }
+          validate({ structure: {} }, { structure: { document: 123 } })
+        end
+
+        it 'applies a float default' do
+          structure_members['document']['traits'] = { 'smithy.api#default' => 123.45 }
+          validate({ structure: {} }, { structure: { document: 123.45 } })
+        end
+
+        it 'applies an empty list default' do
+          structure_members['document']['traits'] = { 'smithy.api#default' => [] }
+          validate({ structure: {} }, { structure: { document: [] } })
+        end
+
+        it 'applies an empty map default' do
+          structure_members['document']['traits'] = { 'smithy.api#default' => {} }
+          validate({ structure: {} }, { structure: { document: {} } })
+        end
+      end
+
+      it 'applies an empty list default' do
+        structure_members['list']['traits'] = { 'smithy.api#default' => [] }
+        validate({ structure: {} }, { structure: { list: [] } })
+      end
+
+      it 'applies an empty map default' do
+        structure_members['map']['traits'] = { 'smithy.api#default' => {} }
+        validate({ structure: {} }, { structure: { map: {} } })
+      end
+
+      context 'timestamps' do
+        it 'applies a timestamp default as a string' do
+          timestamp = '2025-08-27T00:00:00Z'
+          structure_members['timestamp']['traits'] = { 'smithy.api#default' => timestamp }
+          validate({ structure: {} }, { structure: { timestamp: Time.parse(timestamp) } })
+        end
+
+        it 'applies a timestamp default as an integer' do
+          timestamp = 1_234_567_890
+          structure_members['timestamp']['traits'] = { 'smithy.api#default' => timestamp }
+          validate({ structure: {} }, { structure: { timestamp: Time.at(timestamp) } })
+        end
+      end
+    end
+  end
+end

--- a/gems/smithy-client/spec/smithy-client/param_converter_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/param_converter_spec.rb
@@ -43,7 +43,7 @@ module Smithy
             ],
             union: { structure: { string: :abc } }
           }
-          converted = ParamConverter.new(input, convert_structures: false).convert(params)
+          converted = ParamConverter.new(input).convert(params)
           expect(converted).to eq(expected)
         end
 
@@ -64,51 +64,7 @@ module Smithy
             ],
             union: union_type.new({ string: :abc })
           )
-          converted = ParamConverter.new(input, convert_structures: false).convert(params)
-          expect(converted.to_h).to eq(expected)
-        end
-
-        it 'performs a deeply nested conversion of hash values into types' do
-          params = {
-            structure: { boolean: 'true' },
-            map: 'not a map',
-            structure_map: {
-              'key' => { map: { color: :blue } }
-            },
-            list: 'not a list',
-            structure_list: [
-              { integer: 1 },
-              { integer: 2.0 },
-              { integer: '3' }
-            ],
-            union: { structure: { string: :abc } }
-          }
           converted = ParamConverter.new(input).convert(params)
-          expect(converted).to be_a(input.shape.type)
-          expect(converted.union).to be_a(input.shape.member(:union).shape.member_type(:structure))
-          expect(converted.to_h).to eq(expected)
-        end
-
-        it 'performs a deeply nested conversion of type values into types' do
-          structure_type = input.shape.type
-          union_type = input.shape.member(:union).shape.member_type(:structure)
-          params = structure_type.new(
-            structure: structure_type.new(boolean: 'true'),
-            map: 'not a map',
-            structure_map: {
-              'key' => structure_type.new(map: { color: :blue })
-            },
-            list: 'not a list',
-            structure_list: [
-              { integer: 1 },
-              { integer: 2.0 },
-              { integer: '3' }
-            ],
-            union: union_type.new({ string: :abc })
-          )
-          converted = ParamConverter.new(input).convert(params)
-          expect(converted).to be_a(structure_type)
-          expect(converted.union).to be_a(union_type)
           expect(converted.to_h).to eq(expected)
         end
       end

--- a/gems/smithy-client/spec/smithy-client/plugins/default_params_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/default_params_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+
+require 'smithy-client/plugins/default_params'
+
+module Smithy
+  module Client
+    module Plugins
+      describe ParamValidator do
+        let(:sample_client) { ClientHelper.sample_client }
+
+        let(:client_class) do
+          client_class = sample_client.const_get(:Client)
+          client_class.clear_plugins
+          client_class.add_plugin(DefaultParams)
+          client_class.add_plugin(DummySendPlugin)
+          client_class
+        end
+
+        let(:client) { client_class.new }
+
+        it 'adds the handler' do
+          expect(client.handlers).to include(DefaultParams::Handler)
+        end
+
+        it 'calls the default params class' do
+          params = {}
+          input = client.config.service.operation(:operation).input
+          expect(Client::DefaultParams).to receive(:new).with(input).and_call_original
+          expect_any_instance_of(Client::DefaultParams).to receive(:apply).with(params).and_call_original
+          client.operation(params)
+        end
+      end
+    end
+  end
+end

--- a/gems/smithy-client/spec/smithy-client/plugins/stub_responses_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/stub_responses_spec.rb
@@ -120,7 +120,7 @@ module Smithy
               long: 0,
               map: {},
               short: 0,
-              streaming_blob: String.new('blob'),
+              streaming_blob: String.new('streamingBlob'),
               structure_list: [],
               structure_map: {},
               string: 'string',

--- a/gems/smithy/lib/smithy/templates/client/client.erb
+++ b/gems/smithy/lib/smithy/templates/client/client.erb
@@ -81,7 +81,6 @@ module <%= module_name %>
     #       # resource did not enter the desired state in time
     #     end
     #
-    #
     # @param [Symbol] waiter_name
     # @param [Hash] params ({})
     # @param [Hash] options ({})

--- a/gems/smithy/lib/smithy/views/client/schema.rb
+++ b/gems/smithy/lib/smithy/views/client/schema.rb
@@ -124,7 +124,6 @@ module Smithy
         # @api private
         class Shape
           OMITTED_TRAITS = %w[
-            smithy.api#default
             smithy.api#documentation
           ].freeze
 
@@ -278,7 +277,6 @@ module Smithy
         # @api private
         class ShapeRef
           OMITTED_TRAITS = %w[
-            smithy.api#default
             smithy.api#documentation
           ].freeze
 

--- a/gems/smithy/lib/smithy/views/client/types.rb
+++ b/gems/smithy/lib/smithy/views/client/types.rb
@@ -185,14 +185,14 @@ module Smithy
             case @target['type']
             when 'blob' then "Base64.strict_decode64('#{default}')"
             when 'bigDecimal' then "BigDecimal('#{default}')"
-            when 'document' then document(default)
+            when 'document' then document_default(default)
             when 'enum', 'string' then "'#{default}'"
-            when 'timestamp' then timestamp(default)
+            when 'timestamp' then timestamp_default(default)
             else default
             end
           end
 
-          def document(default)
+          def document_default(default)
             case default
             when nil then 'nil'
             when String then "'#{default}'"
@@ -200,7 +200,7 @@ module Smithy
             end
           end
 
-          def timestamp(default)
+          def timestamp_default(default)
             case default
             when Integer then "Time.at(#{default})"
             when String then "Time.parse('#{default}')"

--- a/gems/smithy/lib/smithy/welds/plugins.rb
+++ b/gems/smithy/lib/smithy/welds/plugins.rb
@@ -2,6 +2,7 @@
 
 require 'smithy-client/plugins/checksum_required'
 require 'smithy-client/plugins/content_length'
+require 'smithy-client/plugins/default_params'
 require 'smithy-client/plugins/host_prefix'
 require 'smithy-client/plugins/idempotency_token'
 require 'smithy-client/plugins/logging'
@@ -31,6 +32,7 @@ module Smithy
         {
           Smithy::Client::Plugins::ChecksumRequired => { require_path: "#{base_path}/checksum_required" },
           Smithy::Client::Plugins::ContentLength => { require_path: "#{base_path}/content_length" },
+          Smithy::Client::Plugins::DefaultParams => { require_path: "#{base_path}/default_params" },
           Smithy::Client::Plugins::HostPrefix => { require_path: "#{base_path}/host_prefix" },
           Smithy::Client::Plugins::IdempotencyToken => { require_path: "#{base_path}/idempotency_token" },
           Smithy::Client::Plugins::Logging => { require_path: "#{base_path}/logging" },

--- a/gems/smithy/spec/interfaces/client/stub_responses_spec.rb
+++ b/gems/smithy/spec/interfaces/client/stub_responses_spec.rb
@@ -30,7 +30,7 @@ describe 'Client: Stub Responses' do
           int_enum: 0,
           list: [],
           map: {},
-          structure: { member: 'string' },
+          structure: { member: 'member' },
           union: { string: 'string' }
         }
       end


### PR DESCRIPTION
Breaks the symmetry of the defaults trait implementation. Defaults are added into type initializers for schema related gems, but for clients, are really used for output. For input, add a plugin to the client to populate default values. This allows us to retain "hash only" input and not worry about structure/union type cases and do any weird conversion. We can expect a hash throughout.