### PR TITLE
request/response -> http_request/response

### DIFF
--- a/gems/smithy-client/lib/smithy-client/handler_context.rb
+++ b/gems/smithy-client/lib/smithy-client/handler_context.rb
@@ -9,8 +9,8 @@ module Smithy
       # @option options [Base] :client (nil)
       # @option options [Hash] :params ({})
       # @option options [Configuration] :config (nil)
-      # @option options [Request] :request (HTTP::Request.new)
-      # @option options [Response] :response (HTTP::Response.new)
+      # @option options [HTTP::Request] :http_request (HTTP::Request.new)
+      # @option options [HTTP::Response] :http_response (HTTP::Response.new)
       # @option options [Hash] :metadata ({})
       def initialize(options = {})
         @operation_name = options[:operation_name]
@@ -18,8 +18,8 @@ module Smithy
         @client = options[:client]
         @params = options[:params] || {}
         @config = options[:config]
-        @request = options[:request] || HTTP::Request.new
-        @response = options[:response] || HTTP::Response.new
+        @http_request = options[:http_request] || HTTP::Request.new
+        @http_response = options[:http_response] || HTTP::Response.new
         @retries = 0
         @metadata = {}
       end
@@ -39,11 +39,11 @@ module Smithy
       # @return [Struct] The client configuration.
       attr_accessor :config
 
-      # @return [Request]
-      attr_accessor :request
+      # @return [HTTP::Request]
+      attr_accessor :http_request
 
-      # @return [Response]
-      attr_accessor :response
+      # @return [HTTP::Response]
+      attr_accessor :http_response
 
       # @return [Integer]
       attr_accessor :retries

--- a/gems/smithy-client/lib/smithy-client/net_http/handler.rb
+++ b/gems/smithy-client/lib/smithy-client/net_http/handler.rb
@@ -18,7 +18,7 @@ module Smithy
         # @param [HandlerContext] context
         # @return [Output]
         def call(context)
-          transmit(context.config, context.request, context.response)
+          transmit(context.config, context.http_request, context.http_response)
           Output.new(context: context)
         end
 

--- a/gems/smithy-client/lib/smithy-client/output.rb
+++ b/gems/smithy-client/lib/smithy-client/output.rb
@@ -13,9 +13,7 @@ module Smithy
         @context = options[:context] || HandlerContext.new
         @data = options[:data]
         @error = options[:error]
-        @request = @context.request
-        @response = @context.response
-        @response.on_error { |error| @error = error }
+        @context.http_response.on_error { |error| @error = error }
         super(@error || @data)
       end
 

--- a/gems/smithy-client/lib/smithy-client/plugins/checksum_required.rb
+++ b/gems/smithy-client/lib/smithy-client/plugins/checksum_required.rb
@@ -18,7 +18,7 @@ module Smithy
 
           def call(context)
             if checksum_required_operation?(context)
-              context.request.headers['Content-Md5'] ||= md5(context.request.body)
+              context.http_request.headers['Content-Md5'] ||= md5(context.http_request.body)
             end
             @handler.call(context)
           end

--- a/gems/smithy-client/lib/smithy-client/plugins/content_length.rb
+++ b/gems/smithy-client/lib/smithy-client/plugins/content_length.rb
@@ -11,9 +11,9 @@ module Smithy
           METHODS_WITH_BODY = Set.new(%w[POST PUT PATCH PROPFIND PROPPATCH MKCOL LOCK UNLOCK])
 
           def call(context)
-            body = context.request.body
-            if body.respond_to?(:size) && METHODS_WITH_BODY.include?(context.request.http_method)
-              context.request.headers['Content-Length'] = body.size
+            body = context.http_request.body
+            if body.respond_to?(:size) && METHODS_WITH_BODY.include?(context.http_request.http_method)
+              context.http_request.headers['Content-Length'] = body.size
             end
             @handler.call(context)
           end

--- a/gems/smithy-client/lib/smithy-client/plugins/host_prefix.rb
+++ b/gems/smithy-client/lib/smithy-client/plugins/host_prefix.rb
@@ -46,7 +46,7 @@ module Smithy
             prefix = host_prefix.gsub(/\{.+?}/) do |label|
               label_value(input, label.delete('{}'), context.params)
             end
-            context.request.endpoint.host = prefix + context.request.endpoint.host
+            context.http_request.endpoint.host = prefix + context.http_request.endpoint.host
           end
 
           def label_value(input, label, params)

--- a/gems/smithy-client/lib/smithy-client/plugins/param_converter.rb
+++ b/gems/smithy-client/lib/smithy-client/plugins/param_converter.rb
@@ -22,7 +22,7 @@ module Smithy
           def call(context)
             converter = Client::ParamConverter.new(context.operation.input)
             context.params = converter.convert(context.params)
-            context.response.on_done { converter.close_opened_files }
+            context.http_response.on_done { converter.close_opened_files }
             @handler.call(context)
           end
         end

--- a/gems/smithy-client/lib/smithy-client/plugins/request_compression.rb
+++ b/gems/smithy-client/lib/smithy-client/plugins/request_compression.rb
@@ -72,7 +72,7 @@ module Smithy
               if selected_encoding
                 if streaming?(context.operation.input)
                   process_streaming_compression(selected_encoding, context)
-                elsif context.request.body.size >= context.config.request_min_compression_size_bytes
+                elsif context.http_request.body.size >= context.config.request_min_compression_size_bytes
                   process_compression(selected_encoding, context)
                 end
               end
@@ -101,7 +101,7 @@ module Smithy
           def process_streaming_compression(encoding, context)
             case encoding
             when 'gzip'
-              context.request.body = GzipIO.new(context.request.body)
+              context.http_request.body = GzipIO.new(context.http_request.body)
             else
               raise StandardError, "Encoding #{encoding} is not supported"
             end
@@ -122,13 +122,13 @@ module Smithy
             compressed = StringIO.new
             compressed.binmode
             gzip_writer = Zlib::GzipWriter.new(compressed)
-            if context.request.body.respond_to?(:read)
-              update_in_chunks(gzip_writer, context.request.body)
+            if context.http_request.body.respond_to?(:read)
+              update_in_chunks(gzip_writer, context.http_request.body)
             else
-              gzip_writer.write(context.request.body)
+              gzip_writer.write(context.http_request.body)
             end
             gzip_writer.close
-            context.request.body = StringIO.new(compressed.string)
+            context.http_request.body = StringIO.new(compressed.string)
           end
 
           def update_in_chunks(compressor, io)
@@ -141,7 +141,7 @@ module Smithy
           end
 
           def update_content_encoding(encoding, context)
-            headers = context.request.headers
+            headers = context.http_request.headers
             if headers['Content-Encoding']
               headers['Content-Encoding'] += ", #{encoding}"
             else

--- a/gems/smithy-client/lib/smithy-client/plugins/response_target.rb
+++ b/gems/smithy-client/lib/smithy-client/plugins/response_target.rb
@@ -15,7 +15,7 @@ module Smithy
         class Handler < Client::Handler
           def call(context)
             target = context[:response_target]
-            add_event_listeners(context.response, target) if target
+            add_event_listeners(context.http_response, target) if target
             @handler.call(context)
           end
 

--- a/gems/smithy-client/lib/smithy-client/plugins/retry_errors.rb
+++ b/gems/smithy-client/lib/smithy-client/plugins/retry_errors.rb
@@ -85,9 +85,9 @@ module Smithy
           def handle(context, retry_strategy, token)
             output = @handler.call(context)
             if (error = output.error)
-              return output unless retryable?(context.request)
+              return output unless retryable?(context.http_request)
 
-              error_info = HTTP::ErrorInspector.new(error, context.response)
+              error_info = HTTP::ErrorInspector.new(error, context.http_response)
               token = retry_strategy.refresh_retry_token(token, error_info)
               return output unless token
 
@@ -109,12 +109,11 @@ module Smithy
           end
 
           def reset_request(context)
-            request = context.request
-            request.body.rewind
+            context.http_request.body.rewind
           end
 
           def reset_response(context, output)
-            context.response.reset
+            context.http_response.reset
             output.error = nil
           end
         end

--- a/gems/smithy-client/lib/smithy-client/plugins/sign_requests.rb
+++ b/gems/smithy-client/lib/smithy-client/plugins/sign_requests.rb
@@ -9,7 +9,7 @@ module Smithy
         class Handler < Client::Handler
           def call(context)
             context[:auth].signer.sign(
-              request: context.request,
+              request: context.http_request,
               identity: context[:auth].identity,
               properties: context[:auth].signer_properties
             )

--- a/gems/smithy-client/lib/smithy-client/plugins/stub_responses.rb
+++ b/gems/smithy-client/lib/smithy-client/plugins/stub_responses.rb
@@ -56,7 +56,7 @@ module Smithy
           private
 
           def apply_stub(stub, output)
-            resp = output.context.response
+            resp = output.context.http_response
             if stub[:error]
               signal_error(stub[:error], resp)
             elsif stub[:http]

--- a/gems/smithy-client/lib/smithy-client/rpc_v2_cbor/request_builder.rb
+++ b/gems/smithy-client/lib/smithy-client/rpc_v2_cbor/request_builder.rb
@@ -21,11 +21,11 @@ module Smithy
         private
 
         def apply_http_method(context)
-          context.request.http_method = 'POST'
+          context.http_request.http_method = 'POST'
         end
 
         def apply_headers(context)
-          context.request.headers['Smithy-Protocol'] = 'rpc-v2-cbor'
+          context.http_request.headers['Smithy-Protocol'] = 'rpc-v2-cbor'
           apply_content_type_header(context)
           apply_accept_header(context)
         end
@@ -39,7 +39,7 @@ module Smithy
               'application/cbor'
             end
 
-          context.request.headers['Content-Type'] ||= content_type if content_type
+          context.http_request.headers['Content-Type'] ||= content_type if content_type
         end
 
         def apply_accept_header(context)
@@ -50,15 +50,15 @@ module Smithy
               'application/cbor'
             end
 
-          context.request.headers['Accept'] ||= accept
+          context.http_request.headers['Accept'] ||= accept
         end
 
         def apply_body(context)
-          context.request.body = @codec.serialize(context.operation.input, context.params)
+          context.http_request.body = @codec.serialize(context.operation.input, context.params)
         end
 
         def apply_url_path(context)
-          base = context.request.endpoint
+          base = context.http_request.endpoint
           service_name = context.config.service.name
           base.path += "/service/#{service_name}/operation/#{context.operation.name}"
         end

--- a/gems/smithy-client/lib/smithy-client/rpc_v2_cbor/response_parser.rb
+++ b/gems/smithy-client/lib/smithy-client/rpc_v2_cbor/response_parser.rb
@@ -13,25 +13,25 @@ module Smithy
           if !valid_response?(context)
             code, message, data = http_status_error(context)
             build_error(context, code, message, data)
-          elsif (300..599).cover?(context.response.status_code)
+          elsif (300..599).cover?(context.http_response.status_code)
             error(context)
           end
         end
 
         def parse_data(context)
-          @codec.deserialize(context.operation.output, context.response.body.read)
+          @codec.deserialize(context.operation.output, context.http_response.body.read)
         end
 
         private
 
         def valid_response?(context)
-          req_header = context.request.headers['smithy-protocol']
-          resp_header = context.request.headers['smithy-protocol']
+          req_header = context.http_request.headers['smithy-protocol']
+          resp_header = context.http_request.headers['smithy-protocol']
           req_header == resp_header
         end
 
         def error(context)
-          body = context.response.body.read
+          body = context.http_response.body.read
           if body.empty?
             code, message, data = http_status_error(context)
           else
@@ -77,7 +77,7 @@ module Smithy
         end
 
         def http_status_error_code(context)
-          status_code = context.response.status_code
+          status_code = context.http_response.status_code
           "HTTP#{status_code}Error"
         end
       end

--- a/gems/smithy-client/sig/smithy-client/handler_context.rbs
+++ b/gems/smithy-client/sig/smithy-client/handler_context.rbs
@@ -7,8 +7,8 @@ module Smithy
       attr_accessor client: Base?
       attr_accessor params: Hash[Symbol | String, untyped]
       attr_accessor config: Struct[untyped]?
-      attr_accessor request: HTTP::Request | untyped
-      attr_accessor response: HTTP::Response | untyped
+      attr_accessor http_request: HTTP::Request | untyped
+      attr_accessor http_response: HTTP::Response | untyped
       attr_accessor retries: Integer
       attr_reader metadata: Hash[untyped, untyped]
       def []: (untyped) -> untyped

--- a/gems/smithy-client/spec/smithy-client/handler_context_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/handler_context_spec.rb
@@ -66,27 +66,27 @@ module Smithy
         end
       end
 
-      describe '#request' do
+      describe '#http_request' do
         it 'defaults to HTTP::Request' do
-          expect(subject.request).to be_a(HTTP::Request)
+          expect(subject.http_request).to be_a(HTTP::Request)
         end
 
         it 'can be set in the constructor' do
-          request = double('request')
-          context = HandlerContext.new(request: request)
-          expect(context.request).to be(request)
+          http_request = double('http_request')
+          context = HandlerContext.new(http_request: http_request)
+          expect(context.http_request).to be(http_request)
         end
       end
 
-      describe '#response' do
+      describe '#http_response' do
         it 'defaults to HTTP::Response' do
-          expect(subject.response).to be_a(HTTP::Response)
+          expect(subject.http_response).to be_a(HTTP::Response)
         end
 
         it 'can be set in the constructor' do
-          response = double('response')
-          context = HandlerContext.new(response: response)
-          expect(context.response).to be(response)
+          http_response = double('http_response')
+          context = HandlerContext.new(http_response: http_response)
+          expect(context.http_response).to be(http_response)
         end
       end
 

--- a/gems/smithy-client/spec/smithy-client/net_http/handler_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/net_http/handler_spec.rb
@@ -18,7 +18,7 @@ module Smithy
         let(:context) do
           client = client_class.new
           context = HandlerContext.new(config: client.config)
-          context.request.endpoint = endpoint
+          context.http_request.endpoint = endpoint
           context
         end
 
@@ -31,7 +31,7 @@ module Smithy
         subject { Handler.new }
 
         describe '#call' do
-          let(:http_request) { context.request }
+          let(:http_request) { context.http_request }
 
           it 'returns an Output object from #call' do
             stub_request(:any, endpoint)
@@ -128,18 +128,18 @@ module Smithy
             it 'populates the status code' do
               stub_request(:any, endpoint).to_return(status: 200)
               output = make_request
-              expect(output.context.response.status_code).to eq(200)
+              expect(output.context.http_response.status_code).to eq(200)
             end
 
             it 'populates the headers' do
               stub_request(:any, endpoint).to_return(headers: { 'Content-Length' => '0' })
               output = make_request
-              expect(output.context.response.headers['Content-Length']).to eq('0')
+              expect(output.context.http_response.headers['Content-Length']).to eq('0')
             end
 
             it 'populates the response body' do
               stub_request(:any, endpoint).to_return(body: 'response-body')
-              resp_body = make_request.context.response.body
+              resp_body = make_request.context.http_response.body
               resp_body.rewind
               expect(resp_body.read).to eq('response-body')
             end

--- a/gems/smithy-client/spec/smithy-client/plugins/checksum_required_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/checksum_required_spec.rb
@@ -39,7 +39,7 @@ module Smithy
           allow(body).to receive(:read).and_call_original # codec read
           allow(body).to receive(:read).with(1024 * 1024, any_args).and_call_original
           output = client.operation(streaming_blob: body)
-          expect(output.context.request.headers['Content-Md5']).to eq('pAFSSYDaTfRd1BEr40kHGA==')
+          expect(output.context.http_request.headers['Content-Md5']).to eq('pAFSSYDaTfRd1BEr40kHGA==')
         end
 
         it 'calculates checksums before signing' do

--- a/gems/smithy-client/spec/smithy-client/plugins/host_prefix_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/host_prefix_spec.rb
@@ -63,7 +63,7 @@ module Smithy
             }
             client.config.endpoint = 'https://example.com'
             output = client.operation(string: 'foo')
-            expect(output.context.request.endpoint.host).to eq('bar.example.com')
+            expect(output.context.http_request.endpoint.host).to eq('bar.example.com')
           end
 
           it 'applies the host prefix with a label to the endpoint' do
@@ -72,7 +72,7 @@ module Smithy
             }
             client.config.endpoint = 'https://example.com'
             output = client.operation(string: 'foo')
-            expect(output.context.request.endpoint.host).to eq('foo.bar.example.com')
+            expect(output.context.http_request.endpoint.host).to eq('foo.bar.example.com')
           end
 
           it 'raises when the label is not a valid host label' do

--- a/gems/smithy-client/spec/smithy-client/plugins/http_api_key_auth_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/http_api_key_auth_spec.rb
@@ -68,7 +68,7 @@ module Smithy
             }
 
             output = client.operation
-            expect(output.context.request.headers['x-api-key']).to eq('stubbed-api-key')
+            expect(output.context.http_request.headers['x-api-key']).to eq('stubbed-api-key')
           end
 
           it 'signs in the header with a custom scheme' do
@@ -77,7 +77,7 @@ module Smithy
             }
 
             output = client.operation
-            expect(output.context.request.headers['x-api-key']).to eq('ApiKey stubbed-api-key')
+            expect(output.context.http_request.headers['x-api-key']).to eq('ApiKey stubbed-api-key')
           end
 
           it 'can sign on the query string' do
@@ -86,7 +86,7 @@ module Smithy
             }
 
             output = client.operation
-            expect(output.context.request.endpoint.query).to include('x-api-key=stubbed-api-key')
+            expect(output.context.http_request.endpoint.query).to include('x-api-key=stubbed-api-key')
           end
         end
       end

--- a/gems/smithy-client/spec/smithy-client/plugins/http_basic_auth_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/http_basic_auth_spec.rb
@@ -87,7 +87,7 @@ module Smithy
 
             output = client.operation
             identity_string = "#{client.config.http_login_username}:#{client.config.http_login_password}"
-            expect(output.context.request.headers['Authorization'])
+            expect(output.context.http_request.headers['Authorization'])
               .to eq("Basic #{Base64.strict_encode64(identity_string)}")
           end
         end

--- a/gems/smithy-client/spec/smithy-client/plugins/http_bearer_auth_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/http_bearer_auth_spec.rb
@@ -66,7 +66,7 @@ module Smithy
             shapes['smithy.ruby.tests#SampleClient']['traits']['smithy.api#httpBearerAuth'] = {}
 
             output = client.operation
-            expect(output.context.request.headers['Authorization'])
+            expect(output.context.http_request.headers['Authorization'])
               .to eq("Bearer #{client.config.http_bearer_token}")
           end
         end

--- a/gems/smithy-client/spec/smithy-client/plugins/request_compression_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/request_compression_spec.rb
@@ -83,12 +83,12 @@ module Smithy
 
           it 'compresses the body using gzip and sets the content-encoding header' do
             output = client.operation(string: large_body)
-            expect(output.context.request.headers['Content-Encoding']).to eq('gzip')
+            expect(output.context.http_request.headers['Content-Encoding']).to eq('gzip')
           end
 
           it 'preserves the uncompressed body' do
             output = client.operation(string: large_body)
-            uncompressed_body = Zlib::GzipReader.new(output.context.request.body)
+            uncompressed_body = Zlib::GzipReader.new(output.context.http_request.body)
             expect(uncompressed_body.read).to include(large_body)
           end
 
@@ -97,7 +97,7 @@ module Smithy
               'smithy.api#requestCompression' => { 'encodings' => %w[custom gzip] }
             }
             output = client.operation(string: large_body)
-            expect(output.context.request.headers['Content-Encoding']).to eq('gzip')
+            expect(output.context.http_request.headers['Content-Encoding']).to eq('gzip')
           end
 
           it 'does not compress when no supported encoding is found' do
@@ -105,7 +105,7 @@ module Smithy
               'smithy.api#requestCompression' => { 'encodings' => ['custom'] }
             }
             output = client.operation(string: large_body)
-            expect(output.context.request.headers['Content-Encoding']).to be_nil
+            expect(output.context.http_request.headers['Content-Encoding']).to be_nil
           end
 
           it 'compresses the body when the size is greater than the minimum size' do
@@ -113,25 +113,25 @@ module Smithy
             shapes['smithy.ruby.tests#StreamingBlob'].delete('traits')
             client.config.request_min_compression_size_bytes = 128
             output = client.operation(string: small_body)
-            expect(output.context.request.headers['Content-Encoding']).to eq('gzip')
+            expect(output.context.http_request.headers['Content-Encoding']).to eq('gzip')
           end
 
           it 'does not compress when the body is smaller than the minimum size' do
             # input with any streaming member is always compressed regardless of min size
             shapes['smithy.ruby.tests#StreamingBlob'].delete('traits')
             output = client.operation(string: small_body)
-            expect(output.context.request.headers['Content-Encoding']).to be_nil
+            expect(output.context.http_request.headers['Content-Encoding']).to be_nil
           end
 
           it 'compresses a streaming body regardless of minimum size' do
             client.config.request_min_compression_size_bytes = 0
             client.stub_responses(:operation, lambda do |context|
-              headers = context.request.headers
+              headers = context.http_request.headers
               expect(headers['Content-Encoding']).to eq('gzip')
               # capture the body by reading it into a new IO object
               body = StringIO.new
               # IO.copy_stream is the same method used by Net::HTTP to write our body to the socket
-              IO.copy_stream(context.request.body, body)
+              IO.copy_stream(context.http_request.body, body)
               body.rewind
               expect(Zlib::GzipReader.new(body).read).to include(large_body) # cbor
               {}

--- a/gems/smithy-client/spec/smithy-client/plugins/response_target_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/response_target_spec.rb
@@ -39,13 +39,13 @@ module Smithy
             proc = proc { |chunk| } # empty
             output = client.operation({}, target: proc)
             expected = client.config.response_body.size
-            expect(output.context.response.body.size).to eq(expected)
+            expect(output.context.http_response.body.size).to eq(expected)
           end
 
           it 'does not buffer the response chunks' do
             proc = proc { |_chunk| } # empty
             output = client.operation({}, target: proc)
-            body = output.context.response.body
+            body = output.context.http_response.body
             expect(body.read).to eq('')
             expect(body).not_to respond_to(:truncate)
           end
@@ -69,14 +69,14 @@ module Smithy
 
           it 'closes the file before returning the response' do
             output = client.operation({}, target: target)
-            expect(output.context.response.body).to be_closed
+            expect(output.context.http_response.body).to be_closed
           end
 
           it 'does not write error messages to the target' do
             error = StandardError.new('error')
             client = client_class.new(response_error: error)
             output = client.operation({}, target: target)
-            expect(output.context.response.body.read).to eq('')
+            expect(output.context.http_response.body.read).to eq('')
             expect { File.unlink(@tempfile.path) }.to raise_error(Errno::ENOENT)
           end
         end
@@ -92,14 +92,14 @@ module Smithy
 
           it 'closes the file before returning the response' do
             output = client.operation({}, target: target)
-            expect(output.context.response.body).to be_closed
+            expect(output.context.http_response.body).to be_closed
           end
 
           it 'does not write error messages to the target' do
             error = StandardError.new('error')
             client = client_class.new(response_error: error)
             output = client.operation({}, target: target)
-            expect(output.context.response.body.read).to eq('')
+            expect(output.context.http_response.body.read).to eq('')
             expect { File.unlink(@tempfile.path) }.to raise_error(Errno::ENOENT)
           end
         end

--- a/gems/smithy-client/spec/smithy-client/plugins/stub_responses_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/stub_responses_spec.rb
@@ -56,13 +56,13 @@ module Smithy
 
         it 'defaults the endpoint using the stubbing endpoint provider' do
           output = client.operation
-          expect(output.context.request.endpoint.host).to eq('stubbed-endpoint')
+          expect(output.context.http_request.endpoint.host).to eq('stubbed-endpoint')
         end
 
         it 'allows for passed in endpoints using the stubbing endpoint provider' do
           client = client_class.new(stub_responses: true, endpoint: 'https://example.com')
           output = client.operation
-          expect(output.context.request.endpoint.host).to eq('example.com')
+          expect(output.context.http_request.endpoint.host).to eq('example.com')
         end
 
         it 'signals error for exceptions' do
@@ -188,9 +188,9 @@ module Smithy
             body = Smithy::CBOR.encode({ 'string' => 'value' })
             client.stub_responses(:operation, { status_code: 200, headers: headers, body: body })
             output = client.operation
-            expect(output.context.response.status_code).to eq(200)
-            expect(output.context.response.headers.to_h).to eq(headers)
-            expect(output.context.response.body.string).to eq(body.force_encoding('UTF-8'))
+            expect(output.context.http_response.status_code).to eq(200)
+            expect(output.context.http_response.headers.to_h).to eq(headers)
+            expect(output.context.http_response.body.string).to eq(body.force_encoding('UTF-8'))
           end
 
           it 'can stub data' do

--- a/gems/smithy-client/spec/spec_helper.rb
+++ b/gems/smithy-client/spec/spec_helper.rb
@@ -17,7 +17,7 @@ require_relative 'support/client_helper'
 class DummySendPlugin < Smithy::Client::Plugin
   class Handler < Smithy::Client::Handler
     def call(context)
-      response = context.response
+      response = context.http_response
       config = context.config
 
       response.signal_headers(config.response_status_code, config.response_headers)

--- a/gems/smithy-client/spec/support/retry_errors_helper.rb
+++ b/gems/smithy-client/spec/support/retry_errors_helper.rb
@@ -75,7 +75,7 @@ end
 # See handle_with_retry for test case definition
 def setup_next_response(test_case)
   response = test_case[:response]
-  output.context.response.status_code = response[:status_code]
+  output.context.http_response.status_code = response[:status_code]
   output.error = response[:error]
 
   allow(Process).to receive(:clock_gettime).and_return(response[:timestamp]) if response[:timestamp]

--- a/gems/smithy/lib/smithy/templates/client/endpoint_plugin.erb
+++ b/gems/smithy/lib/smithy/templates/client/endpoint_plugin.erb
@@ -35,7 +35,7 @@ module <%= module_name %>
           params = EndpointParameters.create(context)
           endpoint = context.config.endpoint_provider.resolve(params)\
 
-          context.request.endpoint = endpoint.uri
+          context.http_request.endpoint = endpoint.uri
           apply_endpoint_headers(context, endpoint.headers)
 
           context[:endpoint_params] = params
@@ -47,7 +47,7 @@ module <%= module_name %>
 
         def apply_endpoint_headers(context, headers)
           headers.each do |key, value|
-            context.request.headers[key] = value
+            context.http_request.headers[key] = value
           end
         end
       end

--- a/gems/smithy/lib/smithy/templates/client/endpoint_provider_spec.erb
+++ b/gems/smithy/lib/smithy/templates/client/endpoint_provider_spec.erb
@@ -52,12 +52,12 @@ module <%= module_name %>
 <% end -%>
           )
         expected_uri = URI.parse(expected['endpoint']['url'])
-        expect(output.context.request.endpoint.to_s).to include(expected_uri.host)
-        expect(output.context.request.endpoint.to_s).to include(expected_uri.scheme)
-        expect(output.context.request.endpoint.to_s).to include(expected_uri.path)
+        expect(output.context.http_request.endpoint.to_s).to include(expected_uri.host)
+        expect(output.context.http_request.endpoint.to_s).to include(expected_uri.scheme)
+        expect(output.context.http_request.endpoint.to_s).to include(expected_uri.path)
 
         expected['endpoint'].fetch('headers', {}).each do |k,v|
-          expect(resp.context.request.headers[k]).to eq(v)
+          expect(resp.context.http_request.headers[k]).to eq(v)
         end
 
         # TODO: expect auth

--- a/gems/smithy/lib/smithy/templates/client/protocol_spec.erb
+++ b/gems/smithy/lib/smithy/templates/client/protocol_spec.erb
@@ -31,7 +31,7 @@ module <%= module_name %>
           allow(SecureRandom).to receive(:uuid).and_return('00000000-0000-4000-8000-000000000000')
 <% end -%>
           output = client.<%= operation_tests.name %>(<%= test.params %>)
-          request = output.context.request
+          request = output.context.http_request
           expect(request.http_method).to eq('<%= test['method'] %>')
           expect(request.endpoint.path).to eq('<%= test['uri'] %>')
 <% if test['resolvedHost'] -%>

--- a/projections/shapes/lib/shapes/plugins/endpoint.rb
+++ b/projections/shapes/lib/shapes/plugins/endpoint.rb
@@ -27,7 +27,7 @@ module ShapeService
           params = EndpointParameters.create(context)
           endpoint = context.config.endpoint_provider.resolve(params)\
 
-          context.request.endpoint = endpoint.uri
+          context.http_request.endpoint = endpoint.uri
           apply_endpoint_headers(context, endpoint.headers)
 
           context[:endpoint_params] = params
@@ -39,7 +39,7 @@ module ShapeService
 
         def apply_endpoint_headers(context, headers)
           headers.each do |key, value|
-            context.request.headers[key] = value
+            context.http_request.headers[key] = value
           end
         end
       end

--- a/projections/weather/lib/weather/plugins/endpoint.rb
+++ b/projections/weather/lib/weather/plugins/endpoint.rb
@@ -27,7 +27,7 @@ module Weather
           params = EndpointParameters.create(context)
           endpoint = context.config.endpoint_provider.resolve(params)\
 
-          context.request.endpoint = endpoint.uri
+          context.http_request.endpoint = endpoint.uri
           apply_endpoint_headers(context, endpoint.headers)
 
           context[:endpoint_params] = params
@@ -39,7 +39,7 @@ module Weather
 
         def apply_endpoint_headers(context, headers)
           headers.each do |key, value|
-            context.request.headers[key] = value
+            context.http_request.headers[key] = value
           end
         end
       end


### PR DESCRIPTION
Rename request/response in context to http_request/response. It will be http or http2 (both are http). Other transports can have a separate accessor such as mqtt if/when that happens.