### PR TITLE
Input/Output -> Request/Response

### DIFF
--- a/gems/smithy-client/lib/smithy-client.rb
+++ b/gems/smithy-client/lib/smithy-client.rb
@@ -21,7 +21,7 @@ require_relative 'smithy-client/handler_list'
 require_relative 'smithy-client/handler_list_entry'
 require_relative 'smithy-client/managed_file'
 require_relative 'smithy-client/networking_error'
-require_relative 'smithy-client/pageable_output'
+require_relative 'smithy-client/pageable_response'
 require_relative 'smithy-client/param_converter'
 require_relative 'smithy-client/param_validator'
 require_relative 'smithy-client/plugin'
@@ -31,8 +31,8 @@ require_relative 'smithy-client/service_error'
 require_relative 'smithy-client/util'
 require_relative 'smithy-client/waiters/poller'
 require_relative 'smithy-client/waiters/waiter'
-require_relative 'smithy-client/input'
-require_relative 'smithy-client/output'
+require_relative 'smithy-client/request'
+require_relative 'smithy-client/response'
 require_relative 'smithy-client/base'
 
 # client http
@@ -52,7 +52,8 @@ require_relative 'smithy-client/identity'
 require_relative 'smithy-client/refreshing_identity_provider'
 require_relative 'smithy-client/signer'
 
-# TODO: move to another gem
+# protocols
+
 require_relative 'smithy-client/rpc_v2_cbor/protocol'
 
 # stubbing

--- a/gems/smithy-client/lib/smithy-client/base.rb
+++ b/gems/smithy-client/lib/smithy-client/base.rb
@@ -18,12 +18,11 @@ module Smithy
       # @return [HandlerList]
       attr_reader :handlers
 
-      # Builds and returns an {Input} for the named operation. The request
-      #  will not have been sent.
+      # Builds and returns a {Request} for the named operation. The request will not have been sent.
       # @param [Symbol] operation_name
-      # @return [Input]
-      def build_input(operation_name, params = {})
-        Input.new(
+      # @return [Request]
+      def build_request(operation_name, params = {})
+        Request.new(
           handlers: @handlers.for(operation_name),
           context: context_for(operation_name, params)
         )

--- a/gems/smithy-client/lib/smithy-client/handler.rb
+++ b/gems/smithy-client/lib/smithy-client/handler.rb
@@ -15,7 +15,7 @@ module Smithy
       attr_accessor :handler
 
       # @param [Smithy::Client::HandlerContext] context
-      # @return [Smithy::Client::Output]
+      # @return [Smithy::Client::Response]
       def call(context)
         @handler.call(context)
       end

--- a/gems/smithy-client/lib/smithy-client/net_http/handler.rb
+++ b/gems/smithy-client/lib/smithy-client/net_http/handler.rb
@@ -19,7 +19,7 @@ module Smithy
         # @return [Output]
         def call(context)
           transmit(context.config, context.http_request, context.http_response)
-          Output.new(context: context)
+          Response.new(context: context)
         end
 
         private

--- a/gems/smithy-client/lib/smithy-client/pageable_response.rb
+++ b/gems/smithy-client/lib/smithy-client/pageable_response.rb
@@ -2,21 +2,21 @@
 
 module Smithy
   module Client
-    # Raised when calling {PageableOutput#next_page} on a paginator that
-    # is on the last page of results. You can call {PageableOutput#last_page?}
-    # or {PageableOutput#next_page?} to know if there are more pages.
+    # Raised when calling {PageableResponse#next_page} on a paginator that
+    # is on the last page of results. You can call {PageableResponse#last_page?}
+    # or {PageableResponse#next_page?} to know if there are more pages.
     class LastPageError < RuntimeError
-      # @param [Output] output
-      def initialize(output)
-        @output = output
+      # @param [Response] response
+      def initialize(response)
+        @response = response
         super('unable to fetch next page, end of results reached')
       end
 
-      # @return [Output]
-      attr_reader :output
+      # @return [Response]
+      attr_reader :response
     end
 
-    # Decorates a {Smithy::Client::Output} with paging convenience methods.
+    # Decorates a {Smithy::Client::Response} with paging convenience methods.
     # Most API calls provide paged responses to limit the amount of data returned
     # with each response. To optimize for latency, some APIs may return an
     # inconsistent number of responses per page. You should rely on the values of
@@ -26,14 +26,14 @@ module Smithy
     #
     # # Enumerator Methods
     # The simplest way to handle paged response data is to use the built-in
-    # `each_page` enumerator on the output object:
+    # `each_page` enumerator on the response object:
     #
     #     weather = Weather::Client.new
     #     weather.list_cities.each_page do |page|
     #       puts page.items.map(&:name)
     #     end
     #
-    # This yields one output object per API call made. The SDK retrieves additional
+    # This yields one response object per API call made. The SDK retrieves additional
     # pages of data to complete the request.
     #
     # If the operation allows for it, a selected item can be enumerated using
@@ -44,8 +44,8 @@ module Smithy
     #       puts item.name
     #     end
     #
-    # # Handling Paged Output Manually
-    # To handle paging yourself, use the output's `next_page?` method to verify
+    # # Handling Paged Responses Manually
+    # To handle paging yourself, use the Response's `next_page?` method to verify
     # there are more pages to retrieve, or use the `last_page?` method to verify
     # there are no more pages to retrieve.
     #
@@ -55,16 +55,16 @@ module Smithy
     #     weather = Weather::Client.new
     #
     #     # Get the first page of data
-    #     output = weather.list_cities
+    #     response = weather.list_cities
     #
     #     # Get additional pages
-    #     while output.next_page?
-    #       output = output.next_page
+    #     while response.next_page?
+    #       response = response.next_page
     #       # Use the response data here...
-    #       puts output.items.map(&:name)
+    #       puts response.items.map(&:name)
     #     end
     #
-    module PageableOutput
+    module PageableResponse
       # @api private
       attr_accessor :paginator
 
@@ -87,7 +87,7 @@ module Smithy
       end
 
       # @param [Hash] params A hash of additional request params.
-      # @return [Output] Returns the next page of results.
+      # @return [Response] Returns the next page of results.
       def next_page(params = {})
         raise LastPageError, self if last_page?
 
@@ -95,15 +95,15 @@ module Smithy
         context.client.send(context.operation_name, params)
       end
 
-      # Yields the current and each following output to the given block.
-      # @yieldparam [Output] output
+      # Yields the current and each following response to the given block.
+      # @yieldparam [Response] response
       # @return [Enumerable, nil] Returns a new Enumerable if no block is given.
       def each_page(&)
-        output = self
-        yield(output)
-        until output.last_page?
-          output = output.next_page
-          yield(output)
+        response = self
+        yield(response)
+        until response.last_page?
+          response = response.next_page
+          yield(response)
         end
       end
 
@@ -111,11 +111,11 @@ module Smithy
       # @yieldparam [Object] item
       # @return [Enumerable, nil] Returns a new Enumerable if no block is given.
       def each_item(&)
-        output = self
-        @paginator.items(output.data).each(&)
-        until output.last_page?
-          output = output.next_page
-          @paginator.items(output.data).each(&)
+        response = self
+        @paginator.items(response.data).each(&)
+        until response.last_page?
+          response = response.next_page
+          @paginator.items(response.data).each(&)
         end
       end
 

--- a/gems/smithy-client/lib/smithy-client/plugins/pageable_response.rb
+++ b/gems/smithy-client/lib/smithy-client/plugins/pageable_response.rb
@@ -4,14 +4,14 @@ module Smithy
   module Client
     module Plugins
       # @api private
-      class PageableOutput < Plugin
+      class PageableResponse < Plugin
         # @api private
         class Handler < Client::Handler
           def call(context)
-            output = @handler.call(context)
-            output.extend(Client::PageableOutput)
-            output.paginator = context.operation[:paginator] || NullPaginator.new
-            output
+            response = @handler.call(context)
+            response.extend(Client::PageableResponse)
+            response.paginator = context.operation[:paginator] || NullPaginator.new
+            response
           end
 
           # @api private

--- a/gems/smithy-client/lib/smithy-client/plugins/protocol.rb
+++ b/gems/smithy-client/lib/smithy-client/plugins/protocol.rb
@@ -23,10 +23,10 @@ module Smithy
         # @api private
         class ParseHandler < Handler
           def call(context)
-            output = @handler.call(context)
-            output.error = context.config.protocol.parse_error(output) unless output.error
-            output.data = context.config.protocol.parse_data(output) unless output.error
-            output
+            response = @handler.call(context)
+            response.error = context.config.protocol.parse_error(response) unless response.error
+            response.data = context.config.protocol.parse_data(response) unless response.error
+            response
           end
         end
 

--- a/gems/smithy-client/lib/smithy-client/plugins/raise_response_errors.rb
+++ b/gems/smithy-client/lib/smithy-client/plugins/raise_response_errors.rb
@@ -11,16 +11,16 @@ module Smithy
           doc_type: 'Boolean',
           docstring: <<~DOCS)
             When `true`, response errors are raised. When `false`, the error is placed on the
-            output in the {Smithy::Client::Output#error error accessor}.
+            output in the {Smithy::Client::Response#error error accessor}.
           DOCS
 
         # @api private
         class Handler < Client::Handler
           def call(context)
-            output = @handler.call(context)
-            raise output.error if output.error
+            response = @handler.call(context)
+            raise response.error if response.error
 
-            output
+            response
           end
         end
 

--- a/gems/smithy-client/lib/smithy-client/plugins/retry_errors.rb
+++ b/gems/smithy-client/lib/smithy-client/plugins/retry_errors.rb
@@ -83,22 +83,22 @@ module Smithy
           private
 
           def handle(context, retry_strategy, token)
-            output = @handler.call(context)
-            if (error = output.error)
-              return output unless retryable?(context.http_request)
+            response = @handler.call(context)
+            if (error = response.error)
+              return response unless retryable?(context.http_request)
 
               error_info = HTTP::ErrorInspector.new(error, context.http_response)
               token = retry_strategy.refresh_retry_token(token, error_info)
-              return output unless token
+              return response unless token
 
               Kernel.sleep(token.retry_delay)
             else
               retry_strategy.record_success(token)
-              return output
+              return response
             end
 
             reset_request(context)
-            reset_response(context, output)
+            reset_response(context, response)
             context.retries += 1
             handle(context, retry_strategy, token)
           end
@@ -112,9 +112,9 @@ module Smithy
             context.http_request.body.rewind
           end
 
-          def reset_response(context, output)
+          def reset_response(context, response)
             context.http_response.reset
-            output.error = nil
+            response.error = nil
           end
         end
 

--- a/gems/smithy-client/lib/smithy-client/plugins/stub_responses.rb
+++ b/gems/smithy-client/lib/smithy-client/plugins/stub_responses.rb
@@ -47,40 +47,40 @@ module Smithy
         # @api private
         class StubHandler < Client::Handler
           def call(context)
-            output = Smithy::Client::Output.new(context: context)
+            response = Smithy::Client::Response.new(context: context)
             stub = context.client.next_stub(context)
-            stub[:mutex].synchronize { apply_stub(stub, output) }
-            output
+            stub[:mutex].synchronize { apply_stub(stub, response) }
+            response
           end
 
           private
 
-          def apply_stub(stub, output)
-            resp = output.context.http_response
+          def apply_stub(stub, response)
+            http_response = response.context.http_response
             if stub[:error]
-              signal_error(stub[:error], resp)
+              signal_error(stub[:error], http_response)
             elsif stub[:http]
-              signal_http(stub[:http], resp)
+              signal_http(stub[:http], http_response)
             end
           end
 
-          def signal_error(error, resp)
+          def signal_error(error, http_response)
             if error.is_a?(Exception)
-              resp.signal_error(error)
+              http_response.signal_error(error)
             else
-              resp.signal_error(error.new)
+              http_response.signal_error(error.new)
             end
           end
 
-          def signal_http(stub, resp)
-            resp.signal_headers(stub.status_code, stub.headers)
-            signal_data(stub, resp)
-            resp.signal_done
+          def signal_http(stub, http_response)
+            http_response.signal_headers(stub.status_code, stub.headers)
+            signal_data(stub, http_response)
+            http_response.signal_done
           end
 
-          def signal_data(stub, resp)
+          def signal_data(stub, http_response)
             while (chunk = stub.body.read(1024 * 1024))
-              resp.signal_data(chunk)
+              http_response.signal_data(chunk)
             end
             stub.body.rewind
           end

--- a/gems/smithy-client/lib/smithy-client/request.rb
+++ b/gems/smithy-client/lib/smithy-client/request.rb
@@ -2,8 +2,8 @@
 
 module Smithy
   module Client
-    # Represents the input to a service operation call.
-    class Input
+    # Represents a request for a service operation call.
+    class Request
       include HandlerBuilder
 
       # @option options [HandlerList] :handlers (nil)
@@ -19,9 +19,9 @@ module Smithy
       # @return [HandlerContext]
       attr_reader :context
 
-      # Sends the request, returning an {Output} object.
+      # Sends the request, returning an {Response} object.
       #
-      #     output = input.send_input
+      #     response = request.send_request
       #
       # # Streaming Responses
       #
@@ -36,11 +36,11 @@ module Smithy
       # object, by passing the `:target` option.
       #
       #     # create a new file at the given path
-      #     input.send_input(target: '/path/to/target/file')
+      #     request.send_request(target: '/path/to/target/file')
       #
       #     # or provide an IO object to write to
       #     File.open('photo.jpg', 'wb') do |file|
-      #       input.send_input(target: file)
+      #       request.send_request(target: file)
       #     end
       #
       # **Please Note**: The target IO object may receive `#truncate(0)`
@@ -49,11 +49,11 @@ module Smithy
       #
       # ## Block Streaming
       #
-      # Pass a block to `#send_input` and the response will be yielded in
+      # Pass a block to `#send_request` and the response will be yielded in
       # chunks to the given block.
       #
       #     # stream the response data
-      #     input.send_input do |chunk|
+      #     request.send_request do |chunk|
       #       file.write(chunk)
       #     end
       #
@@ -65,9 +65,9 @@ module Smithy
       #   a request that may return a large payload that you don't want to
       #   load into memory.
       #
-      # @return [Output, nil]
+      # @return [Response, nil]
       #
-      def send_input(options = {}, &block)
+      def send_request(options = {}, &block)
         @context[:response_target] = options[:target] || block
         @handlers.to_stack&.call(@context)
       end

--- a/gems/smithy-client/lib/smithy-client/response.rb
+++ b/gems/smithy-client/lib/smithy-client/response.rb
@@ -4,8 +4,8 @@ require 'delegate'
 
 module Smithy
   module Client
-    # Represents the output of a service operation call.
-    class Output < Delegator
+    # Represents the response for a service operation call.
+    class Response < Delegator
       # @option options [HandlerContext] :context (nil)
       # @option options [Structure] :data (nil)
       # @option options [StandardError] :error (nil)

--- a/gems/smithy-client/lib/smithy-client/rpc_v2_cbor/protocol.rb
+++ b/gems/smithy-client/lib/smithy-client/rpc_v2_cbor/protocol.rb
@@ -17,12 +17,12 @@ module Smithy
           RequestBuilder.new(@options).build(context)
         end
 
-        def parse_error(output)
-          ResponseParser.new(@options).parse_error(output.context)
+        def parse_error(response)
+          ResponseParser.new(@options).parse_error(response.context)
         end
 
-        def parse_data(output)
-          ResponseParser.new(@options).parse_data(output.context)
+        def parse_data(response)
+          ResponseParser.new(@options).parse_data(response.context)
         end
 
         def stub_data(service, operation, data)

--- a/gems/smithy-client/lib/smithy-client/rpc_v2_cbor/response_stubber.rb
+++ b/gems/smithy-client/lib/smithy-client/rpc_v2_cbor/response_stubber.rb
@@ -10,23 +10,23 @@ module Smithy
         end
 
         def stub_data(_service, operation, data)
-          resp = HTTP::Response.new
-          resp.status_code = 200
-          resp.headers['Smithy-Protocol'] = 'rpc-v2-cbor'
-          resp.headers['Content-Type'] = 'application/cbor'
-          resp.body = @codec.serialize(operation.output, data)
-          resp
+          response = HTTP::Response.new
+          response.status_code = 200
+          response.headers['Smithy-Protocol'] = 'rpc-v2-cbor'
+          response.headers['Content-Type'] = 'application/cbor'
+          response.body = @codec.serialize(operation.output, data)
+          response
         end
 
         def stub_error(_service, error_code)
-          resp = HTTP::Response.new
-          resp.status_code = 400
-          resp.headers['Smithy-Protocol'] = 'rpc-v2-cbor'
-          resp.headers['Content-Type'] = 'application/cbor'
-          resp.headers['X-Amzn-RequestId'] = 'stubbed-request-id'
+          response = HTTP::Response.new
+          response.status_code = 400
+          response.headers['Smithy-Protocol'] = 'rpc-v2-cbor'
+          response.headers['Content-Type'] = 'application/cbor'
+          response.headers['X-Amzn-RequestId'] = 'stubbed-request-id'
           data = { '__type' => error_code, 'message' => 'stubbed-error-message' }
-          resp.body = CBOR.encode(data)
-          resp
+          response.body = CBOR.encode(data)
+          response
         end
       end
     end

--- a/gems/smithy-client/lib/smithy-client/stubbing/protocol.rb
+++ b/gems/smithy-client/lib/smithy-client/stubbing/protocol.rb
@@ -11,17 +11,17 @@ module Smithy
         def parse_error(_output); end
 
         def stub_data(_service, _operation, data)
-          resp = HTTP::Response.new
-          resp.status_code = 200
-          resp.body = StringIO.new(data.to_json)
-          resp
+          response = HTTP::Response.new
+          response.status_code = 200
+          response.body = StringIO.new(data.to_json)
+          response
         end
 
         def stub_error(_service, error_code)
-          resp = HTTP::Response.new
-          resp.status_code = 500
-          resp.body = StringIO.new(error_code.to_json)
-          resp
+          response = HTTP::Response.new
+          response.status_code = 500
+          response.body = StringIO.new(error_code.to_json)
+          response
         end
       end
     end

--- a/gems/smithy-client/lib/smithy-client/stubs.rb
+++ b/gems/smithy-client/lib/smithy-client/stubs.rb
@@ -95,10 +95,10 @@ module Smithy
       #     client.get_city(city_id: "Winchester')
       #     #=> raises Weather::Errors::NoSuchResource
       #
-      #     output = client.get_city(city_id: "Winchester')
-      #     output.name #=> 'Winchester'
-      #     output.coordinates.latitude #=> 39.1825
-      #     output.coordinates.longitude #=> -78.1676
+      #     response = client.get_city(city_id: "Winchester')
+      #     response.name #=> 'Winchester'
+      #     response.coordinates.latitude #=> 39.1825
+      #     response.coordinates.longitude #=> -78.1676
       #
       # @param [Symbol] operation_name
       # @param [Mixed] stubs One or more responses to return from the named operation.
@@ -187,21 +187,21 @@ module Smithy
 
       def http_response_stub(operation_name, data)
         if data.is_a?(Hash) && data.keys.sort == %i[body headers status_code]
-          { http: hash_to_http_resp(data) }
+          { http: hash_to_http_response(data) }
         else
-          { http: data_to_http_resp(operation_name, data) }
+          { http: data_to_http_response(operation_name, data) }
         end
       end
 
-      def hash_to_http_resp(data)
-        http_resp = HTTP::Response.new
-        http_resp.status_code = data[:status_code]
-        http_resp.headers.update(data[:headers])
-        http_resp.body = data[:body]
-        http_resp
+      def hash_to_http_response(data)
+        http_response = HTTP::Response.new
+        http_response.status_code = data[:status_code]
+        http_response.headers.update(data[:headers])
+        http_response.body = data[:body]
+        http_response
       end
 
-      def data_to_http_resp(operation_name, data)
+      def data_to_http_response(operation_name, data)
         operation = @config.service.operation(operation_name)
         data = ParamConverter.new(operation.output).convert(data)
         ParamValidator.new(operation.output, validate_required: false).validate!(data, context: 'stub')

--- a/gems/smithy-client/lib/smithy-client/waiters/poller.rb
+++ b/gems/smithy-client/lib/smithy-client/waiters/poller.rb
@@ -13,55 +13,54 @@ module Smithy
 
         def call(client, params)
           @input = params
-          # TODO: make build_input public and update this line
-          input = client.send(:build_input, @operation_name, params)
-          input.handlers.remove(Plugins::RaiseResponseErrors::Handler)
-          output = input.send_input
-          status = evaluate_acceptors(output)
-          [output, status.to_sym]
+          request = client.build_request(@operation_name, params)
+          request.handlers.remove(Plugins::RaiseResponseErrors::Handler)
+          response = request.send_request
+          status = evaluate_acceptors(response)
+          [response, status.to_sym]
         end
 
         private
 
-        def evaluate_acceptors(output)
+        def evaluate_acceptors(response)
           @acceptors.each do |acceptor|
-            return acceptor['state'] if acceptor_matches?(acceptor['matcher'], output)
+            return acceptor['state'] if acceptor_matches?(acceptor['matcher'], response)
           end
-          output.error.nil? ? 'retry' : 'error'
+          response.error.nil? ? 'retry' : 'error'
         end
 
-        def acceptor_matches?(matcher, output)
+        def acceptor_matches?(matcher, response)
           matcher_type = matcher.keys.first
-          send("matches_#{matcher_type}?", matcher[matcher_type], output)
+          send("matches_#{matcher_type}?", matcher[matcher_type], response)
         end
 
-        def matches_output?(path_matcher, output)
-          return false if output.data.nil?
+        def matches_output?(path_matcher, response)
+          return false if response.data.nil?
 
-          actual = JMESPath.search(path_matcher['path'], output.data)
+          actual = JMESPath.search(path_matcher['path'], response.data)
           equal?(actual, path_matcher['expected'], path_matcher['comparator'])
         end
 
         # rubocop:disable Naming/MethodName
-        def matches_inputOutput?(path_matcher, output)
-          return false unless !output.data.nil? && @input
+        def matches_inputOutput?(path_matcher, response)
+          return false unless !response.data.nil? && @input
 
           data = {
             input: @input,
-            output: output.data
+            output: response.data
           }
           actual = JMESPath.search(path_matcher['path'], data)
           equal?(actual, path_matcher['expected'], path_matcher['comparator'])
         end
 
-        def matches_success?(path_matcher, output)
-          path_matcher == true ? !output.data.nil? : !output.error.nil?
+        def matches_success?(path_matcher, response)
+          path_matcher == true ? !response.data.nil? : !response.error.nil?
         end
 
-        def matches_errorType?(path_matcher, output)
-          return false if output.error.nil?
+        def matches_errorType?(path_matcher, response)
+          return false if response.error.nil?
 
-          output.error.class.to_s.end_with?("Errors::#{path_matcher}")
+          response.error.class.to_s.end_with?("Errors::#{path_matcher}")
         end
 
         def equal?(actual, expected, comparator)

--- a/gems/smithy-client/lib/smithy-client/waiters/waiter.rb
+++ b/gems/smithy-client/lib/smithy-client/waiters/waiter.rb
@@ -83,13 +83,13 @@ module Smithy
         def poll(client, params)
           attempts = 0
           loop do
-            output, status = @poller.call(client, params)
+            response, status = @poller.call(client, params)
             attempts += 1
 
             case status
             when :success then return
-            when :failure then raise FailureStateError, output.error
-            when :error then raise UnexpectedError, output.error
+            when :failure then raise FailureStateError, response.error
+            when :error then raise UnexpectedError, response.error
             when :retry
               raise MaxWaitTimeExceededError, @max_wait_time if @remaining_time.zero?
 

--- a/gems/smithy-client/sig/smithy-client/handler.rbs
+++ b/gems/smithy-client/sig/smithy-client/handler.rbs
@@ -4,7 +4,7 @@ module Smithy
       def initialize: (?Handler?) -> void
       attr_accessor handler: Handler?
 
-      def call: (HandlerContext) -> _Output[untyped]
+      def call: (HandlerContext) -> _Response[untyped]
     end
   end
 end

--- a/gems/smithy-client/sig/smithy-client/response.rbs
+++ b/gems/smithy-client/sig/smithy-client/response.rbs
@@ -1,8 +1,8 @@
 module Smithy
   module Client
     # RBS does not support Delegator.
-    # the behavior mimics `Smithy::Client::Output` as much as possible.
-    interface _Output[DATA_OR_ERROR]
+    # the behavior mimics `Smithy::Client::Response` as much as possible.
+    interface _Response[DATA_OR_ERROR]
       def context: () -> HandlerContext?
       def data: () -> DATA_OR_ERROR?
       def error: () -> DATA_OR_ERROR?

--- a/gems/smithy-client/spec/smithy-client/base_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/base_spec.rb
@@ -44,51 +44,51 @@ module Smithy
         end
       end
 
-      describe '#build_input' do
-        let(:input) { subject.build_input(:operation) }
+      describe '#build_request' do
+        let(:request) { subject.build_request(:operation) }
 
         before(:each) do
           service.add_operation(:operation, Schema::Shapes::OperationShape.new)
         end
 
-        it 'returns an Input' do
-          expect(input).to be_kind_of(Input)
+        it 'returns a Request' do
+          expect(request).to be_kind_of(Request)
         end
 
         it 'populates the handlers' do
-          expect(input.handlers.to_a).to eq(subject.handlers.to_a)
+          expect(request.handlers.to_a).to eq(subject.handlers.to_a)
         end
 
         it 'includes operation specific handlers in the handler list' do
           subject.handler(Handler, operations: [:operation])
-          input = subject.build_input(:operation)
-          expect(input.handlers.to_a).to include(Handler)
+          request = subject.build_request(:operation)
+          expect(request.handlers.to_a).to include(Handler)
         end
 
         it 'populates the handler context operation name' do
-          input = subject.build_input(:operation)
-          expect(input.context.operation_name).to eq(:operation)
+          request = subject.build_request(:operation)
+          expect(request.context.operation_name).to eq(:operation)
         end
 
         it 'defaults params to an empty hash' do
-          input = subject.build_input(:operation)
-          expect(input.context.params).to eq({})
+          request = subject.build_request(:operation)
+          expect(request.context.params).to eq({})
         end
 
         it 'populates the handler context params' do
           params = {}
-          input = subject.build_input(:operation, params)
-          expect(input.context.params).to be(params)
+          request = subject.build_request(:operation, params)
+          expect(request.context.params).to be(params)
         end
 
         it 'populates the handler context configuration' do
-          input = subject.build_input(:operation)
-          expect(input.context.config).to be(subject.config)
+          request = subject.build_request(:operation)
+          expect(request.context.config).to be(subject.config)
         end
 
         it 'raises an error for unknown operations' do
           expect do
-            subject.build_input(:foo)
+            subject.build_request(:foo)
           end.to raise_error('unknown operation :foo')
         end
       end

--- a/gems/smithy-client/spec/smithy-client/handler_builder_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/handler_builder_spec.rb
@@ -51,7 +51,7 @@ module Smithy
           end
           subject.handler(step: :send) do |context|
             called << :send
-            Output.new(context: context)
+            Response.new(context: context)
           end
           context = HandlerContext.new
           subject.handlers.to_stack.call(context)
@@ -73,12 +73,12 @@ module Smithy
           end
           subject.handler do |context|
             context[:order] << :four
-            Output.new(context: context)
+            Response.new(context: context)
           end
           context = HandlerContext.new
           context.metadata[:order] = []
-          output = subject.handlers.to_stack.call(context)
-          expect(output.context[:order]).to eq(%i[one two three four])
+          response = subject.handlers.to_stack.call(context)
+          expect(response.context[:order]).to eq(%i[one two three four])
         end
 
         it 'returns the handler class' do

--- a/gems/smithy-client/spec/smithy-client/net_http/handler_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/net_http/handler_spec.rb
@@ -33,16 +33,16 @@ module Smithy
         describe '#call' do
           let(:http_request) { context.http_request }
 
-          it 'returns an Output object from #call' do
+          it 'returns an Response object from #call' do
             stub_request(:any, endpoint)
-            output = make_request
-            expect(output).to be_kind_of(Output)
+            response = make_request
+            expect(response).to be_kind_of(Response)
           end
 
           it 'populates the #context of the returned response' do
             stub_request(:any, endpoint)
-            output = make_request
-            expect(output.context).to be(context)
+            response = make_request
+            expect(response.context).to be(context)
           end
 
           describe 'request endpoint' do
@@ -74,8 +74,8 @@ module Smithy
 
             it 'raises a helpful error if the request method is invalid' do
               http_request.http_method = 'abc'
-              output = make_request
-              expect(output.error).to be_a(ArgumentError)
+              response = make_request
+              expect(response.error).to be_a(ArgumentError)
             end
           end
 
@@ -127,14 +127,14 @@ module Smithy
           describe 'response' do
             it 'populates the status code' do
               stub_request(:any, endpoint).to_return(status: 200)
-              output = make_request
-              expect(output.context.http_response.status_code).to eq(200)
+              response = make_request
+              expect(response.context.http_response.status_code).to eq(200)
             end
 
             it 'populates the headers' do
               stub_request(:any, endpoint).to_return(headers: { 'Content-Length' => '0' })
-              output = make_request
-              expect(output.context.http_response.headers['Content-Length']).to eq('0')
+              response = make_request
+              expect(response.context.http_response.headers['Content-Length']).to eq('0')
             end
 
             it 'populates the response body' do
@@ -146,27 +146,27 @@ module Smithy
 
             it 'wraps errors with a NetworkingError' do
               stub_request(:any, endpoint).to_raise(EOFError)
-              output = make_request
-              expect(output.error).to be_a(Smithy::Client::NetworkingError)
+              response = make_request
+              expect(response.error).to be_a(Smithy::Client::NetworkingError)
             end
 
             it 'wraps errors for proxies with a NetworkingError' do
               error = Net::HTTPFatalError.new('Gateway Time-out', nil)
               stub_request(:any, endpoint).to_raise(error)
-              output = make_request
-              expect(output.error).to be_a(Smithy::Client::NetworkingError)
+              response = make_request
+              expect(response.error).to be_a(Smithy::Client::NetworkingError)
             end
 
             it 'wraps OpenSSL errors with a NetworkingError' do
               stub_request(:any, endpoint).to_raise(OpenSSL::SSL::SSLError)
-              output = make_request
-              expect(output.error).to be_a(Smithy::Client::NetworkingError)
+              response = make_request
+              expect(response.error).to be_a(Smithy::Client::NetworkingError)
             end
 
             it 'raises when content length and body length mismatch' do
               stub_request(:any, endpoint).to_return(body: 'foo', headers: { 'Content-Length' => 1 })
-              output = make_request
-              expect(output.error).to be_a(Smithy::Client::NetworkingError)
+              response = make_request
+              expect(response.error).to be_a(Smithy::Client::NetworkingError)
             end
           end
         end

--- a/gems/smithy-client/spec/smithy-client/plugins/checksum_required_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/checksum_required_spec.rb
@@ -38,8 +38,8 @@ module Smithy
           body = StringIO.new('.' * 5 * 1024 * 1024) # 5MB
           allow(body).to receive(:read).and_call_original # codec read
           allow(body).to receive(:read).with(1024 * 1024, any_args).and_call_original
-          output = client.operation(streaming_blob: body)
-          expect(output.context.http_request.headers['Content-Md5']).to eq('pAFSSYDaTfRd1BEr40kHGA==')
+          response = client.operation(streaming_blob: body)
+          expect(response.context.http_request.headers['Content-Md5']).to eq('pAFSSYDaTfRd1BEr40kHGA==')
         end
 
         it 'calculates checksums before signing' do

--- a/gems/smithy-client/spec/smithy-client/plugins/host_prefix_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/host_prefix_spec.rb
@@ -62,8 +62,8 @@ module Smithy
               'smithy.api#endpoint' => { 'hostPrefix' => 'bar.' }
             }
             client.config.endpoint = 'https://example.com'
-            output = client.operation(string: 'foo')
-            expect(output.context.http_request.endpoint.host).to eq('bar.example.com')
+            response = client.operation(string: 'foo')
+            expect(response.context.http_request.endpoint.host).to eq('bar.example.com')
           end
 
           it 'applies the host prefix with a label to the endpoint' do
@@ -71,8 +71,8 @@ module Smithy
               'smithy.api#endpoint' => { 'hostPrefix' => '{string}.bar.' }
             }
             client.config.endpoint = 'https://example.com'
-            output = client.operation(string: 'foo')
-            expect(output.context.http_request.endpoint.host).to eq('foo.bar.example.com')
+            response = client.operation(string: 'foo')
+            expect(response.context.http_request.endpoint.host).to eq('foo.bar.example.com')
           end
 
           it 'raises when the label is not a valid host label' do

--- a/gems/smithy-client/spec/smithy-client/plugins/http_api_key_auth_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/http_api_key_auth_spec.rb
@@ -67,8 +67,8 @@ module Smithy
               'name' => 'x-api-key', 'in' => 'header'
             }
 
-            output = client.operation
-            expect(output.context.http_request.headers['x-api-key']).to eq('stubbed-api-key')
+            response = client.operation
+            expect(response.context.http_request.headers['x-api-key']).to eq('stubbed-api-key')
           end
 
           it 'signs in the header with a custom scheme' do
@@ -76,8 +76,8 @@ module Smithy
               'name' => 'x-api-key', 'in' => 'header', 'scheme' => 'ApiKey'
             }
 
-            output = client.operation
-            expect(output.context.http_request.headers['x-api-key']).to eq('ApiKey stubbed-api-key')
+            response = client.operation
+            expect(response.context.http_request.headers['x-api-key']).to eq('ApiKey stubbed-api-key')
           end
 
           it 'can sign on the query string' do
@@ -85,8 +85,8 @@ module Smithy
               'name' => 'x-api-key', 'in' => 'query'
             }
 
-            output = client.operation
-            expect(output.context.http_request.endpoint.query).to include('x-api-key=stubbed-api-key')
+            response = client.operation
+            expect(response.context.http_request.endpoint.query).to include('x-api-key=stubbed-api-key')
           end
         end
       end

--- a/gems/smithy-client/spec/smithy-client/plugins/http_basic_auth_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/http_basic_auth_spec.rb
@@ -85,9 +85,9 @@ module Smithy
           it 'signs in the header' do
             shapes['smithy.ruby.tests#SampleClient']['traits']['smithy.api#httpBasicAuth'] = {}
 
-            output = client.operation
+            response = client.operation
             identity_string = "#{client.config.http_login_username}:#{client.config.http_login_password}"
-            expect(output.context.http_request.headers['Authorization'])
+            expect(response.context.http_request.headers['Authorization'])
               .to eq("Basic #{Base64.strict_encode64(identity_string)}")
           end
         end

--- a/gems/smithy-client/spec/smithy-client/plugins/http_bearer_auth_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/http_bearer_auth_spec.rb
@@ -65,8 +65,8 @@ module Smithy
           it 'signs in the header' do
             shapes['smithy.ruby.tests#SampleClient']['traits']['smithy.api#httpBearerAuth'] = {}
 
-            output = client.operation
-            expect(output.context.http_request.headers['Authorization'])
+            response = client.operation
+            expect(response.context.http_request.headers['Authorization'])
               .to eq("Bearer #{client.config.http_bearer_token}")
           end
         end

--- a/gems/smithy-client/spec/smithy-client/plugins/idempotency_token_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/idempotency_token_spec.rb
@@ -36,14 +36,14 @@ module Smithy
 
         it 'applies the idempotency token to params' do
           expect(SecureRandom).to receive(:uuid).and_return('uuid')
-          output = client.operation
-          expect(output.context.params[:string]).to eq('uuid')
+          response = client.operation
+          expect(response.context.params[:string]).to eq('uuid')
         end
 
         it 'does not overwrite an existing idempotency token' do
           expect(SecureRandom).not_to receive(:uuid)
-          output = client.operation(string: 'existing_token')
-          expect(output.context.params[:string]).to eq('existing_token')
+          response = client.operation(string: 'existing_token')
+          expect(response.context.params[:string]).to eq('existing_token')
         end
 
         it 'applies the idempotency token before building the request' do

--- a/gems/smithy-client/spec/smithy-client/plugins/logging_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/logging_spec.rb
@@ -38,17 +38,17 @@ module Smithy
         end
 
         it 'logs the output to the log level' do
-          expect(logger).to receive(log_level).with(instance_of(Output))
+          expect(logger).to receive(log_level).with(instance_of(Response))
           client = client_class.new(logger: logger, log_level: log_level)
           client.operation
         end
 
         it 'sets start and end times in the context' do
           client = client_class.new(logger: logger, log_level: log_level)
-          out = client.operation
-          expect(out.context[:logging_started_at]).to be_kind_of(Time)
-          expect(out.context[:logging_completed_at]).to be_kind_of(Time)
-          expect(out.context[:logging_started_at]).to be <= out.context[:logging_completed_at]
+          response = client.operation
+          expect(response.context[:logging_started_at]).to be_kind_of(Time)
+          expect(response.context[:logging_completed_at]).to be_kind_of(Time)
+          expect(response.context[:logging_started_at]).to be <= response.context[:logging_completed_at]
         end
       end
     end

--- a/gems/smithy-client/spec/smithy-client/plugins/pageable_response_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/pageable_response_spec.rb
@@ -2,12 +2,12 @@
 
 require_relative '../../spec_helper'
 
-require 'smithy-client/plugins/pageable_output'
+require 'smithy-client/plugins/pageable_response'
 
 module Smithy
   module Client
     module Plugins
-      describe PageableOutput do
+      describe PageableResponse do
         let(:shapes) do
           {
             'smithy.ruby.tests#Example' => {
@@ -62,7 +62,7 @@ module Smithy
           client_class.clear_plugins
           client_class.add_plugin(sample_client::Plugins::Endpoint)
           client_class.add_plugin(Protocol)
-          client_class.add_plugin(PageableOutput)
+          client_class.add_plugin(PageableResponse)
           client_class.add_plugin(StubResponses)
           client_class
         end
@@ -79,11 +79,11 @@ module Smithy
             )
 
             pages = []
-            output = client.get_foos
-            pages << output
-            while output.next_page?
-              output = output.next_page
-              pages << output
+            response = client.get_foos
+            pages << response
+            while response.next_page?
+              response = response.next_page
+              pages << response
             end
             expect(pages.size).to eq 3
             expect(pages[0].foos).to eq %w[foo1 foo2]
@@ -99,15 +99,15 @@ module Smithy
               { next_token: nil, foos: ['foo4'] }
             )
 
-            output = client.get_foos
-            expect(output.next_page?).to be true
-            expect(output.last_page?).to be false
-            output = output.next_page
-            expect(output.next_page?).to be true
-            expect(output.last_page?).to be false
-            output = output.next_page
-            expect(output.next_page?).to be false
-            expect(output.last_page?).to be true
+            response = client.get_foos
+            expect(response.next_page?).to be true
+            expect(response.last_page?).to be false
+            response = response.next_page
+            expect(response.next_page?).to be true
+            expect(response.last_page?).to be false
+            response = response.next_page
+            expect(response.next_page?).to be false
+            expect(response.last_page?).to be true
           end
 
           it 'can paginate with each_page' do
@@ -181,11 +181,11 @@ module Smithy
           )
 
           pages = []
-          output = client.get_foos
-          pages << output
-          while output.next_page?
-            output = output.next_page
-            pages << output
+          response = client.get_foos
+          pages << response
+          while response.next_page?
+            response = response.next_page
+            pages << response
           end
           expect(pages.size).to eq 3
           expect(pages[0].foos).to eq %w[foo1 foo2]
@@ -252,11 +252,11 @@ module Smithy
             { next_token: nil, foos: ['foo4'] }
           )
 
-          output = client.get_foos
-          expect(output.paginator).to be_a(Smithy::Client::Plugins::PageableOutput::Handler::NullPaginator)
-          expect(output.next_page?).to be false
-          expect(output.last_page?).to be true
-          expect { output.next_page }.to raise_error(LastPageError)
+          response = client.get_foos
+          expect(response.paginator).to be_a(Smithy::Client::Plugins::PageableResponse::Handler::NullPaginator)
+          expect(response.next_page?).to be false
+          expect(response.last_page?).to be true
+          expect { response.next_page }.to raise_error(LastPageError)
         end
       end
     end

--- a/gems/smithy-client/spec/smithy-client/plugins/raise_response_errors_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/raise_response_errors_spec.rb
@@ -35,9 +35,9 @@ module Smithy
           expect(client.handlers).to include(RaiseResponseErrors::Handler)
         end
 
-        it 'returns output' do
-          output = client.operation
-          expect(output).to be_kind_of(Output)
+        it 'returns the response' do
+          response = client.operation
+          expect(response).to be_kind_of(Response)
         end
 
         it 'raises the response error when :raise_response_errors is true' do
@@ -46,14 +46,14 @@ module Smithy
           expect { client.operation }.to raise_error(error)
         end
 
-        it 'puts the error on the output when :raise_response_errors is false' do
+        it 'puts the error on the response when :raise_response_errors is false' do
           error = StandardError.new('msg')
           client = client_class.new(
             raise_response_errors: false,
             response_error: error
           )
-          output = client.operation
-          expect(output.error).to be(error)
+          response = client.operation
+          expect(response.error).to be(error)
         end
       end
     end

--- a/gems/smithy-client/spec/smithy-client/plugins/request_compression_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/request_compression_spec.rb
@@ -82,13 +82,13 @@ module Smithy
           end
 
           it 'compresses the body using gzip and sets the content-encoding header' do
-            output = client.operation(string: large_body)
-            expect(output.context.http_request.headers['Content-Encoding']).to eq('gzip')
+            response = client.operation(string: large_body)
+            expect(response.context.http_request.headers['Content-Encoding']).to eq('gzip')
           end
 
           it 'preserves the uncompressed body' do
-            output = client.operation(string: large_body)
-            uncompressed_body = Zlib::GzipReader.new(output.context.http_request.body)
+            response = client.operation(string: large_body)
+            uncompressed_body = Zlib::GzipReader.new(response.context.http_request.body)
             expect(uncompressed_body.read).to include(large_body)
           end
 
@@ -96,31 +96,31 @@ module Smithy
             shapes['smithy.ruby.tests#Operation']['traits'] = {
               'smithy.api#requestCompression' => { 'encodings' => %w[custom gzip] }
             }
-            output = client.operation(string: large_body)
-            expect(output.context.http_request.headers['Content-Encoding']).to eq('gzip')
+            response = client.operation(string: large_body)
+            expect(response.context.http_request.headers['Content-Encoding']).to eq('gzip')
           end
 
           it 'does not compress when no supported encoding is found' do
             shapes['smithy.ruby.tests#Operation']['traits'] = {
               'smithy.api#requestCompression' => { 'encodings' => ['custom'] }
             }
-            output = client.operation(string: large_body)
-            expect(output.context.http_request.headers['Content-Encoding']).to be_nil
+            response = client.operation(string: large_body)
+            expect(response.context.http_request.headers['Content-Encoding']).to be_nil
           end
 
           it 'compresses the body when the size is greater than the minimum size' do
             # input with any streaming member is always compressed regardless of min size
             shapes['smithy.ruby.tests#StreamingBlob'].delete('traits')
             client.config.request_min_compression_size_bytes = 128
-            output = client.operation(string: small_body)
-            expect(output.context.http_request.headers['Content-Encoding']).to eq('gzip')
+            response = client.operation(string: small_body)
+            expect(response.context.http_request.headers['Content-Encoding']).to eq('gzip')
           end
 
           it 'does not compress when the body is smaller than the minimum size' do
             # input with any streaming member is always compressed regardless of min size
             shapes['smithy.ruby.tests#StreamingBlob'].delete('traits')
-            output = client.operation(string: small_body)
-            expect(output.context.http_request.headers['Content-Encoding']).to be_nil
+            response = client.operation(string: small_body)
+            expect(response.context.http_request.headers['Content-Encoding']).to be_nil
           end
 
           it 'compresses a streaming body regardless of minimum size' do

--- a/gems/smithy-client/spec/smithy-client/plugins/response_target_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/response_target_spec.rb
@@ -37,15 +37,15 @@ module Smithy
 
           it 'counts the bytes yielded' do
             proc = proc { |chunk| } # empty
-            output = client.operation({}, target: proc)
+            response = client.operation({}, target: proc)
             expected = client.config.response_body.size
-            expect(output.context.http_response.body.size).to eq(expected)
+            expect(response.context.http_response.body.size).to eq(expected)
           end
 
           it 'does not buffer the response chunks' do
             proc = proc { |_chunk| } # empty
-            output = client.operation({}, target: proc)
-            body = output.context.http_response.body
+            response = client.operation({}, target: proc)
+            body = response.context.http_response.body
             expect(body.read).to eq('')
             expect(body).not_to respond_to(:truncate)
           end
@@ -68,15 +68,15 @@ module Smithy
           end
 
           it 'closes the file before returning the response' do
-            output = client.operation({}, target: target)
-            expect(output.context.http_response.body).to be_closed
+            response = client.operation({}, target: target)
+            expect(response.context.http_response.body).to be_closed
           end
 
           it 'does not write error messages to the target' do
             error = StandardError.new('error')
             client = client_class.new(response_error: error)
-            output = client.operation({}, target: target)
-            expect(output.context.http_response.body.read).to eq('')
+            response = client.operation({}, target: target)
+            expect(response.context.http_response.body.read).to eq('')
             expect { File.unlink(@tempfile.path) }.to raise_error(Errno::ENOENT)
           end
         end
@@ -91,15 +91,15 @@ module Smithy
           end
 
           it 'closes the file before returning the response' do
-            output = client.operation({}, target: target)
-            expect(output.context.http_response.body).to be_closed
+            response = client.operation({}, target: target)
+            expect(response.context.http_response.body).to be_closed
           end
 
           it 'does not write error messages to the target' do
             error = StandardError.new('error')
             client = client_class.new(response_error: error)
-            output = client.operation({}, target: target)
-            expect(output.context.http_response.body.read).to eq('')
+            response = client.operation({}, target: target)
+            expect(response.context.http_response.body.read).to eq('')
             expect { File.unlink(@tempfile.path) }.to raise_error(Errno::ENOENT)
           end
         end

--- a/gems/smithy-client/spec/smithy-client/plugins/retry_errors_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/retry_errors_spec.rb
@@ -99,7 +99,7 @@ module Smithy
             config.build!
           end
 
-          let(:output) { Output.new(context: HandlerContext.new(config: config)) }
+          let(:response) { Response.new(context: HandlerContext.new(config: config)) }
           let(:service_error) { ServiceError.new(nil, nil, nil) }
 
           let(:retry_strategy) { config.retry_strategy }

--- a/gems/smithy-client/spec/smithy-client/plugins/stub_responses_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/stub_responses_spec.rb
@@ -55,14 +55,14 @@ module Smithy
         end
 
         it 'defaults the endpoint using the stubbing endpoint provider' do
-          output = client.operation
-          expect(output.context.http_request.endpoint.host).to eq('stubbed-endpoint')
+          response = client.operation
+          expect(response.context.http_request.endpoint.host).to eq('stubbed-endpoint')
         end
 
         it 'allows for passed in endpoints using the stubbing endpoint provider' do
           client = client_class.new(stub_responses: true, endpoint: 'https://example.com')
-          output = client.operation
-          expect(output.context.http_request.endpoint.host).to eq('example.com')
+          response = client.operation
+          expect(response.context.http_request.endpoint.host).to eq('example.com')
         end
 
         it 'signals error for exceptions' do
@@ -95,11 +95,11 @@ module Smithy
 
         it 'tracks an api request for each stubbed response' do
           client.stub_responses(:operation, { string: 'stubbed-data' })
-          output1 = client.operation
-          output2 = client.operation
+          response1 = client.operation
+          response2 = client.operation
           expect(client.config.api_requests.size).to eq(2)
-          expect(client.config.api_requests.first).to be(output1.context)
-          expect(client.config.api_requests.last).to be(output2.context)
+          expect(client.config.api_requests.first).to be(response1.context)
+          expect(client.config.api_requests.last).to be(response2.context)
         end
 
         context 'response stubbing' do
@@ -136,8 +136,8 @@ module Smithy
 
           it 'returns the correct type' do
             client.stub_responses(:operation)
-            output = client.operation
-            expect(output.data).to be_a(sample_client::Types::OperationOutput)
+            response = client.operation
+            expect(response.data).to be_a(sample_client::Types::OperationOutput)
           end
 
           it 'validates stubs at request time' do
@@ -149,22 +149,22 @@ module Smithy
 
           it 'can stub default data' do
             client.stub_responses(:operation)
-            output = client.operation
-            expect(output.data.to_h).to include(default_stub_data)
-            expect(output.data.structure.to_h).to include(default_stub_data)
+            response = client.operation
+            expect(response.data.to_h).to include(default_stub_data)
+            expect(response.data.structure.to_h).to include(default_stub_data)
           end
 
           it 'can stub procs' do
             client.stub_responses(:operation, ->(ctx) { { string: ctx.params[:string] } })
-            output = client.operation(string: 'new string')
-            expect(output.data.string).to eq('new string')
+            response = client.operation(string: 'new string')
+            expect(response.data.string).to eq('new string')
           end
 
           it 'can stub nested procs' do
             proc = ->(ctx2) { { string: ctx2.params[:string] } }
             client.stub_responses(:operation, ->(_ctx1) { proc })
-            output = client.operation(string: 'new string')
-            expect(output.data.string).to eq('new string')
+            response = client.operation(string: 'new string')
+            expect(response.data.string).to eq('new string')
           end
 
           it 'can stub exceptions' do
@@ -187,24 +187,24 @@ module Smithy
             headers = { 'header' => 'value' }
             body = Smithy::CBOR.encode({ 'string' => 'value' })
             client.stub_responses(:operation, { status_code: 200, headers: headers, body: body })
-            output = client.operation
-            expect(output.context.http_response.status_code).to eq(200)
-            expect(output.context.http_response.headers.to_h).to eq(headers)
-            expect(output.context.http_response.body.string).to eq(body.force_encoding('UTF-8'))
+            response = client.operation
+            expect(response.context.http_response.status_code).to eq(200)
+            expect(response.context.http_response.headers.to_h).to eq(headers)
+            expect(response.context.http_response.body.string).to eq(body.force_encoding('UTF-8'))
           end
 
           it 'can stub data' do
             data = { string: 'new string' }
             client.stub_responses(:operation, data)
-            output = client.operation
-            expect(output.data.string).to eq('new string')
+            response = client.operation
+            expect(response.data.string).to eq('new string')
           end
 
           it 'does not set defaults when stubbed data is provided' do
             data = { string: 'new string' }
             client.stub_responses(:operation, data)
-            output = client.operation
-            expect(output.data).not_to include(default_stub_data.except(:string))
+            response = client.operation
+            expect(response.data).not_to include(default_stub_data.except(:string))
           end
 
           it 'can stub multiple responses' do

--- a/gems/smithy-client/spec/smithy-client/request_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/request_spec.rb
@@ -6,11 +6,11 @@ require 'tempfile'
 
 module Smithy
   module Client
-    describe Input do
+    describe Request do
       let(:handlers) { HandlerList.new }
       let(:context) { HandlerContext.new }
 
-      subject { Input.new(handlers: handlers, context: context) }
+      subject { Request.new(handlers: handlers, context: context) }
 
       it 'is a HandlerBuilder' do
         expect(subject).to be_kind_of(HandlerBuilder)
@@ -18,11 +18,11 @@ module Smithy
 
       describe '#initialize' do
         it 'defaults handlers to an empty HandlerList' do
-          expect(Input.new.handlers).to be_kind_of(HandlerList)
+          expect(Request.new.handlers).to be_kind_of(HandlerList)
         end
 
         it 'defaults context to a new HandlerContext' do
-          expect(Input.new.context).to be_kind_of(HandlerContext)
+          expect(Request.new.context).to be_kind_of(HandlerContext)
         end
       end
 
@@ -38,36 +38,36 @@ module Smithy
         end
       end
 
-      describe '#send_input' do
+      describe '#send_request' do
         it 'constructs a stack from the handler list' do
           expect(handlers).to receive(:to_stack).and_return(->(context) {})
-          subject.send_input
+          subject.send_request
         end
 
-        it 'returns the output from the handler stack #call method' do
-          output = double('output')
-          allow(handlers).to receive(:to_stack).and_return(->(_) { output })
-          expect(subject.send_input).to be(output)
+        it 'returns the response from the handler stack #call method' do
+          response = double('response')
+          allow(handlers).to receive(:to_stack).and_return(->(_) { response })
+          expect(subject.send_request).to be(response)
         end
 
         it 'passes the handler context to the handler stack' do
           passed = nil
           allow(handlers).to receive(:to_stack)
             .and_return(->(context) { passed = context })
-          subject.send_input
+          subject.send_request
           expect(passed).to be(context)
         end
 
         it 'can set a response target with the target option' do
           target = double('target')
           expect(context).to receive(:[]=).with(:response_target, target)
-          subject.send_input(target: target)
+          subject.send_request(target: target)
         end
 
         it 'can set a response target with a block' do
           target = proc {}
           expect(context).to receive(:[]=).with(:response_target, target)
-          subject.send_input(&target)
+          subject.send_request(&target)
         end
       end
     end

--- a/gems/smithy-client/spec/smithy-client/response_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/response_spec.rb
@@ -4,9 +4,7 @@ require_relative '../spec_helper'
 
 module Smithy
   module Client
-    describe Output do
-      subject { Output.new }
-
+    describe Response do
       it 'is a Delegator' do
         expect(subject).to be_kind_of(Delegator)
       end
@@ -51,7 +49,7 @@ module Smithy
 
       describe '#initialize' do
         it 'defaults the context to a new HandlerContext' do
-          expect(Output.new.context).to be_kind_of(HandlerContext)
+          expect(Response.new.context).to be_kind_of(HandlerContext)
         end
       end
 
@@ -74,8 +72,8 @@ module Smithy
       describe '#context' do
         it 'returns the context' do
           context = HandlerContext.new
-          output = Output.new(context: context)
-          expect(output.context).to be(context)
+          response = Response.new(context: context)
+          expect(response.context).to be(context)
         end
       end
     end

--- a/gems/smithy-client/spec/spec_helper.rb
+++ b/gems/smithy-client/spec/spec_helper.rb
@@ -27,7 +27,7 @@ class DummySendPlugin < Smithy::Client::Plugin
         response.signal_data(config.response_body)
       end
       response.signal_done
-      Smithy::Client::Output.new(context: context)
+      Smithy::Client::Response.new(context: context)
     end
   end
 

--- a/gems/smithy-client/spec/support/retry_errors_helper.rb
+++ b/gems/smithy-client/spec/support/retry_errors_helper.rb
@@ -5,7 +5,7 @@
 def handle(send_handler = nil, &block)
   allow(Kernel).to receive(:sleep)
   subject.handler = send_handler || block
-  subject.call(output.context)
+  subject.call(response.context)
 end
 
 # A helper method to test Standard and Adaptive tests
@@ -21,7 +21,7 @@ def handle_with_retry(test_cases)
     setup_next_response(test_cases[i])
 
     i += 1
-    output
+    response
   end
 
   expect(i).to(
@@ -35,7 +35,7 @@ end
 
 # Reset the request context for a subsequent call
 def reset_request
-  output.context.retries = 0
+  response.context.retries = 0
 end
 
 # apply a delay to the current test case
@@ -56,7 +56,7 @@ def apply_expectations(test_case)
       .to eq(expected[:available_capacity])
   end
 
-  expect(output.context.retries).to eq(expected[:retries]) if expected[:retries]
+  expect(response.context.retries).to eq(expected[:retries]) if expected[:retries]
 
   if expected[:calculated_rate]
     expect(client_rate_limiter.instance_variable_get(:@calculated_rate))
@@ -74,9 +74,9 @@ end
 
 # See handle_with_retry for test case definition
 def setup_next_response(test_case)
-  response = test_case[:response]
-  output.context.http_response.status_code = response[:status_code]
-  output.error = response[:error]
+  next_response = test_case[:response]
+  response.context.http_response.status_code = next_response[:status_code]
+  response.error = next_response[:error]
 
-  allow(Process).to receive(:clock_gettime).and_return(response[:timestamp]) if response[:timestamp]
+  allow(Process).to receive(:clock_gettime).and_return(next_response[:timestamp]) if next_response[:timestamp]
 end

--- a/gems/smithy/lib/smithy/templates/client/client.erb
+++ b/gems/smithy/lib/smithy/templates/client/client.erb
@@ -31,8 +31,8 @@ module <%= module_name %>
     # <%= docstring %>
 <% end -%>
     def <%= operation.method_name %>(params = {}, options = {})
-      input = build_input(:<%= operation.method_name %>, params)
-      input.send_input(options)
+      request = build_request(:<%= operation.method_name %>, params)
+      request.send_request(options)
     end
 
 <% end -%>
@@ -101,21 +101,22 @@ module <%= module_name %>
       waiter(waiter_name, options).wait(params)
     end
 
-    private
-
-    def build_input(operation_name, params)
+    # @api private
+    def build_request(operation_name, params)
       handlers = @handlers.for(operation_name)
       context = Smithy::Client::HandlerContext.new(
         operation_name: operation_name,
         operation: config.service.operation(operation_name),
         client: self,
-        params: params,
         config: config,
+        params: params
       )
       context[:gem_name] = '<%= gem_name %>'
       context[:gem_version] = '<%= gem_version %>'
-      Smithy::Client::Input.new(handlers: handlers, context: context)
+      Smithy::Client::Request.new(handlers: handlers, context: context)
     end
+
+    private
 
     def waiters
 <% waiters.each do |line| -%>

--- a/gems/smithy/lib/smithy/templates/client/client_rbs.erb
+++ b/gems/smithy/lib/smithy/templates/client/client_rbs.erb
@@ -10,7 +10,7 @@ module <%= module_name %>
 <% operations.each do |operation| -%>
 
     interface <%= operation.response_interface %>
-      include Smithy::Client::_Output[<%= operation.output.type %>]
+      include Smithy::Client::_Response[<%= operation.output.type %>]
 <% operation.output.member_types.each do |name, type| -%>
       def <%= name %>: () -> <%= type %>?
 <% end -%>

--- a/gems/smithy/lib/smithy/templates/client/endpoint_provider_spec.erb
+++ b/gems/smithy/lib/smithy/templates/client/endpoint_provider_spec.erb
@@ -46,18 +46,18 @@ module <%= module_name %>
           )
         end.to raise_error(ArgumentError, expected['error'])
 <% else -%>
-          output = client.<%= operation_input.operation_name %>(
+          response = client.<%= operation_input.operation_name %>(
 <% operation_input.operation_params.each do |p| -%>
             <%= p.param %>: <%= p.value %>,
 <% end -%>
           )
         expected_uri = URI.parse(expected['endpoint']['url'])
-        expect(output.context.http_request.endpoint.to_s).to include(expected_uri.host)
-        expect(output.context.http_request.endpoint.to_s).to include(expected_uri.scheme)
-        expect(output.context.http_request.endpoint.to_s).to include(expected_uri.path)
+        expect(response.context.http_request.endpoint.to_s).to include(expected_uri.host)
+        expect(response.context.http_request.endpoint.to_s).to include(expected_uri.scheme)
+        expect(response.context.http_request.endpoint.to_s).to include(expected_uri.path)
 
         expected['endpoint'].fetch('headers', {}).each do |k,v|
-          expect(resp.context.http_request.headers[k]).to eq(v)
+          expect(response.context.http_request.headers[k]).to eq(v)
         end
 
         # TODO: expect auth

--- a/gems/smithy/lib/smithy/templates/client/protocol_spec.erb
+++ b/gems/smithy/lib/smithy/templates/client/protocol_spec.erb
@@ -30,8 +30,8 @@ module <%= module_name %>
 <% if test.idempotency_token_trait? -%>
           allow(SecureRandom).to receive(:uuid).and_return('00000000-0000-4000-8000-000000000000')
 <% end -%>
-          output = client.<%= operation_tests.name %>(<%= test.params %>)
-          request = output.context.http_request
+          response = client.<%= operation_tests.name %>(<%= test.params %>)
+          request = response.context.http_request
           expect(request.http_method).to eq('<%= test['method'] %>')
           expect(request.endpoint.path).to eq('<%= test['uri'] %>')
 <% if test['resolvedHost'] -%>
@@ -96,11 +96,11 @@ module <%= module_name %>
           response[:body] = nil
 <% end -%>
           client.stub_responses(:<%= operation_tests.name %>, response)
-          output = client.<%= operation_tests.name %>(<%= test.params %>)
+          response = client.<%= operation_tests.name %>(<%= test.params %>)
 <% if (member_name, _shape = test.streaming_member) -%>
-          output.data.<%= member_name.underscore %>.rewind
-          output.data.<%= member_name.underscore %> = output.data.<%= member_name.underscore %>.read
-          output.data.<%= member_name.underscore %> = nil if output.data.<%= member_name.underscore %>.empty?
+          response.data.<%= member_name.underscore %>.rewind
+          response.data.<%= member_name.underscore %> = response.data.<%= member_name.underscore %>.read
+          response.data.<%= member_name.underscore %> = nil if response.data.<%= member_name.underscore %>.empty?
 <% end -%>
           <%= test.data_expect %>
         end

--- a/gems/smithy/lib/smithy/views/client/operation_examples.rb
+++ b/gems/smithy/lib/smithy/views/client/operation_examples.rb
@@ -42,8 +42,8 @@ module Smithy
               #{documentation(example)}
               params = #{params(example['input'], @operation['input']['target'])}
               options = {}
-              output = client.#{@operation_name}(params, options)
-              output.to_h #=>
+              response = client.#{@operation_name}(params, options)
+              response.to_h #=>
               #{params(example['output'], @operation['output']['target'])}
           EXAMPLE
         end
@@ -56,7 +56,7 @@ module Smithy
               params = #{params(example['input'], @operation['input']['target'])}
               options = {}
               begin
-                output = client.#{@operation_name}(params, options)
+                response = client.#{@operation_name}(params, options)
               rescue Smithy::Client::ServiceError => e
                 puts e.class #=> #{Model::Shape.name(error['shapeId'])}
                 puts e.data.to_h #=>

--- a/gems/smithy/lib/smithy/views/client/protocol_spec.rb
+++ b/gems/smithy/lib/smithy/views/client/protocol_spec.rb
@@ -217,7 +217,7 @@ module Smithy
 
           def data_expect
             output = ShapeToHash.transform_value(@model, test_case.fetch('params', {}), @output_shape)
-            "expect(output.data.to_h).to match_data(#{output})"
+            "expect(response.data.to_h).to match_data(#{output})"
           end
 
           def streaming_member

--- a/gems/smithy/lib/smithy/views/client/request_response_example.rb
+++ b/gems/smithy/lib/smithy/views/client/request_response_example.rb
@@ -19,9 +19,9 @@ module Smithy
             @example Request syntax with placeholder values
               params = #{request_params}
               options = {}
-              output = client.#{@operation_name}(params, options)
+              response = client.#{@operation_name}(params, options)
             @example Response structure with placeholder values
-              output.to_h #=>
+              response.to_h #=>
               #{response_hash}
           EXAMPLE
           example.split("\n")

--- a/gems/smithy/lib/smithy/welds/plugins.rb
+++ b/gems/smithy/lib/smithy/welds/plugins.rb
@@ -7,7 +7,7 @@ require 'smithy-client/plugins/host_prefix'
 require 'smithy-client/plugins/idempotency_token'
 require 'smithy-client/plugins/logging'
 require 'smithy-client/plugins/net_http'
-require 'smithy-client/plugins/pageable_output'
+require 'smithy-client/plugins/pageable_response'
 require 'smithy-client/plugins/param_converter'
 require 'smithy-client/plugins/param_validator'
 require 'smithy-client/plugins/protocol'
@@ -37,7 +37,7 @@ module Smithy
           Smithy::Client::Plugins::IdempotencyToken => { require_path: "#{base_path}/idempotency_token" },
           Smithy::Client::Plugins::Logging => { require_path: "#{base_path}/logging" },
           Smithy::Client::Plugins::NetHTTP => { require_path: "#{base_path}/net_http" },
-          Smithy::Client::Plugins::PageableOutput => { require_path: "#{base_path}/pageable_output" },
+          Smithy::Client::Plugins::PageableResponse => { require_path: "#{base_path}/pageable_response" },
           Smithy::Client::Plugins::ParamConverter => { require_path: "#{base_path}/param_converter" },
           Smithy::Client::Plugins::ParamValidator => { require_path: "#{base_path}/param_validator" },
           Smithy::Client::Plugins::Protocol => { require_path: "#{base_path}/protocol" },

--- a/gems/smithy/spec/interfaces/client/client_spec.rb
+++ b/gems/smithy/spec/interfaces/client/client_spec.rb
@@ -20,16 +20,15 @@ describe 'Client: Client' do
       end
 
       it 'builds and sends a request when it receives a request method' do
-        input = subject.send(:build_input, :get_city, { id: '1' })
-        expect(subject).to receive(:build_input).with(:get_city, { city_id: '1' }).and_return(input)
-        expect(input).to receive(:send_input)
+        expect(subject).to receive(:build_request).with(:get_city, { city_id: '1' }).and_call_original
+        expect_any_instance_of(Smithy::Client::Request).to receive(:send_request).and_call_original
         subject.get_city(city_id: '1')
       end
 
       # it 'passes block arguments to the request method' do
       #   input = subject.send(:build_input, :get_city, { id: '1' })
       #   expect(subject).to receive(:build_input).with(:get_city, { city_id: '1' }).and_return(input)
-      #   allow(input).to receive(:send_input)
+      #   allow(input).to receive(:send_request)
       #     .and_yield('chunk1')
       #     .and_yield('chunk2')
       #     .and_yield('chunk3')
@@ -135,8 +134,8 @@ describe 'Client: Client' do
             }
           }
           options = {}
-          output = client.operation(params, options)
-          output.to_h #=>
+          response = client.operation(params, options)
+          response.to_h #=>
           {
             string: "output",
             structure: {
@@ -173,7 +172,7 @@ describe 'Client: Client' do
           }
           options = {}
           begin
-            output = client.operation(params, options)
+            response = client.operation(params, options)
           rescue Smithy::Client::ServiceError => e
             puts e.class #=> Error
             puts e.data.to_h #=>
@@ -250,9 +249,9 @@ describe 'Client: Client' do
             }
           }
           options = {}
-          output = client.operation(params, options)
+          response = client.operation(params, options)
         @example Response structure with placeholder values
-          output.to_h #=>
+          response.to_h #=>
           {
             blob: "data",
             streaming_blob: File.read("source_file"), # required
@@ -328,9 +327,9 @@ describe 'Client: Client' do
               }
             }
             options = {}
-            output = client.operation(params, options)
+            response = client.operation(params, options)
           @example Response structure with placeholder values
-            output.to_h #=>
+            response.to_h #=>
             {
               structure: {
                 structure: {

--- a/gems/smithy/spec/interfaces/client/endpoint_provider_spec.rb
+++ b/gems/smithy/spec/interfaces/client/endpoint_provider_spec.rb
@@ -15,9 +15,9 @@ describe 'Client: EndpointProvider', rbs_test: true do
         it 'resolves the endpoint' do
           params = EndpointDefaults::EndpointParameters.new(bar: 'bar', baz: 'baz')
 
-          out = subject.resolve(params)
-          expect(out).to be_a(Smithy::Client::EndpointRules::Endpoint)
-          expect(out.uri).to eq('https://example.com/baz')
+          endpoint = subject.resolve(params)
+          expect(endpoint).to be_a(Smithy::Client::EndpointRules::Endpoint)
+          expect(endpoint.uri).to eq('https://example.com/baz')
         end
 
         it 'raises errors from rules' do

--- a/projections/shapes/lib/shapes/client.rb
+++ b/projections/shapes/lib/shapes/client.rb
@@ -40,7 +40,7 @@ module ShapeService
     add_plugin(Smithy::Client::Plugins::IdempotencyToken)
     add_plugin(Smithy::Client::Plugins::Logging)
     add_plugin(Smithy::Client::Plugins::NetHTTP)
-    add_plugin(Smithy::Client::Plugins::PageableOutput)
+    add_plugin(Smithy::Client::Plugins::PageableResponse)
     add_plugin(Smithy::Client::Plugins::ParamConverter)
     add_plugin(Smithy::Client::Plugins::ParamValidator)
     add_plugin(Smithy::Client::Plugins::Protocol)
@@ -262,8 +262,8 @@ module ShapeService
     #   }
     # @return [Types::OperationOutput]
     def operation(params = {}, options = {})
-      input = build_input(:operation, params)
-      input.send_request(options)
+      request = build_request(:operation, params)
+      request.send_request(options)
     end
 
     # Polls an API operation until a resource enters a desired state.
@@ -331,21 +331,22 @@ module ShapeService
       waiter(waiter_name, options).wait(params)
     end
 
-    private
-
-    def build_input(operation_name, params)
+    # @api private
+    def build_request(operation_name, params)
       handlers = @handlers.for(operation_name)
       context = Smithy::Client::HandlerContext.new(
         operation_name: operation_name,
         operation: config.service.operation(operation_name),
         client: self,
-        params: params,
         config: config,
+        params: params
       )
       context[:gem_name] = 'shapes'
       context[:gem_version] = '1.0.0'
       Smithy::Client::Request.new(handlers: handlers, context: context)
     end
+
+    private
 
     def waiters
       {}

--- a/projections/shapes/lib/shapes/client.rb
+++ b/projections/shapes/lib/shapes/client.rb
@@ -11,7 +11,7 @@ require 'smithy-client/plugins/host_prefix'
 require 'smithy-client/plugins/idempotency_token'
 require 'smithy-client/plugins/logging'
 require 'smithy-client/plugins/net_http'
-require 'smithy-client/plugins/pageable_output'
+require 'smithy-client/plugins/pageable_response'
 require 'smithy-client/plugins/param_converter'
 require 'smithy-client/plugins/param_validator'
 require 'smithy-client/plugins/protocol'
@@ -136,7 +136,7 @@ module ShapeService
     #  The protocol to use for request serialization and response deserialization.
     # @option options [Boolean] :raise_response_errors (true)
     #  When `true`, response errors are raised. When `false`, the error is placed on the
-    #  output in the {Smithy::Client::Output#error error accessor}.
+    #  output in the {Smithy::Client::Response#error error accessor}.
     # @option options [Integer] :request_min_compression_size_bytes (10240)
     #  The minimum size in bytes that triggers compression for request bodies.
     #  The value must be non-negative integer value between 0 and 10,485,780 bytes inclusive.
@@ -224,9 +224,9 @@ module ShapeService
     #     }
     #   }
     #   options = {}
-    #   output = client.operation(params, options)
+    #   response = client.operation(params, options)
     # @example Response structure with placeholder values
-    #   output.to_h #=>
+    #   response.to_h #=>
     #   {
     #     blob: "data",
     #     boolean: false,
@@ -263,7 +263,7 @@ module ShapeService
     # @return [Types::OperationOutput]
     def operation(params = {}, options = {})
       input = build_input(:operation, params)
-      input.send_input(options)
+      input.send_request(options)
     end
 
     # Polls an API operation until a resource enters a desired state.
@@ -344,7 +344,7 @@ module ShapeService
       )
       context[:gem_name] = 'shapes'
       context[:gem_version] = '1.0.0'
-      Smithy::Client::Input.new(handlers: handlers, context: context)
+      Smithy::Client::Request.new(handlers: handlers, context: context)
     end
 
     def waiters

--- a/projections/shapes/sig/shapes/client.rbs
+++ b/projections/shapes/sig/shapes/client.rbs
@@ -38,7 +38,7 @@ module ShapeService
     ) -> void | (?Hash[Symbol, untyped]) -> void
 
     interface _OperationResponse
-      include Smithy::Client::_Output[Types::OperationOutput]
+      include Smithy::Client::_Response[Types::OperationOutput]
       def blob: () -> String?
       def boolean: () -> bool?
       def string: () -> String?

--- a/projections/weather/lib/weather/client.rb
+++ b/projections/weather/lib/weather/client.rb
@@ -11,7 +11,7 @@ require 'smithy-client/plugins/host_prefix'
 require 'smithy-client/plugins/idempotency_token'
 require 'smithy-client/plugins/logging'
 require 'smithy-client/plugins/net_http'
-require 'smithy-client/plugins/pageable_output'
+require 'smithy-client/plugins/pageable_response'
 require 'smithy-client/plugins/param_converter'
 require 'smithy-client/plugins/param_validator'
 require 'smithy-client/plugins/protocol'
@@ -136,7 +136,7 @@ module Weather
     #  The protocol to use for request serialization and response deserialization.
     # @option options [Boolean] :raise_response_errors (true)
     #  When `true`, response errors are raised. When `false`, the error is placed on the
-    #  output in the {Smithy::Client::Output#error error accessor}.
+    #  output in the {Smithy::Client::Response#error error accessor}.
     # @option options [Integer] :request_min_compression_size_bytes (10240)
     #  The minimum size in bytes that triggers compression for request bodies.
     #  The value must be non-negative integer value between 0 and 10,485,780 bytes inclusive.
@@ -176,9 +176,9 @@ module Weather
     #     city_id: "CityId", # required
     #   }
     #   options = {}
-    #   output = client.get_city(params, options)
+    #   response = client.get_city(params, options)
     # @example Response structure with placeholder values
-    #   output.to_h #=>
+    #   response.to_h #=>
     #   {
     #     name: "String", # required
     #     coordinates: { # required
@@ -189,23 +189,23 @@ module Weather
     # @return [Types::GetCityOutput]
     def get_city(params = {}, options = {})
       input = build_input(:get_city, params)
-      input.send_input(options)
+      input.send_request(options)
     end
 
     # @param [Hash, Smithy::Schema::EmptyStructure] params
     # @example Request syntax with placeholder values
     #   params = {}
     #   options = {}
-    #   output = client.get_current_time(params, options)
+    #   response = client.get_current_time(params, options)
     # @example Response structure with placeholder values
-    #   output.to_h #=>
+    #   response.to_h #=>
     #   {
     #     time: Time.now, # required
     #   }
     # @return [Types::GetCurrentTimeOutput]
     def get_current_time(params = {}, options = {})
       input = build_input(:get_current_time, params)
-      input.send_input(options)
+      input.send_request(options)
     end
 
     # @param [Hash, Types::GetForecastInput] params
@@ -215,16 +215,16 @@ module Weather
     #     city_id: "CityId", # required
     #   }
     #   options = {}
-    #   output = client.get_forecast(params, options)
+    #   response = client.get_forecast(params, options)
     # @example Response structure with placeholder values
-    #   output.to_h #=>
+    #   response.to_h #=>
     #   {
     #     chance_of_rain: 1.0
     #   }
     # @return [Types::GetForecastOutput]
     def get_forecast(params = {}, options = {})
       input = build_input(:get_forecast, params)
-      input.send_input(options)
+      input.send_request(options)
     end
 
     # @param [Hash, Types::ListCitiesInput] params
@@ -236,9 +236,9 @@ module Weather
     #     page_size: 1
     #   }
     #   options = {}
-    #   output = client.list_cities(params, options)
+    #   response = client.list_cities(params, options)
     # @example Response structure with placeholder values
-    #   output.to_h #=>
+    #   response.to_h #=>
     #   {
     #     next_token: "String",
     #     items: [ # required
@@ -251,7 +251,7 @@ module Weather
     # @return [Types::ListCitiesOutput]
     def list_cities(params = {}, options = {})
       input = build_input(:list_cities, params)
-      input.send_input(options)
+      input.send_request(options)
     end
 
     # Polls an API operation until a resource enters a desired state.
@@ -332,7 +332,7 @@ module Weather
       )
       context[:gem_name] = 'weather'
       context[:gem_version] = '1.0.0'
-      Smithy::Client::Input.new(handlers: handlers, context: context)
+      Smithy::Client::Request.new(handlers: handlers, context: context)
     end
 
     def waiters

--- a/projections/weather/lib/weather/client.rb
+++ b/projections/weather/lib/weather/client.rb
@@ -40,7 +40,7 @@ module Weather
     add_plugin(Smithy::Client::Plugins::IdempotencyToken)
     add_plugin(Smithy::Client::Plugins::Logging)
     add_plugin(Smithy::Client::Plugins::NetHTTP)
-    add_plugin(Smithy::Client::Plugins::PageableOutput)
+    add_plugin(Smithy::Client::Plugins::PageableResponse)
     add_plugin(Smithy::Client::Plugins::ParamConverter)
     add_plugin(Smithy::Client::Plugins::ParamValidator)
     add_plugin(Smithy::Client::Plugins::Protocol)
@@ -188,8 +188,8 @@ module Weather
     #   }
     # @return [Types::GetCityOutput]
     def get_city(params = {}, options = {})
-      input = build_input(:get_city, params)
-      input.send_request(options)
+      request = build_request(:get_city, params)
+      request.send_request(options)
     end
 
     # @param [Hash, Smithy::Schema::EmptyStructure] params
@@ -204,8 +204,8 @@ module Weather
     #   }
     # @return [Types::GetCurrentTimeOutput]
     def get_current_time(params = {}, options = {})
-      input = build_input(:get_current_time, params)
-      input.send_request(options)
+      request = build_request(:get_current_time, params)
+      request.send_request(options)
     end
 
     # @param [Hash, Types::GetForecastInput] params
@@ -223,8 +223,8 @@ module Weather
     #   }
     # @return [Types::GetForecastOutput]
     def get_forecast(params = {}, options = {})
-      input = build_input(:get_forecast, params)
-      input.send_request(options)
+      request = build_request(:get_forecast, params)
+      request.send_request(options)
     end
 
     # @param [Hash, Types::ListCitiesInput] params
@@ -250,8 +250,8 @@ module Weather
     #   }
     # @return [Types::ListCitiesOutput]
     def list_cities(params = {}, options = {})
-      input = build_input(:list_cities, params)
-      input.send_request(options)
+      request = build_request(:list_cities, params)
+      request.send_request(options)
     end
 
     # Polls an API operation until a resource enters a desired state.
@@ -319,21 +319,22 @@ module Weather
       waiter(waiter_name, options).wait(params)
     end
 
-    private
-
-    def build_input(operation_name, params)
+    # @api private
+    def build_request(operation_name, params)
       handlers = @handlers.for(operation_name)
       context = Smithy::Client::HandlerContext.new(
         operation_name: operation_name,
         operation: config.service.operation(operation_name),
         client: self,
-        params: params,
         config: config,
+        params: params
       )
       context[:gem_name] = 'weather'
       context[:gem_version] = '1.0.0'
       Smithy::Client::Request.new(handlers: handlers, context: context)
     end
+
+    private
 
     def waiters
       {

--- a/projections/weather/sig/weather/client.rbs
+++ b/projections/weather/sig/weather/client.rbs
@@ -38,7 +38,7 @@ module Weather
     ) -> void | (?Hash[Symbol, untyped]) -> void
 
     interface _GetCityResponse
-      include Smithy::Client::_Output[Types::GetCityOutput]
+      include Smithy::Client::_Response[Types::GetCityOutput]
       def name: () -> String?
       def coordinates: () -> Types::CityCoordinates?
     end
@@ -47,13 +47,13 @@ module Weather
     ) -> _GetCityResponse | (?Hash[Symbol, untyped], ?Hash[Symbol, untyped]) -> _GetCityResponse
 
     interface _GetCurrentTimeResponse
-      include Smithy::Client::_Output[Types::GetCurrentTimeOutput]
+      include Smithy::Client::_Response[Types::GetCurrentTimeOutput]
       def time: () -> Time?
     end
     def get_current_time: (?Hash[Symbol, untyped], ?Hash[Symbol, untyped]) -> _GetCurrentTimeResponse
 
     interface _GetForecastResponse
-      include Smithy::Client::_Output[Types::GetForecastOutput]
+      include Smithy::Client::_Response[Types::GetForecastOutput]
       def chance_of_rain: () -> Float?
     end
     def get_forecast: (
@@ -61,7 +61,7 @@ module Weather
     ) -> _GetForecastResponse | (?Hash[Symbol, untyped], ?Hash[Symbol, untyped]) -> _GetForecastResponse
 
     interface _ListCitiesResponse
-      include Smithy::Client::_Output[Types::ListCitiesOutput]
+      include Smithy::Client::_Response[Types::ListCitiesOutput]
       def next_token: () -> String?
       def items: () -> Array[Types::CitySummary]?
     end


### PR DESCRIPTION
Rename Input -> Request and Output -> Response, now that http_response/request are used again. This also conforms with SDK v3.