### PR TITLE
Add v3 style unions

### DIFF
--- a/gems/smithy-cbor/lib/smithy-cbor/deserializer.rb
+++ b/gems/smithy-cbor/lib/smithy-cbor/deserializer.rb
@@ -68,12 +68,12 @@ module Smithy
           next if value.nil?
 
           target = ref.shape.member_type(member_name) if target.nil?
-          return target.new(shape(member_ref, value))
+          return target.new(member_name => shape(member_ref, value))
         end
 
         values.delete('__type')
         key, value = values.first
-        ref.shape.member_type(:unknown).new(key, value)
+        ref.shape.member_type(:unknown).new(unknown: { key => value })
       end
 
       def sparse?(shape)

--- a/gems/smithy-cbor/spec/smithy-cbor/codec_spec.rb
+++ b/gems/smithy-cbor/spec/smithy-cbor/codec_spec.rb
@@ -4,9 +4,8 @@ require_relative '../spec_helper'
 
 module Smithy
   module CBOR
-    # TODO: test all codec cases
     describe Codec do
-      let(:shape) { SchemaHelper.sample_schema.const_get(:Structure) }
+      let(:structure_shape) { SchemaHelper.sample_schema.const_get(:Structure) }
 
       it 'serialize returns nil when given a unit shape' do
         expect(subject.serialize(Schema::Shapes::Prelude::Unit, '')).to be_nil
@@ -46,82 +45,82 @@ module Smithy
           union: { string: 'string' }
         }
         data = data.merge(structure: data)
-        bytes = subject.serialize(shape, data)
-        expect(subject.deserialize(shape, bytes).to_h).to eq(data)
+        bytes = subject.serialize(structure_shape, data)
+        expect(subject.deserialize(structure_shape, bytes).to_h).to eq(data)
       end
 
       context 'structures' do
         it 'serializes and deserializes structures as a type' do
-          type = shape.type.new(string: 'string')
-          bytes = subject.serialize(shape, type)
-          expect(subject.deserialize(shape, bytes).string).to eq('string')
+          type = structure_shape.type.new(string: 'string')
+          bytes = subject.serialize(structure_shape, type)
+          expect(subject.deserialize(structure_shape, bytes).string).to eq('string')
         end
 
         it 'serializes and deserializes structures as a hash' do
           data = { string: 'string' }
-          bytes = subject.serialize(shape, data)
-          expect(subject.deserialize(shape, bytes).to_h).to eq(data)
+          bytes = subject.serialize(structure_shape, data)
+          expect(subject.deserialize(structure_shape, bytes).to_h).to eq(data)
         end
       end
 
       context 'unions' do
         it 'serializes and deserializes union as a type' do
-          union = shape.member(:union).shape.member_type(:string).new('string')
-          type = shape.type.new(union: union)
-          bytes = subject.serialize(shape, type)
-          expect(subject.deserialize(shape, bytes).union).to eq(union)
+          union = structure_shape.member(:union).shape.member_type(:string).new(string: 'string')
+          type = structure_shape.type.new(union: union)
+          bytes = subject.serialize(structure_shape, type)
+          expect(subject.deserialize(structure_shape, bytes).union).to eq(union)
         end
 
         it 'serializes and deserializes union as a hash' do
           data = { union: { string: 'string' } }
-          bytes = subject.serialize(shape, data)
-          expect(subject.deserialize(shape, bytes).to_h).to eq(data)
+          bytes = subject.serialize(structure_shape, data)
+          expect(subject.deserialize(structure_shape, bytes).to_h).to eq(data)
         end
 
         it 'serializes a nil union' do
           data = { union: nil }
-          bytes = subject.serialize(shape, data)
-          expect(subject.deserialize(shape, bytes).union).to eq(nil)
+          bytes = subject.serialize(structure_shape, data)
+          expect(subject.deserialize(structure_shape, bytes).union).to eq(nil)
         end
 
         it 'deserializes unknown union members' do
-          unknown_union_type = shape.member(:union).shape.member_type(:unknown)
+          unknown_union_type = structure_shape.member(:union).shape.member_type(:unknown)
           data = { union: { 'someThing' => 'someValue' } }
-          deserialized = subject.deserialize(shape, CBOR.encode(data))
+          deserialized = subject.deserialize(structure_shape, CBOR.encode(data))
           expect(deserialized.union).to be_a(unknown_union_type)
-          expect(deserialized.union.to_h).to eq(unknown: { name: 'someThing', value: 'someValue' })
+          expect(deserialized.union.to_h).to eq(unknown: { 'someThing' => 'someValue' })
         end
       end
 
       context 'lists' do
         it 'serializes and deserializes lists' do
           data = { list: ['string'] }
-          bytes = subject.serialize(shape, data)
-          expect(subject.deserialize(shape, bytes).to_h).to eq(data)
+          bytes = subject.serialize(structure_shape, data)
+          expect(subject.deserialize(structure_shape, bytes).to_h).to eq(data)
         end
 
         it 'can handle sparse lists' do
-          list_shape = shape.member(:list).shape
+          list_shape = structure_shape.member(:list).shape
           list_shape.traits.merge!('smithy.api#sparse' => {})
           data = { list: [nil] }
-          bytes = subject.serialize(shape, data)
-          expect(subject.deserialize(shape, bytes).to_h).to eq(data)
+          bytes = subject.serialize(structure_shape, data)
+          expect(subject.deserialize(structure_shape, bytes).to_h).to eq(data)
         end
       end
 
       context 'maps' do
         it 'serializes and deserializes maps' do
           data = { map: { 'key' => 'value' } }
-          bytes = subject.serialize(shape, data)
-          expect(subject.deserialize(shape, bytes).to_h).to eq(data)
+          bytes = subject.serialize(structure_shape, data)
+          expect(subject.deserialize(structure_shape, bytes).to_h).to eq(data)
         end
 
         it 'can handle sparse maps' do
-          map_shape = shape.member(:map).shape
+          map_shape = structure_shape.member(:map).shape
           map_shape.traits.merge!('smithy.api#sparse' => {})
           data = { map: { 'key' => nil } }
-          bytes = subject.serialize(shape, data)
-          expect(subject.deserialize(shape, bytes).to_h).to eq(data)
+          bytes = subject.serialize(structure_shape, data)
+          expect(subject.deserialize(structure_shape, bytes).to_h).to eq(data)
         end
       end
     end

--- a/gems/smithy-client/lib/smithy-client/stubbing/empty_stub.rb
+++ b/gems/smithy-client/lib/smithy-client/stubbing/empty_stub.rb
@@ -50,7 +50,7 @@ module Smithy
 
           value = shape(member_ref, visited)
           klass = shape.member_type(member_name)
-          klass.new(value)
+          klass.new(member_name => value)
         end
 
         def scalar(ref)

--- a/gems/smithy-client/spec/smithy-client/param_converter_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/param_converter_spec.rb
@@ -62,7 +62,7 @@ module Smithy
               { integer: 2.0 },
               { integer: '3' }
             ],
-            union: union_type.new({ string: :abc })
+            union: union_type.new(structure: { string: :abc })
           )
           converted = ParamConverter.new(input).convert(params)
           expect(converted.to_h).to eq(expected)
@@ -296,7 +296,8 @@ module Smithy
           end
 
           it 'does not modify structs' do
-            value = ::Struct.new(:a).new(1)
+            type = ::Struct.new(:a) { include Schema::Structure }
+            value = type.new(a: 1)
             converted = ParamConverter.c(shape_class, value)
             expect(converted).to be(value)
           end
@@ -357,7 +358,9 @@ module Smithy
           end
 
           it 'does not modify unions' do
-            value = Schema::Union.new(string: 'abc')
+            type = ::Struct.new(:a) { include Schema::Union }
+            sub_type = Class.new(type)
+            value = sub_type.new(a: 1)
             converted = ParamConverter.c(shape_class, value)
             expect(converted).to be(value)
           end

--- a/gems/smithy-client/spec/smithy-client/param_validator_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/param_validator_spec.rb
@@ -313,12 +313,12 @@ module Smithy
 
         it 'accepts a modeled type' do
           union_structure = sample_client.const_get(:Types).const_get(:Union).const_get(:Structure)
-          validate({ union: union_structure.new({ string: 'string' }) })
+          validate({ union: union_structure.new(structure: { string: 'string' }) })
         end
 
         it 'raises an error when given the wrong modeled type' do
           union_structure = sample_client.const_get(:Types).const_get(:Union).const_get(:Structure)
-          validate({ union: union_structure.new({ structure: 'abc' }) },
+          validate({ union: union_structure.new(structure: { structure: 'abc' }) },
                    'expected params[:union][:structure] to be a Hash, got class String instead.')
         end
       end

--- a/gems/smithy-json/lib/smithy-json/deserializer.rb
+++ b/gems/smithy-json/lib/smithy-json/deserializer.rb
@@ -98,12 +98,12 @@ module Smithy
           next if value.nil?
 
           target = ref.shape.member_type(member_name) if target.nil?
-          return target.new(shape(member_ref, value))
+          return target.new(member_name => shape(member_ref, value))
         end
 
         values.delete('__type')
         key, value = values.first
-        ref.shape.member_type(:unknown).new(key, value)
+        ref.shape.member_type(:unknown).new(unknown: { key => value })
       end
 
       def location_name(ref)

--- a/gems/smithy-json/lib/smithy-json/serializer.rb
+++ b/gems/smithy-json/lib/smithy-json/serializer.rb
@@ -91,9 +91,9 @@ module Smithy
         return if values.nil?
 
         data = {}
-        if values.is_a?(Smithy::Schema::Union)
+        if values.is_a?(Schema::Union)
           _name, member_ref = ref.shape.member_by_type(values.class)
-          data[location_name(member_ref)] = shape(member_ref, values)
+          data[location_name(member_ref)] = shape(member_ref, values).value
         else
           key, value = values.first
           if ref.shape.member?(key)

--- a/gems/smithy-json/spec/smithy-json/codec_spec.rb
+++ b/gems/smithy-json/spec/smithy-json/codec_spec.rb
@@ -4,7 +4,6 @@ require_relative '../spec_helper'
 
 module Smithy
   module JSON
-    # TODO: test all codec cases
     describe Codec do
       let(:shapes) { SchemaHelper.sample_shapes }
       let(:sample_schema) { SchemaHelper.sample_schema(shapes: shapes) }
@@ -76,7 +75,7 @@ module Smithy
 
       context 'unions' do
         it 'serializes and deserializes union as a type' do
-          union = structure_shape.member(:union).shape.member_type(:string).new('string')
+          union = structure_shape.member(:union).shape.member_type(:string).new(string: 'string')
           type = structure_shape.type.new(union: union)
           json = subject.serialize(structure_shape, type)
           expect(subject.deserialize(structure_shape, json).union).to eq(union)
@@ -105,7 +104,7 @@ module Smithy
           data = { 'union' => { 'someThing' => 'someValue' } }.to_json
           deserialized = subject.deserialize(structure_shape, data)
           expect(deserialized.union).to be_a(unknown_union_type)
-          expect(deserialized.union.to_h).to eq(unknown: { name: 'someThing', value: 'someValue' })
+          expect(deserialized.union.to_h).to eq(unknown: { 'someThing' => 'someValue' })
         end
 
         it 'ignores extra __type key when deserializing' do

--- a/gems/smithy-schema/lib/smithy-schema.rb
+++ b/gems/smithy-schema/lib/smithy-schema.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require_relative 'smithy-schema/structure'
+require_relative 'smithy-schema/empty_structure'
 require_relative 'smithy-schema/union'
+
 require_relative 'smithy-schema/shapes'
 require_relative 'smithy-schema/document'
 require_relative 'smithy-schema/type_registry'

--- a/gems/smithy-schema/lib/smithy-schema/document_utils/deserializer.rb
+++ b/gems/smithy-schema/lib/smithy-schema/document_utils/deserializer.rb
@@ -106,7 +106,7 @@ module Smithy
             next if value.nil?
 
             target = ref.shape.member_type(member_name) if target.nil?
-            return target.new(shape(member_ref, value))
+            return target.new(member_name => shape(member_ref, value))
           end
 
           values.delete('__type')

--- a/gems/smithy-schema/lib/smithy-schema/empty_structure.rb
+++ b/gems/smithy-schema/lib/smithy-schema/empty_structure.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Smithy
+  module Schema
+    # An empty Struct that includes the {Schema::Structure} module.
+    class EmptyStructure < Struct.new(nil) # rubocop:disable Style/StructInheritance
+      include Smithy::Schema::Structure
+    end
+  end
+end

--- a/gems/smithy-schema/lib/smithy-schema/structure.rb
+++ b/gems/smithy-schema/lib/smithy-schema/structure.rb
@@ -2,15 +2,13 @@
 
 module Smithy
   module Schema
-    # A module mixed into Structs that provides utility methods.
+    # A module mixed into Structs that provides utility methods for Structure shapes.
     module Structure
       # Deeply converts the Struct into a hash. Structure members that
       # are `nil` are omitted from the resultant hash.
       # @return [Hash, Structure]
       def to_h(obj = self)
         case obj
-        when Union
-          obj.to_h
         when Structure
           _to_h_structure(obj)
         when Hash
@@ -41,11 +39,6 @@ module Smithy
       def _to_h_array(obj)
         obj.collect { |value| to_hash(value) }
       end
-    end
-
-    # An empty Struct that includes the {Schema::Structure} module.
-    class EmptyStructure < Struct.new # rubocop:disable Style/StructInheritance
-      include Smithy::Schema::Structure
     end
   end
 end

--- a/gems/smithy-schema/lib/smithy-schema/union.rb
+++ b/gems/smithy-schema/lib/smithy-schema/union.rb
@@ -4,16 +4,16 @@ require 'delegate'
 
 module Smithy
   module Schema
-    # Top level class for all generated Union types
-    class Union < ::SimpleDelegator
+    # A module mixed into Structs that provides utility methods for Union shapes.
+    module Union
       include Structure
 
-      def to_s
-        "#<#{self.class.name} #{__getobj__ || 'nil'}>"
+      def member
+        members.find { |m| !self[m].nil? }
       end
 
       def value
-        __getobj__
+        self[member] if member
       end
     end
   end

--- a/gems/smithy-schema/sig/smithy-schema/document.rbs
+++ b/gems/smithy-schema/sig/smithy-schema/document.rbs
@@ -1,0 +1,7 @@
+module Smithy
+  module Schema
+    class Document < SimpleDelegator
+      # TODO
+    end
+  end
+end

--- a/gems/smithy-schema/sig/smithy-schema/empty_structure.rbs
+++ b/gems/smithy-schema/sig/smithy-schema/empty_structure.rbs
@@ -1,0 +1,7 @@
+module Smithy
+  module Schema
+    class EmptyStructure
+      include Structure
+    end
+  end
+end

--- a/gems/smithy-schema/sig/smithy-schema/structure.rbs
+++ b/gems/smithy-schema/sig/smithy-schema/structure.rbs
@@ -1,10 +1,7 @@
 module Smithy
   module Schema
     module Structure
-    end
-
-    class EmptyStructure
-      include Structure
+      def to_h: () -> ::Hash[Symbol, ::Object]
     end
   end
 end

--- a/gems/smithy-schema/sig/smithy-schema/type_registry.rbs
+++ b/gems/smithy-schema/sig/smithy-schema/type_registry.rbs
@@ -1,0 +1,7 @@
+module Smithy
+  module Schema
+    class TypeRegistry
+      # TODO
+    end
+  end
+end

--- a/gems/smithy-schema/sig/smithy-schema/union.rbs
+++ b/gems/smithy-schema/sig/smithy-schema/union.rbs
@@ -1,7 +1,10 @@
 module Smithy
   module Schema
-    class Union < ::SimpleDelegator
+    module Union
       include Structure
+
+      def member: () -> Symbol
+      def value: () -> Object
     end
   end
 end

--- a/gems/smithy-schema/spec/smithy-schema/structure_spec.rb
+++ b/gems/smithy-schema/spec/smithy-schema/structure_spec.rb
@@ -19,14 +19,12 @@ module Smithy
         end
       end
 
-      let(:union_class) { Class.new(Union) }
-      let(:struct_value_class) do
-        Class.new(union_class) do
-          def to_h
-            { struct_value: super(__getobj__) }
-          end
+      let(:union) do
+        Struct.new(:struct_value, keyword_init: true) do
+          include Union
         end
       end
+      let(:struct_value) { Class.new(union) }
 
       subject do
         structure.new(
@@ -36,7 +34,7 @@ module Smithy
             structure.new(value: 'bar')
           ],
           hash_value: { key: structure.new(value: 'value') },
-          union_value: struct_value_class.new(structure.new(value: 'value')),
+          union_value: struct_value.new(struct_value: structure.new(value: 'value')),
           value: 'value',
           some_object: Object.new
         )

--- a/gems/smithy-schema/spec/smithy-schema/union_spec.rb
+++ b/gems/smithy-schema/spec/smithy-schema/union_spec.rb
@@ -5,43 +5,29 @@ require_relative '../spec_helper'
 module Smithy
   module Schema
     describe Union do
-      let(:union_class) { Class.new(Union) }
-      let(:string_value_class) do
-        Class.new(union_class) do
-          def to_h
-            { string_value: super(__getobj__) }
-          end
-
-          # anonymous class, need a class name to test to_s
-          def self.name
-            'TestUnion::StringValue'
-          end
+      let(:union) do
+        Struct.new(:string_value, :integer_value, keyword_init: true) do
+          include Union
         end
       end
+      let(:string_value) { Class.new(union) }
+      let(:integer_value) { Class.new(union) }
 
-      subject { string_value_class.new('union') }
-
-      it 'uses simple delegator and structure' do
-        expect(subject).to be_a(SimpleDelegator)
-        expect(subject).to be_a(Structure)
+      it 'is a Structure' do
+        expect(subject).to include(Structure)
       end
 
-      describe '#to_h' do
-        it 'serializes the value to a hash' do
-          expect(subject.to_h).to eq(string_value: 'union')
-        end
-      end
-
-      describe '#to_s' do
-        it 'returns a string representation' do
-          expect(subject.to_s)
-            .to eq('#<TestUnion::StringValue union>')
+      describe '#member' do
+        it 'returns the first non-nil member' do
+          union = integer_value.new(integer_value: 1)
+          expect(union.member).to eq(:integer_value)
         end
       end
 
       describe '#value' do
-        it 'returns the value' do
-          expect(subject.value).to eq('union')
+        it 'returns the first non-nil value' do
+          union = integer_value.new(integer_value: 1)
+          expect(union.value).to eq(1)
         end
       end
     end

--- a/gems/smithy/lib/smithy/templates/client/types.erb
+++ b/gems/smithy/lib/smithy/templates/client/types.erb
@@ -41,27 +41,21 @@ module <%= module_name %>
 <% end -%>
     end
 <% when 'union' -%>
-    class <%= type.name %> < Smithy::Schema::Union
+<% type.attribute_docstrings.each do |docstring| -%>
+    # <%= docstring %>
+<% end -%>
+    class <%= type.name %> < Struct.new(
 <% type.members.each do |member| -%>
-<% member.docstrings.each do |docstring| -%>
-      # <%= docstring %>
+      :<%= member.name.underscore %>,
 <% end -%>
-      class <%= member.name.camelize  %> < <%= type.name %>
-        def to_h
-          { <%= member.name.underscore %>: super(__getobj__) }
-        end
-      end
+      :unknown,
+      keyword_init: true)
+      include Smithy::Schema::Union
 
+<% type.members.each do |member| -%>
+      class <%= member.name.camelize  %> < <%= type.name %>; end
 <% end -%>
-      class Unknown < <%= type.name %>
-        def initialize(name, value)
-          super({ name: name, value: value })
-        end
-
-        def to_h
-          { unknown: super(__getobj__) }
-        end
-      end
+      class Unknown < <%= type.name %>; end
     end
 <% end -%>
 <% end -%>

--- a/gems/smithy/lib/smithy/templates/client/types_rbs.erb
+++ b/gems/smithy/lib/smithy/templates/client/types_rbs.erb
@@ -32,9 +32,11 @@ module <%= module_name %>
       attr_accessor <%= member.name.underscore %>: <%= member.rbs_type %>?
 <% end -%>
 
+<% if type.type == 'union' -%>
 <% type.members.each do |member| -%>
       class <%= member.name.camelize %> < <%= type.name %>
       end
+<% end -%>
 <% end -%>
     end
 <% end -%>

--- a/gems/smithy/lib/smithy/templates/client/types_rbs.erb
+++ b/gems/smithy/lib/smithy/templates/client/types_rbs.erb
@@ -2,31 +2,40 @@ module <%= module_name %>
   module Types
 <% types.each do |type| -%>
 
-<% if type.type == 'structure' -%>
+<% case type.type -%>
+<% when 'enum', 'intEnum' -%>
+    module <%= type.name %>
+<% type.members.each do |member| -%>
+<% if type.type == 'enum' -%>
+      <%= member.name %>: String
+<% elsif type.type == 'intEnum' -%>
+      <%= member.name %>: Integer
+<% end -%>
+    end
+<% end -%>
+<% when 'structure', 'union' -%>
     class <%= type.name %>
+<% if type.type == 'structure' -%>
       include Smithy::Schema::Structure
+<% elsif type.type == 'union' -%>
+      include Smithy::Schema::Union
+<% end -%>
 
       def initialize: (
 <% type.members.each do |member| -%>
-        ?<%= member.name %>: <%= member.rbs_type %>,
+        ?<%= member.name.underscore %>: <%= member.rbs_type %>,
 <% end -%>
       ) -> void
       | (?Hash[Symbol, untyped]) -> void
 
 <% type.members.each do |member| -%>
-      attr_accessor <%= member.name %>: <%= member.rbs_type %>?
-<% end -%>
-    end
-<% elsif type.type == 'union' -%>
-    class <%= type.name %> < Smithy::Schema::Union
-<% type.members.each do |member| %>
-      class <%= member.name.camelize  %> < <%= type.name %>
-      end
+      attr_accessor <%= member.name.underscore %>: <%= member.rbs_type %>?
 <% end -%>
 
-      class Unknown < <%= type.name %>
-        def initialize: (name: String?, value: untyped?) -> void
+<% type.members.each do |member| -%>
+      class <%= member.name.camelize %> < <%= type.name %>
       end
+<% end -%>
     end
 <% end -%>
 <% end -%>

--- a/gems/smithy/lib/smithy/templates/client/types_rbs.erb
+++ b/gems/smithy/lib/smithy/templates/client/types_rbs.erb
@@ -11,8 +11,8 @@ module <%= module_name %>
 <% elsif type.type == 'intEnum' -%>
       <%= member.name %>: Integer
 <% end -%>
-    end
 <% end -%>
+    end
 <% when 'structure', 'union' -%>
     class <%= type.name %>
 <% if type.type == 'structure' -%>
@@ -31,12 +31,14 @@ module <%= module_name %>
 <% type.members.each do |member| -%>
       attr_accessor <%= member.name.underscore %>: <%= member.rbs_type %>?
 <% end -%>
-
 <% if type.type == 'union' -%>
+
 <% type.members.each do |member| -%>
       class <%= member.name.camelize %> < <%= type.name %>
       end
 <% end -%>
+      class Unknown < <%= type.name %>
+      end
 <% end -%>
     end
 <% end -%>

--- a/gems/smithy/lib/smithy/views/client/types.rb
+++ b/gems/smithy/lib/smithy/views/client/types.rb
@@ -129,16 +129,24 @@ module Smithy
           private
 
           def build_members(members)
-            members.map { |name, member| StructureMember.new(@service, @model, name, member) }
+            members.map { |name, member| StructMember.new(@service, @model, name, member) }
           end
         end
 
         # @api private
         class UnionType < Type
+          def attribute_docstrings
+            lines = []
+            members.each do |member|
+              lines.concat(member.docstrings)
+            end
+            lines
+          end
+
           private
 
           def build_members(members)
-            members.map { |name, member| Member.new(@service, @model, name, member) }
+            members.map { |name, member| StructMember.new(@service, @model, name, member) }
           end
         end
 
@@ -216,7 +224,7 @@ module Smithy
         end
 
         # @api private
-        class StructureMember < Member
+        class StructMember < Member
           def docstrings # rubocop:disable Metrics/AbcSize
             lines = ["@!attribute #{@name.underscore}"]
             lines.concat(indented_docstrings(documentation_docstrings))

--- a/gems/smithy/lib/smithy/views/client/types_rbs.rb
+++ b/gems/smithy/lib/smithy/views/client/types_rbs.rb
@@ -19,30 +19,30 @@ module Smithy
           Model::ServiceIndex
             .new(@model)
             .shapes_for(@plan.service)
-            .select { |_key, shape| %w[structure union].include?(shape['type']) }
+            .select { |_key, shape| %w[enum intEnum structure union].include?(shape['type']) }
             .map { |id, structure| Type.new(@model, id, structure) }
         end
 
         # @api private
         class Type
           def initialize(model, id, shape)
+            @model = model
             @id = id
             @shape = shape
-            @model = model
+            @type = shape['type']
+            @members = build_members(shape['members'])
           end
+
+          attr_reader :type, :members
 
           def name
             Model::Shape.name(@id).camelize
           end
 
-          def members
-            @shape['members'].map do |name, member|
-              Member.new(@model, name, member)
-            end
-          end
+          private
 
-          def type
-            @shape['type']
+          def build_members(members)
+            members.map { |name, member| Member.new(@model, name, member) }
           end
         end
 
@@ -50,7 +50,7 @@ module Smithy
         class Member
           def initialize(model, name, member)
             @model = model
-            @name = name.underscore
+            @name = name
             @id = member['target']
             @target = Model.shape(@model, member['target'])
           end

--- a/gems/smithy/spec/support/examples/types_documentation_examples.rb
+++ b/gems/smithy/spec/support/examples/types_documentation_examples.rb
@@ -313,47 +313,22 @@ RSpec.shared_examples 'types module documentation' do |context|
         assert(expected)
       end
 
-      context 'union members' do
-        def assert(expected)
-          expect(expected).to be_in_documentation(types_file, 'Documentation::Types::Union::DocumentedMember')
-        end
-
-        it 'generates deprecated documentation' do
-          expected = <<~DOC
+      it 'generates attribute documentation' do
+        expected = <<~DOC
+          @!attribute documented_member
+            Union member documentation
             @deprecated
               Deprecated union member
               Since: 2.0
-          DOC
-          assert(expected)
-        end
-
-        it 'generates documentation' do
-          expected = <<~DOC
-            Union member documentation
-          DOC
-          assert(expected)
-        end
-
-        it 'generates external documentation links' do
-          expected = <<~DOC
             @see https://www.example.com/ Union member link
-          DOC
-          assert(expected)
-        end
-
-        it 'generates since documentation' do
-          expected = <<~DOC
             @since 2.0
-          DOC
-          assert(expected)
-        end
-
-        it 'generates unstable documentation' do
-          expected = <<~DOC
             @note This shape is unstable and may change in future releases.
-          DOC
-          assert(expected)
-        end
+            @return [String]
+          @!attribute undocumented_member
+            Shape documentation
+            @return [String]
+        DOC
+        assert(expected)
       end
     end
   end

--- a/gems/smithy/spec/support/examples/types_examples.rb
+++ b/gems/smithy/spec/support/examples/types_examples.rb
@@ -32,7 +32,7 @@ RSpec.shared_examples 'types module' do |context|
         list: ['item'],
         map: { 'key' => 'value' },
         string: 'string',
-        union: ShapeService::Types::Union::Structure.new(structure)
+        union: ShapeService::Types::Union::Structure.new(structure: structure)
       )
       expected = {
         string: 'string',

--- a/projections/shapes/lib/shapes/types.rb
+++ b/projections/shapes/lib/shapes/types.rb
@@ -146,34 +146,24 @@ module ShapeService
       include Smithy::Schema::Structure
     end
 
-    class Union < Smithy::Schema::Union
-      class String < Union
-        def to_h
-          { string: super(__getobj__) }
-        end
-      end
+    # @!attribute string
+    #   @return [String]
+    # @!attribute structure
+    #   @return [Types::Structure]
+    # @!attribute unit
+    #   @return [Smithy::Schema::EmptyStructure]
+    class Union < Struct.new(
+      :string,
+      :structure,
+      :unit,
+      :unknown,
+      keyword_init: true)
+      include Smithy::Schema::Union
 
-      class Structure < Union
-        def to_h
-          { structure: super(__getobj__) }
-        end
-      end
-
-      class Unit < Union
-        def to_h
-          { unit: super(__getobj__) }
-        end
-      end
-
-      class Unknown < Union
-        def initialize(name, value)
-          super({ name: name, value: value })
-        end
-
-        def to_h
-          { unknown: super(__getobj__) }
-        end
-      end
+      class String < Union; end
+      class Structure < Union; end
+      class Unit < Union; end
+      class Unknown < Union; end
     end
 
   end

--- a/projections/shapes/sig/shapes/types.rbs
+++ b/projections/shapes/sig/shapes/types.rbs
@@ -55,44 +55,6 @@ module ShapeService
       attr_accessor structure: Types::Structure?
       attr_accessor union: Types::Union?
 
-      class Blob < OperationInput
-      end
-      class Boolean < OperationInput
-      end
-      class String < OperationInput
-      end
-      class Byte < OperationInput
-      end
-      class Short < OperationInput
-      end
-      class Integer < OperationInput
-      end
-      class Long < OperationInput
-      end
-      class Float < OperationInput
-      end
-      class Double < OperationInput
-      end
-      class BigInteger < OperationInput
-      end
-      class BigDecimal < OperationInput
-      end
-      class Timestamp < OperationInput
-      end
-      class Document < OperationInput
-      end
-      class Enum < OperationInput
-      end
-      class IntEnum < OperationInput
-      end
-      class List < OperationInput
-      end
-      class Map < OperationInput
-      end
-      class Structure < OperationInput
-      end
-      class Union < OperationInput
-      end
     end
 
     class OperationOutput
@@ -141,44 +103,6 @@ module ShapeService
       attr_accessor structure: Types::Structure?
       attr_accessor union: Types::Union?
 
-      class Blob < OperationOutput
-      end
-      class Boolean < OperationOutput
-      end
-      class String < OperationOutput
-      end
-      class Byte < OperationOutput
-      end
-      class Short < OperationOutput
-      end
-      class Integer < OperationOutput
-      end
-      class Long < OperationOutput
-      end
-      class Float < OperationOutput
-      end
-      class Double < OperationOutput
-      end
-      class BigInteger < OperationOutput
-      end
-      class BigDecimal < OperationOutput
-      end
-      class Timestamp < OperationOutput
-      end
-      class Document < OperationOutput
-      end
-      class Enum < OperationOutput
-      end
-      class IntEnum < OperationOutput
-      end
-      class List < OperationOutput
-      end
-      class Map < OperationOutput
-      end
-      class Structure < OperationOutput
-      end
-      class Union < OperationOutput
-      end
     end
 
     class Structure
@@ -191,8 +115,6 @@ module ShapeService
 
       attr_accessor member: String?
 
-      class Member < Structure
-      end
     end
 
     class Union

--- a/projections/shapes/sig/shapes/types.rbs
+++ b/projections/shapes/sig/shapes/types.rbs
@@ -54,7 +54,6 @@ module ShapeService
       attr_accessor map: Hash[String, String]?
       attr_accessor structure: Types::Structure?
       attr_accessor union: Types::Union?
-
     end
 
     class OperationOutput
@@ -102,7 +101,6 @@ module ShapeService
       attr_accessor map: Hash[String, String]?
       attr_accessor structure: Types::Structure?
       attr_accessor union: Types::Union?
-
     end
 
     class Structure
@@ -114,7 +112,6 @@ module ShapeService
       | (?Hash[Symbol, untyped]) -> void
 
       attr_accessor member: String?
-
     end
 
     class Union
@@ -136,6 +133,8 @@ module ShapeService
       class Structure < Union
       end
       class Unit < Union
+      end
+      class Unknown < Union
       end
     end
   end

--- a/projections/shapes/sig/shapes/types.rbs
+++ b/projections/shapes/sig/shapes/types.rbs
@@ -1,6 +1,14 @@
 module ShapeService
   module Types
 
+    module Enum
+      FOO: String
+    end
+
+    module IntEnum
+      BAZ: Integer
+    end
+
     class OperationInput
       include Smithy::Schema::Structure
 
@@ -46,6 +54,45 @@ module ShapeService
       attr_accessor map: Hash[String, String]?
       attr_accessor structure: Types::Structure?
       attr_accessor union: Types::Union?
+
+      class Blob < OperationInput
+      end
+      class Boolean < OperationInput
+      end
+      class String < OperationInput
+      end
+      class Byte < OperationInput
+      end
+      class Short < OperationInput
+      end
+      class Integer < OperationInput
+      end
+      class Long < OperationInput
+      end
+      class Float < OperationInput
+      end
+      class Double < OperationInput
+      end
+      class BigInteger < OperationInput
+      end
+      class BigDecimal < OperationInput
+      end
+      class Timestamp < OperationInput
+      end
+      class Document < OperationInput
+      end
+      class Enum < OperationInput
+      end
+      class IntEnum < OperationInput
+      end
+      class List < OperationInput
+      end
+      class Map < OperationInput
+      end
+      class Structure < OperationInput
+      end
+      class Union < OperationInput
+      end
     end
 
     class OperationOutput
@@ -93,6 +140,45 @@ module ShapeService
       attr_accessor map: Hash[String, String]?
       attr_accessor structure: Types::Structure?
       attr_accessor union: Types::Union?
+
+      class Blob < OperationOutput
+      end
+      class Boolean < OperationOutput
+      end
+      class String < OperationOutput
+      end
+      class Byte < OperationOutput
+      end
+      class Short < OperationOutput
+      end
+      class Integer < OperationOutput
+      end
+      class Long < OperationOutput
+      end
+      class Float < OperationOutput
+      end
+      class Double < OperationOutput
+      end
+      class BigInteger < OperationOutput
+      end
+      class BigDecimal < OperationOutput
+      end
+      class Timestamp < OperationOutput
+      end
+      class Document < OperationOutput
+      end
+      class Enum < OperationOutput
+      end
+      class IntEnum < OperationOutput
+      end
+      class List < OperationOutput
+      end
+      class Map < OperationOutput
+      end
+      class Structure < OperationOutput
+      end
+      class Union < OperationOutput
+      end
     end
 
     class Structure
@@ -104,21 +190,30 @@ module ShapeService
       | (?Hash[Symbol, untyped]) -> void
 
       attr_accessor member: String?
+
+      class Member < Structure
+      end
     end
 
-    class Union < Smithy::Schema::Union
+    class Union
+      include Smithy::Schema::Union
+
+      def initialize: (
+        ?string: String,
+        ?structure: Types::Structure,
+        ?unit: Smithy::Schema::EmptyStructure,
+      ) -> void
+      | (?Hash[Symbol, untyped]) -> void
+
+      attr_accessor string: String?
+      attr_accessor structure: Types::Structure?
+      attr_accessor unit: Smithy::Schema::EmptyStructure?
 
       class String < Union
       end
-
       class Structure < Union
       end
-
       class Unit < Union
-      end
-
-      class Unknown < Union
-        def initialize: (name: String?, value: untyped?) -> void
       end
     end
   end

--- a/projections/weather/sig/weather/types.rbs
+++ b/projections/weather/sig/weather/types.rbs
@@ -12,7 +12,6 @@ module Weather
 
       attr_accessor latitude: Float?
       attr_accessor longitude: Float?
-
     end
 
     class CitySummary
@@ -26,7 +25,6 @@ module Weather
 
       attr_accessor city_id: String?
       attr_accessor name: String?
-
     end
 
     class GetCityInput
@@ -38,7 +36,6 @@ module Weather
       | (?Hash[Symbol, untyped]) -> void
 
       attr_accessor city_id: String?
-
     end
 
     class GetCityOutput
@@ -52,7 +49,6 @@ module Weather
 
       attr_accessor name: String?
       attr_accessor coordinates: Types::CityCoordinates?
-
     end
 
     class GetCurrentTimeOutput
@@ -64,7 +60,6 @@ module Weather
       | (?Hash[Symbol, untyped]) -> void
 
       attr_accessor time: Time?
-
     end
 
     class GetForecastInput
@@ -76,7 +71,6 @@ module Weather
       | (?Hash[Symbol, untyped]) -> void
 
       attr_accessor city_id: String?
-
     end
 
     class GetForecastOutput
@@ -88,7 +82,6 @@ module Weather
       | (?Hash[Symbol, untyped]) -> void
 
       attr_accessor chance_of_rain: Float?
-
     end
 
     class ListCitiesInput
@@ -102,7 +95,6 @@ module Weather
 
       attr_accessor next_token: String?
       attr_accessor page_size: Integer?
-
     end
 
     class ListCitiesOutput
@@ -116,7 +108,6 @@ module Weather
 
       attr_accessor next_token: String?
       attr_accessor items: Array[Types::CitySummary]?
-
     end
 
     class NoSuchResource
@@ -128,7 +119,6 @@ module Weather
       | (?Hash[Symbol, untyped]) -> void
 
       attr_accessor resource_type: String?
-
     end
   end
 end

--- a/projections/weather/sig/weather/types.rbs
+++ b/projections/weather/sig/weather/types.rbs
@@ -12,6 +12,11 @@ module Weather
 
       attr_accessor latitude: Float?
       attr_accessor longitude: Float?
+
+      class Latitude < CityCoordinates
+      end
+      class Longitude < CityCoordinates
+      end
     end
 
     class CitySummary
@@ -25,6 +30,11 @@ module Weather
 
       attr_accessor city_id: String?
       attr_accessor name: String?
+
+      class CityId < CitySummary
+      end
+      class Name < CitySummary
+      end
     end
 
     class GetCityInput
@@ -36,6 +46,9 @@ module Weather
       | (?Hash[Symbol, untyped]) -> void
 
       attr_accessor city_id: String?
+
+      class CityId < GetCityInput
+      end
     end
 
     class GetCityOutput
@@ -49,6 +62,11 @@ module Weather
 
       attr_accessor name: String?
       attr_accessor coordinates: Types::CityCoordinates?
+
+      class Name < GetCityOutput
+      end
+      class Coordinates < GetCityOutput
+      end
     end
 
     class GetCurrentTimeOutput
@@ -60,6 +78,9 @@ module Weather
       | (?Hash[Symbol, untyped]) -> void
 
       attr_accessor time: Time?
+
+      class Time < GetCurrentTimeOutput
+      end
     end
 
     class GetForecastInput
@@ -71,6 +92,9 @@ module Weather
       | (?Hash[Symbol, untyped]) -> void
 
       attr_accessor city_id: String?
+
+      class CityId < GetForecastInput
+      end
     end
 
     class GetForecastOutput
@@ -82,6 +106,9 @@ module Weather
       | (?Hash[Symbol, untyped]) -> void
 
       attr_accessor chance_of_rain: Float?
+
+      class ChanceOfRain < GetForecastOutput
+      end
     end
 
     class ListCitiesInput
@@ -95,6 +122,11 @@ module Weather
 
       attr_accessor next_token: String?
       attr_accessor page_size: Integer?
+
+      class NextToken < ListCitiesInput
+      end
+      class PageSize < ListCitiesInput
+      end
     end
 
     class ListCitiesOutput
@@ -108,6 +140,11 @@ module Weather
 
       attr_accessor next_token: String?
       attr_accessor items: Array[Types::CitySummary]?
+
+      class NextToken < ListCitiesOutput
+      end
+      class Items < ListCitiesOutput
+      end
     end
 
     class NoSuchResource
@@ -119,6 +156,9 @@ module Weather
       | (?Hash[Symbol, untyped]) -> void
 
       attr_accessor resource_type: String?
+
+      class ResourceType < NoSuchResource
+      end
     end
   end
 end

--- a/projections/weather/sig/weather/types.rbs
+++ b/projections/weather/sig/weather/types.rbs
@@ -13,10 +13,6 @@ module Weather
       attr_accessor latitude: Float?
       attr_accessor longitude: Float?
 
-      class Latitude < CityCoordinates
-      end
-      class Longitude < CityCoordinates
-      end
     end
 
     class CitySummary
@@ -31,10 +27,6 @@ module Weather
       attr_accessor city_id: String?
       attr_accessor name: String?
 
-      class CityId < CitySummary
-      end
-      class Name < CitySummary
-      end
     end
 
     class GetCityInput
@@ -47,8 +39,6 @@ module Weather
 
       attr_accessor city_id: String?
 
-      class CityId < GetCityInput
-      end
     end
 
     class GetCityOutput
@@ -63,10 +53,6 @@ module Weather
       attr_accessor name: String?
       attr_accessor coordinates: Types::CityCoordinates?
 
-      class Name < GetCityOutput
-      end
-      class Coordinates < GetCityOutput
-      end
     end
 
     class GetCurrentTimeOutput
@@ -79,8 +65,6 @@ module Weather
 
       attr_accessor time: Time?
 
-      class Time < GetCurrentTimeOutput
-      end
     end
 
     class GetForecastInput
@@ -93,8 +77,6 @@ module Weather
 
       attr_accessor city_id: String?
 
-      class CityId < GetForecastInput
-      end
     end
 
     class GetForecastOutput
@@ -107,8 +89,6 @@ module Weather
 
       attr_accessor chance_of_rain: Float?
 
-      class ChanceOfRain < GetForecastOutput
-      end
     end
 
     class ListCitiesInput
@@ -123,10 +103,6 @@ module Weather
       attr_accessor next_token: String?
       attr_accessor page_size: Integer?
 
-      class NextToken < ListCitiesInput
-      end
-      class PageSize < ListCitiesInput
-      end
     end
 
     class ListCitiesOutput
@@ -141,10 +117,6 @@ module Weather
       attr_accessor next_token: String?
       attr_accessor items: Array[Types::CitySummary]?
 
-      class NextToken < ListCitiesOutput
-      end
-      class Items < ListCitiesOutput
-      end
     end
 
     class NoSuchResource
@@ -157,8 +129,6 @@ module Weather
 
       attr_accessor resource_type: String?
 
-      class ResourceType < NoSuchResource
-      end
     end
   end
 end


### PR DESCRIPTION
Use Ruby SDK v3 style union sealed classes - no longer generate `to_h` methods and make them structs just like structures. Usage:

```
case resp.union.member
when :foo then do_thing(resp.union.value)
when :unknown then do_unknown
end

# or

case resp.union
when Service::Types::Union::Foo then do_thing(resp.union.value)
when Service::Types::Union::Unknown then do_unknown
end
```

Parsing will use subclasses of a struct:

```
union = Service::Types::Union::Foo.new(foo: 'foo')

union.members # [:foo, :unknown] new method as well as other struct methods
union.member # [:foo], because it is set
union.value # foo, because it is set

# instead of

union = Service::Types::Union::Foo.new('foo') # delegation
```
