### PR TITLE
Support vendor params in protocol tests

### DIFF
--- a/gems/smithy-client/lib/smithy-client/dynamic_errors.rb
+++ b/gems/smithy-client/lib/smithy-client/dynamic_errors.rb
@@ -52,7 +52,6 @@ module Smithy
       # @return [Symbol] Returns a symbolized constant name for the given `error_code`.
       def error_class_constant(error_code)
         constant = error_code.to_s
-        constant = constant.gsub(/https?:.*$/, '')
         constant = constant.gsub(/[^a-zA-Z0-9]/, '')
         constant = "Error#{constant}" unless constant.match(/^[a-z]/i)
         constant = constant[0].upcase + constant[1..]

--- a/gems/smithy-client/spec/smithy-client/dynamic_errors_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/dynamic_errors_spec.rb
@@ -19,11 +19,6 @@ module Smithy
         expect(mod.error_class('My.Error')).to be(mod::MyError)
       end
 
-      it 'removes http schemas from the error code' do
-        expect(mod.error_class('ErrorClass:http://example.com')).to be(mod::ErrorClass)
-        expect(mod.error_class('ErrorClass:https://example.com')).to be(mod::ErrorClass)
-      end
-
       it 'ensures the error class name starts with a letter' do
         expect(mod.error_class('123Code')).to be(mod::Error123Code)
       end

--- a/gems/smithy/lib/smithy/templates/client/protocol_spec.erb
+++ b/gems/smithy/lib/smithy/templates/client/protocol_spec.erb
@@ -20,9 +20,9 @@ module <%= module_name %>
         # <%= line %>
 <% end -%>
 <% if test.skip? -%>
-        it '<%= test.id %>', skip: '<%= test.skip_reason %>' do
+        it '<%= test['id'] %>', skip: '<%= test.skip_reason %>' do
 <% else -%>
-        it '<%= test.id %>' do
+        it '<%= test['id'] %>' do
 <% end -%>
 <% if test['host'] -%>
           client = Client.new(client_options.merge(endpoint: '<%= test.endpoint %>'))
@@ -80,9 +80,9 @@ module <%= module_name %>
         # <%= line %>
 <% end -%>
 <% if test.skip? -%>
-        it '<%= test.id %>', skip: '<%= test.skip_reason %>' do
+        it '<%= test['id'] %>', skip: '<%= test.skip_reason %>' do
 <% else -%>
-        it '<%= test.id %>' do
+        it '<%= test['id'] %>' do
 <% end -%>
           response = { status_code: <%= test['code'] %> }
 <% if test['headers'] -%>
@@ -114,9 +114,9 @@ module <%= module_name %>
         # <%= line %>
 <% end -%>
 <% if test.skip? -%>
-        it '<%= test.id %>: <%= test.error_name %>', skip: '<%= test.skip_reason %>' do
+        it '<%= test['id'] %>: <%= test.error_name %>', skip: '<%= test.skip_reason %>' do
 <% else -%>
-        it '<%= test.id %>: <%= test.error_name %>' do
+        it '<%= test['id'] %>: <%= test.error_name %>' do
 <% end -%>
           response = { status_code: <%= test['code'] %> }
 <% if test['headers'] -%>
@@ -131,7 +131,9 @@ module <%= module_name %>
 <% end -%>
           client.stub_responses(:<%= operation_tests.name %>, response)
           expect { client.<%= operation_tests.name %> }.to raise_error do |e|
-<% test.expect do |line| %>
+            expect(e).to be_a(Errors::<%= test.error_name %>)
+            expect(e.data.to_h).to match_data(<%= test.params %>)
+<% test.vendor_code(:error_expect_code) do |line| %>
             <%= line %>
 <% end -%>
           end

--- a/gems/smithy/lib/smithy/templates/client/protocol_spec.erb
+++ b/gems/smithy/lib/smithy/templates/client/protocol_spec.erb
@@ -133,7 +133,7 @@ module <%= module_name %>
           expect { client.<%= operation_tests.name %> }.to raise_error do |e|
             expect(e).to be_a(Errors::<%= test.error_name %>)
             expect(e.data.to_h).to match_data(<%= test.params %>)
-<% test.vendor_code(:error_expect_code) do |line| %>
+<% test.vendor_code(:error_expect_code).each do |line| -%>
             <%= line %>
 <% end -%>
           end

--- a/gems/smithy/lib/smithy/templates/client/protocol_spec.erb
+++ b/gems/smithy/lib/smithy/templates/client/protocol_spec.erb
@@ -16,7 +16,7 @@ module <%= module_name %>
 <% unless operation_tests.request_tests.empty? -%>
       describe 'requests' do
 <% operation_tests.request_tests.each do |test| -%>
-<% test.comments.each do |line| -%>
+<% test.docstrings.each do |line| -%>
         # <%= line %>
 <% end -%>
 <% if test.skip? -%>
@@ -69,6 +69,11 @@ module <%= module_name %>
 <% if test['body'] -%>
           <%= test.body_expect %>
 <% end -%>
+<% if test['vendorParams'] && test['vendorParamsShape'] -%>
+<% test.vendor_code.each do |line| %>
+          <%= line %>
+<% end -%>
+<% end -%>
         end
 <% end -%>
       end
@@ -76,7 +81,7 @@ module <%= module_name %>
 <% unless operation_tests.response_tests.empty? -%>
       describe 'responses' do
 <% operation_tests.response_tests.each do |test| -%>
-<% test.comments.each do |line| -%>
+<% test.docstrings.each do |line| -%>
         # <%= line %>
 <% end -%>
 <% if test.skip? -%>
@@ -103,6 +108,11 @@ module <%= module_name %>
           response.data.<%= member_name.underscore %> = nil if response.data.<%= member_name.underscore %>.empty?
 <% end -%>
           <%= test.data_expect %>
+<% if test['vendorParams'] && test['vendorParamsShape'] -%>
+<% test.vendor_code.each do |line| %>
+          <%= line %>
+<% end -%>
+<% end -%>
         end
 <% end -%>
       end
@@ -110,7 +120,7 @@ module <%= module_name %>
 <% unless operation_tests.error_tests.empty? -%>
       describe 'response errors' do
 <% operation_tests.error_tests.each do |test| -%>
-<% test.comments.each do |line| -%>
+<% test.docstrings.each do |line| -%>
         # <%= line %>
 <% end -%>
 <% if test.skip? -%>
@@ -133,6 +143,11 @@ module <%= module_name %>
           expect { client.<%= operation_tests.name %> }.to raise_error do |e|
             expect(e).to be_a(Errors::<%= test.error_name %>)
             <%= test.data_expect %>
+<% if test['vendorParams'] && test['vendorParamsShape'] -%>
+<% test.vendor_code.each do |line| %>
+            <%= line %>
+<% end -%>
+<% end -%>
           end
         end
 <% end -%>

--- a/gems/smithy/lib/smithy/templates/client/protocol_spec.erb
+++ b/gems/smithy/lib/smithy/templates/client/protocol_spec.erb
@@ -69,11 +69,6 @@ module <%= module_name %>
 <% if test['body'] -%>
           <%= test.body_expect %>
 <% end -%>
-<% if test['vendorParams'] && test['vendorParamsShape'] -%>
-<% test.vendor_code.each do |line| %>
-          <%= line %>
-<% end -%>
-<% end -%>
         end
 <% end -%>
       end
@@ -108,11 +103,6 @@ module <%= module_name %>
           response.data.<%= member_name.underscore %> = nil if response.data.<%= member_name.underscore %>.empty?
 <% end -%>
           <%= test.data_expect %>
-<% if test['vendorParams'] && test['vendorParamsShape'] -%>
-<% test.vendor_code.each do |line| %>
-          <%= line %>
-<% end -%>
-<% end -%>
         end
 <% end -%>
       end
@@ -141,12 +131,8 @@ module <%= module_name %>
 <% end -%>
           client.stub_responses(:<%= operation_tests.name %>, response)
           expect { client.<%= operation_tests.name %> }.to raise_error do |e|
-            expect(e).to be_a(Errors::<%= test.error_name %>)
-            <%= test.data_expect %>
-<% if test['vendorParams'] && test['vendorParamsShape'] -%>
-<% test.vendor_code.each do |line| %>
+<% test.expect do |line| %>
             <%= line %>
-<% end -%>
 <% end -%>
           end
         end

--- a/gems/smithy/lib/smithy/views/client/protocol_spec.rb
+++ b/gems/smithy/lib/smithy/views/client/protocol_spec.rb
@@ -108,12 +108,8 @@ module Smithy
             @output_shape = Model.shape(@model, @operation['output']['target'])
           end
 
-          def vendor_params?
-            @test_case['vendorParamsShape'] && @test_case['vendorParams']
-          end
-
           def vendor_code(method)
-            return [] unless vendor_params?
+            return [] unless @test_case['vendorParamsShape'] && @test_case['vendorParams']
 
             vendor_code = @vendor_code[@test_case['vendorParamsShape']]
             unless vendor_code.respond_to?(method)

--- a/gems/smithy/lib/smithy/views/client/protocol_spec.rb
+++ b/gems/smithy/lib/smithy/views/client/protocol_spec.rb
@@ -108,8 +108,19 @@ module Smithy
             @output_shape = Model.shape(@model, @operation['output']['target'])
           end
 
-          def vendor_code?
+          def vendor_params?
             @test_case['vendorParamsShape'] && @test_case['vendorParams']
+          end
+
+          def vendor_code(method)
+            return [] unless vendor_params?
+
+            vendor_code_class = @vendor_code[@test_case['vendorParamsShape']]
+            unless vendor_code_class.respond_to?(method)
+              raise "Unhandled protocol test vendor code for shape: '#{@test_case['vendorParamsShape']}. '" \
+                    "Please implement a class that responds to :#{method} and register it with a weld."
+            end
+            vendor_code_class.send(method, @test_case['vendorParams'])
           end
 
           def [](key)
@@ -118,10 +129,6 @@ module Smithy
 
           def docstrings
             @test_case.fetch('documentation', '').split("\n")
-          end
-
-          def id
-            @test_case['id']
           end
 
           def additional_requires
@@ -144,14 +151,14 @@ module Smithy
             @operation
               .fetch('traits', {})
               .fetch('smithy.ruby#skipTests', [])
-              .any? { |skip| skip['id'] == id }
+              .any? { |skip| skip['id'] == @test_case['id'] }
           end
 
           def skip_reason
             @operation
               .fetch('traits', {})
               .fetch('smithy.ruby#skipTests', [])
-              .find { |skip| skip['id'] == id }
+              .find { |skip| skip['id'] == @test_case['id'] }
               &.fetch('reason', 'skipped')
           end
         end
@@ -254,22 +261,6 @@ module Smithy
 
           def params
             ShapeToHash.transform_value(@model, @test_case.fetch('params', {}), @error_shape)
-          end
-
-          def expect
-            expect = [
-              "expect(e).to be_a(Errors::#{error_name})",
-              "expect(e.data.to_h).to match_data(#{params})"
-            ]
-            return expect unless vendor_code?
-
-            vendor_code_class = @vendor_code[@test_case['vendorParamsShape']]
-            unless vendor_code_class.respond_to?(:error_expect_code)
-              raise "Unhandled protocol test vendor code for shape: '#{@test_case['vendorParamsShape']}. '" \
-                    'Please implement a class that responds to :error_expect_code and register it with a weld.'
-            end
-            expect.concat(vendor_code_class.error_expect_code(@test_case['vendorParams']).split("\n"))
-            expect
           end
         end
       end

--- a/gems/smithy/lib/smithy/views/client/protocol_spec.rb
+++ b/gems/smithy/lib/smithy/views/client/protocol_spec.rb
@@ -115,12 +115,12 @@ module Smithy
           def vendor_code(method)
             return [] unless vendor_params?
 
-            vendor_code_class = @vendor_code[@test_case['vendorParamsShape']]
-            unless vendor_code_class.respond_to?(method)
+            vendor_code = @vendor_code[@test_case['vendorParamsShape']]
+            unless vendor_code.respond_to?(method)
               raise "Unhandled protocol test vendor code for shape: '#{@test_case['vendorParamsShape']}. '" \
                     "Please implement a class that responds to :#{method} and register it with a weld."
             end
-            vendor_code_class.send(method, @test_case['vendorParams'])
+            vendor_code.send(method, @test_case['vendorParams']).split("\n")
           end
 
           def [](key)

--- a/gems/smithy/lib/smithy/views/client/protocol_spec.rb
+++ b/gems/smithy/lib/smithy/views/client/protocol_spec.rb
@@ -14,7 +14,7 @@ module Smithy
             Model::ServiceIndex
             .new(@model)
             .operations_for(@plan.service)
-            .map { |id, o| OperationTests.new(@model, id, o) }
+            .map { |id, o| OperationTests.new(@plan, @model, id, o) }
             .reject(&:empty?)
           super()
         end
@@ -31,7 +31,8 @@ module Smithy
 
         # @api private
         class OperationTests
-          def initialize(model, id, operation)
+          def initialize(plan, model, id, operation)
+            @plan = plan
             @model = model
             @id = id
             @operation = operation
@@ -61,7 +62,7 @@ module Smithy
               .fetch('traits', {})
               .fetch('smithy.test#httpResponseTests', [])
               .select { |t| t.fetch('appliesTo', 'client') == 'client' }
-              .map { |t| ResponseTest.new(@model, @operation, t) }
+              .map { |t| ResponseTest.new(@plan, @model, @operation, t) }
           end
 
           def build_request_tests
@@ -69,7 +70,7 @@ module Smithy
               .fetch('traits', {})
               .fetch('smithy.test#httpRequestTests', [])
               .select { |t| t.fetch('appliesTo', 'client') == 'client' }
-              .map { |t| RequestTest.new(@model, @operation, t) }
+              .map { |t| RequestTest.new(@plan, @model, @operation, t) }
           end
 
           def build_error_tests
@@ -85,13 +86,14 @@ module Smithy
             error_shape
               .fetch('traits', {})
               .fetch('smithy.test#httpResponseTests', [])
-              .map { |t| ErrorTest.new(@model, @operation, error['target'], t) }
+              .map { |t| ErrorTest.new(@plan, @model, @operation, error['target'], t) }
           end
         end
 
         # @api private
         class TestCase
-          def initialize(model, operation, test_case)
+          def initialize(plan, model, operation, test_case)
+            @plan = plan
             @model = model
             @operation = operation
             @test_case = test_case
@@ -99,25 +101,23 @@ module Smithy
             @output_shape = Model.shape(@model, @operation['output']['target'])
           end
 
-          attr_reader :test_case
-
           def [](key)
-            test_case[key]
+            @test_case[key]
           end
 
-          def comments
-            test_case.fetch('documentation', '').split("\n")
+          def docstrings
+            @test_case.fetch('documentation', '').split("\n")
           end
 
           def id
-            test_case['id']
+            @test_case['id']
           end
 
           def additional_requires
             requires = []
-            if test_case['bodyMediaType']
+            if @test_case['bodyMediaType']
               requires +=
-                case test_case['bodyMediaType']
+                case @test_case['bodyMediaType']
                 when 'application/cbor'
                   %w[base64]
                 when 'application/json'
@@ -127,6 +127,16 @@ module Smithy
                 end
             end
             requires
+          end
+
+          def vendor_code
+            vendor_code =
+              @plan
+              .welds
+              .map { |w| w.protocol_test_vendor_code(@test_case['vendorParams']) }
+              .reduce({}, :merge)
+            default = "raise \"Unhandled vendor code for shape: '#{@test_case['vendorParamsShape']}'\""
+            vendor_code.fetch(@test_case['vendorParamsShape'], default).split("\n")
           end
 
           def skip?
@@ -148,34 +158,35 @@ module Smithy
         # @api private
         class RequestTest < TestCase
           def params
-            ShapeToHash.transform_value(@model, test_case.fetch('params', {}), @input_shape)
+            ShapeToHash.transform_value(@model, @test_case.fetch('params', {}), @input_shape)
           end
 
           def endpoint
-            "https://#{test_case.fetch('host', '127.0.0.1')}"
+            "https://#{@test_case.fetch('host', '127.0.0.1')}"
           end
 
           def body_expect
-            return nil unless test_case['body']
+            return nil unless @test_case['body']
 
-            case test_case['bodyMediaType']
+            case @test_case['bodyMediaType']
             when 'application/cbor'
               'expect(Smithy::CBOR.decode(request.body.read)).' \
-              "to match_data(Smithy::CBOR.decode(::Base64.decode64('#{test_case['body']}')))"
+              "to match_data(Smithy::CBOR.decode(::Base64.decode64('#{@test_case['body']}')))"
             when 'application/json'
-              "expect(JSON.parse(request.body.read)).to eq(JSON.parse('#{test_case['body']}'))"
+              "expect(JSON.parse(request.body.read)).to eq(JSON.parse('#{@test_case['body']}'))"
             else
-              "expect(request.body.read).to eq('#{test_case['body']}')"
+              "expect(request.body.read).to eq('#{@test_case['body']}')"
             end
           end
 
           def query_expect?
-            test_case['queryParams'] || test_case['forbidQueryParams'] || test_case['requireQueryParams']
+            @test_case['queryParams'] || @test_case['forbidQueryParams'] || @test_case['requireQueryParams']
           end
 
           def idempotency_token_trait?
-            @input_shape.fetch('members', {})
-                        .any? { |_name, shape| shape.fetch('traits', {}).key?('smithy.api#idempotencyToken') }
+            @input_shape
+              .fetch('members', {})
+              .any? { |_name, shape| shape.fetch('traits', {}).key?('smithy.api#idempotencyToken') }
           end
         end
 
@@ -207,16 +218,16 @@ module Smithy
           end
 
           def stub_body
-            case test_case['bodyMediaType']
+            case @test_case['bodyMediaType']
             when 'application/cbor'
-              "::Base64.decode64('#{test_case['body']}')"
+              "::Base64.decode64('#{@test_case['body']}')"
             else
-              "'#{test_case['body']}'"
+              "'#{@test_case['body']}'"
             end
           end
 
           def data_expect
-            output = ShapeToHash.transform_value(@model, test_case.fetch('params', {}), @output_shape)
+            output = ShapeToHash.transform_value(@model, @test_case.fetch('params', {}), @output_shape)
             "expect(response.data.to_h).to match_data(#{output})"
           end
 
@@ -230,8 +241,8 @@ module Smithy
 
         # @api private
         class ErrorTest < ResponseTest
-          def initialize(model, operation, error_id, test_case)
-            super(model, operation, test_case)
+          def initialize(plan, model, operation, error_id, test_case)
+            super(plan, model, operation, test_case)
             @error_id = error_id
             @error_shape = Model.shape(@model, error_id)
           end
@@ -241,7 +252,7 @@ module Smithy
           end
 
           def params
-            ShapeToHash.transform_value(@model, test_case.fetch('params', {}), @error_shape)
+            ShapeToHash.transform_value(@model, @test_case.fetch('params', {}), @error_shape)
           end
 
           def data_expect

--- a/gems/smithy/lib/smithy/views/client/protocol_spec.rb
+++ b/gems/smithy/lib/smithy/views/client/protocol_spec.rb
@@ -14,7 +14,7 @@ module Smithy
             Model::ServiceIndex
             .new(@model)
             .operations_for(@plan.service)
-            .map { |id, o| OperationTests.new(@plan, @model, id, o) }
+            .map { |id, o| OperationTests.new(@model, id, o, vendor_code) }
             .reject(&:empty?)
           super()
         end
@@ -29,13 +29,20 @@ module Smithy
           Set.new(@all_operation_tests.map(&:additional_requires).flatten)
         end
 
+        def vendor_code
+          @plan
+            .welds
+            .map(&:protocol_test_vendor_code)
+            .reduce({}, :merge)
+        end
+
         # @api private
         class OperationTests
-          def initialize(plan, model, id, operation)
-            @plan = plan
+          def initialize(model, id, operation, vendor_code)
             @model = model
             @id = id
             @operation = operation
+            @vendor_code = vendor_code
             @request_tests = build_request_tests
             @response_tests = build_response_tests
             @error_tests = build_error_tests
@@ -62,7 +69,7 @@ module Smithy
               .fetch('traits', {})
               .fetch('smithy.test#httpResponseTests', [])
               .select { |t| t.fetch('appliesTo', 'client') == 'client' }
-              .map { |t| ResponseTest.new(@plan, @model, @operation, t) }
+              .map { |t| ResponseTest.new(@model, @operation, t, @vendor_code) }
           end
 
           def build_request_tests
@@ -70,7 +77,7 @@ module Smithy
               .fetch('traits', {})
               .fetch('smithy.test#httpRequestTests', [])
               .select { |t| t.fetch('appliesTo', 'client') == 'client' }
-              .map { |t| RequestTest.new(@plan, @model, @operation, t) }
+              .map { |t| RequestTest.new(@model, @operation, t, @vendor_code) }
           end
 
           def build_error_tests
@@ -86,19 +93,23 @@ module Smithy
             error_shape
               .fetch('traits', {})
               .fetch('smithy.test#httpResponseTests', [])
-              .map { |t| ErrorTest.new(@plan, @model, @operation, error['target'], t) }
+              .map { |t| ErrorTest.new(@model, @operation, error['target'], t, @vendor_code) }
           end
         end
 
         # @api private
         class TestCase
-          def initialize(plan, model, operation, test_case)
-            @plan = plan
+          def initialize(model, operation, test_case, vendor_code)
             @model = model
             @operation = operation
             @test_case = test_case
+            @vendor_code = vendor_code
             @input_shape = Model.shape(@model, @operation['input']['target'])
             @output_shape = Model.shape(@model, @operation['output']['target'])
+          end
+
+          def vendor_code?
+            @test_case['vendorParamsShape'] && @test_case['vendorParams']
           end
 
           def [](key)
@@ -127,16 +138,6 @@ module Smithy
                 end
             end
             requires
-          end
-
-          def vendor_code
-            vendor_code =
-              @plan
-              .welds
-              .map { |w| w.protocol_test_vendor_code(@test_case['vendorParams']) }
-              .reduce({}, :merge)
-            default = "raise \"Unhandled vendor code for shape: '#{@test_case['vendorParamsShape']}'\""
-            vendor_code.fetch(@test_case['vendorParamsShape'], default).split("\n")
           end
 
           def skip?
@@ -241,8 +242,8 @@ module Smithy
 
         # @api private
         class ErrorTest < ResponseTest
-          def initialize(plan, model, operation, error_id, test_case)
-            super(plan, model, operation, test_case)
+          def initialize(model, operation, error_id, test_case, vendor_code)
+            super(model, operation, test_case, vendor_code)
             @error_id = error_id
             @error_shape = Model.shape(@model, error_id)
           end
@@ -255,8 +256,20 @@ module Smithy
             ShapeToHash.transform_value(@model, @test_case.fetch('params', {}), @error_shape)
           end
 
-          def data_expect
-            "expect(e.data.to_h).to match_data(#{params})"
+          def expect
+            expect = [
+              "expect(e).to be_a(Errors::#{error_name})",
+              "expect(e.data.to_h).to match_data(#{params})"
+            ]
+            return expect unless vendor_code?
+
+            vendor_code_class = @vendor_code[@test_case['vendorParamsShape']]
+            unless vendor_code_class.respond_to?(:error_expect_code)
+              raise "Unhandled protocol test vendor code for shape: '#{@test_case['vendorParamsShape']}. '" \
+                    'Please implement a class that responds to :error_expect_code and register it with a weld.'
+            end
+            expect.concat(vendor_code_class.error_expect_code(@test_case['vendorParams']).split("\n"))
+            expect
           end
         end
       end

--- a/gems/smithy/lib/smithy/weld.rb
+++ b/gems/smithy/lib/smithy/weld.rb
@@ -94,5 +94,9 @@ module Smithy
     def remove_auth_schemes
       []
     end
+
+    def protocol_test_vendor_code(params)
+      {}
+    end
   end
 end

--- a/gems/smithy/lib/smithy/weld.rb
+++ b/gems/smithy/lib/smithy/weld.rb
@@ -95,7 +95,7 @@ module Smithy
       []
     end
 
-    def protocol_test_vendor_code(params)
+    def protocol_test_vendor_code
       {}
     end
   end

--- a/gems/smithy/lib/smithy/weld.rb
+++ b/gems/smithy/lib/smithy/weld.rb
@@ -95,6 +95,10 @@ module Smithy
       []
     end
 
+    # Called when generating protocol tests. The key should be the same as the vendor params shape
+    # in a protocol test, and the value should be a class that responds to one of the following methods:
+    # * error_expect_code(params) - returns a string that is rendered inside a rescue block (with error rescued as `e`).
+    # Protocol tests are run with RSpec and expectations should be used.
     def protocol_test_vendor_code
       {}
     end


### PR DESCRIPTION
Support vendor params hook in welds for protocol tests. These are needed for additional assertions.

Usage might be like:
```
      def protocol_test_vendor_code
        {
          'aws.protocoltests.config#ErrorCodeParams' => ErrorCodeParams.new
        }
      end

      # Used for generating error code expectations in protocol tests.
      class ErrorCodeParams
        def error_expect_code(params)
          <<~CODE
            expect(e.code).to eq('#{params['code']}')
            # except(e.type).to eq('#{params['type']}')
          CODE
        end
      end
```