### PR TITLE
JSON -> Json and HTTP -> Http

### DIFF
--- a/gems/smithy-client/lib/smithy-client/handler_context.rb
+++ b/gems/smithy-client/lib/smithy-client/handler_context.rb
@@ -9,8 +9,8 @@ module Smithy
       # @option options [Base] :client (nil)
       # @option options [Hash] :params ({})
       # @option options [Configuration] :config (nil)
-      # @option options [HTTP::Request] :http_request (HTTP::Request.new)
-      # @option options [HTTP::Response] :http_response (HTTP::Response.new)
+      # @option options [Http::Request] :http_request (Http::Request.new)
+      # @option options [Http::Response] :http_response (Http::Response.new)
       # @option options [Hash] :auth (nil)
       # @option options [Hash] :metadata ({})
       def initialize(options = {})
@@ -19,8 +19,8 @@ module Smithy
         @client = options[:client]
         @params = options[:params] || {}
         @config = options[:config]
-        @http_request = options[:http_request] || HTTP::Request.new
-        @http_response = options[:http_response] || HTTP::Response.new
+        @http_request = options[:http_request] || Http::Request.new
+        @http_response = options[:http_response] || Http::Response.new
         @auth = options[:auth]
         @retries = 0
         @metadata = {}
@@ -41,10 +41,10 @@ module Smithy
       # @return [Struct] The client configuration.
       attr_accessor :config
 
-      # @return [HTTP::Request]
+      # @return [Http::Request]
       attr_accessor :http_request
 
-      # @return [HTTP::Response]
+      # @return [Http::Response]
       attr_accessor :http_response
 
       # @return [Hash]

--- a/gems/smithy-client/lib/smithy-client/http/error_inspector.rb
+++ b/gems/smithy-client/lib/smithy-client/http/error_inspector.rb
@@ -4,7 +4,7 @@ require 'time'
 
 module Smithy
   module Client
-    module HTTP
+    module Http
       # An HTTP error inspector, using hints from status code and headers.
       class ErrorInspector
         def initialize(error, http_response)

--- a/gems/smithy-client/lib/smithy-client/http/headers.rb
+++ b/gems/smithy-client/lib/smithy-client/http/headers.rb
@@ -2,12 +2,12 @@
 
 module Smithy
   module Client
-    module HTTP
+    module Http
       # Provides a Hash-like interface for HTTP headers.  Header names
       # are treated indifferently as lower-cased strings.  Header values
       # are cast to strings.
       #
-      #     headers = HTTP::Headers.new
+      #     headers = Http::Headers.new
       #     headers['Content-Length'] = 100
       #     headers[:Authorization] = 'Abc'
       #

--- a/gems/smithy-client/lib/smithy-client/http/request.rb
+++ b/gems/smithy-client/lib/smithy-client/http/request.rb
@@ -4,7 +4,7 @@ require 'stringio'
 
 module Smithy
   module Client
-    module HTTP
+    module Http
       # Represents an HTTP request.
       class Request
         # @option options [String, URI::HTTP, URI::HTTPS, nil] :endpoint (nil)

--- a/gems/smithy-client/lib/smithy-client/http/response.rb
+++ b/gems/smithy-client/lib/smithy-client/http/response.rb
@@ -4,7 +4,7 @@ require 'stringio'
 
 module Smithy
   module Client
-    module HTTP
+    module Http
       # Represents an HTTP Response.
       class Response
         # @option options [Integer] :status_code (0)

--- a/gems/smithy-client/lib/smithy-client/net_http/handler.rb
+++ b/gems/smithy-client/lib/smithy-client/net_http/handler.rb
@@ -25,8 +25,8 @@ module Smithy
         private
 
         # @param [Configuration] config
-        # @param [HTTP::Request] req
-        # @param [HTTP::Response] resp
+        # @param [Http::Request] req
+        # @param [Http::Response] resp
         # @return [void]
         def transmit(config, req, resp)
           # Monkey patch default content-type set by Net::HTTP
@@ -85,7 +85,7 @@ module Smithy
         end
 
         # @param [Configuration] config
-        # @param [HTTP::Request] req
+        # @param [Http::Request] req
         # @yieldparam [Net::HTTP] http
         def session(config, req, &)
           pool_for(config).session_for(req.endpoint, &)
@@ -106,9 +106,9 @@ module Smithy
           end
         end
 
-        # Constructs and returns a Net::HTTP::Request object from a {HTTP::Request}.
-        # @param [HTTP::Request] request
-        # @return [Net::HTTP::Request]
+        # Constructs and returns a Net::Http::Request object from a {Http::Request}.
+        # @param [Http::Request] request
+        # @return [Net::Http::Request]
         def build_net_request(request)
           request_class = net_http_request_class(request)
           req = request_class.new(request.endpoint.request_uri, net_headers_for(request))
@@ -122,9 +122,9 @@ module Smithy
           req
         end
 
-        # @param [HTTP::Request] request
+        # @param [Http::Request] request
         # @raise [ArgumentError]
-        # @return Returns a base `Net::HTTP::Request` class, e.g.,
+        # @return Returns a base `Net::Http::Request` class, e.g.,
         #  `Net::HTTP::Get`, `Net::HTTP::Post`, etc.
         def net_http_request_class(request)
           Net::HTTP.const_get(request.http_method.capitalize)
@@ -134,7 +134,7 @@ module Smithy
         end
 
         # Validate that fields are not trailers and return a hash of headers.
-        # @param [HTTP::Request] request
+        # @param [Http::Request] request
         # @return [Hash<String, String>]
         def net_headers_for(request)
           # Net::HTTP adds a default header for accept-encoding (2.0.0+).
@@ -149,7 +149,7 @@ module Smithy
           headers
         end
 
-        # @param [Net::HTTP::Response] response
+        # @param [Net::Http::Response] response
         # @return [Hash<String, String>]
         def extract_headers(response)
           response.to_hash.transform_values(&:first)

--- a/gems/smithy-client/lib/smithy-client/plugins/retry_errors.rb
+++ b/gems/smithy-client/lib/smithy-client/plugins/retry_errors.rb
@@ -88,7 +88,7 @@ module Smithy
             if (error = response.error)
               return response unless retryable?(context.http_request)
 
-              error_info = HTTP::ErrorInspector.new(error, context.http_response)
+              error_info = Http::ErrorInspector.new(error, context.http_response)
               token = retry_strategy.refresh_retry_token(token, error_info)
               return response unless token
 

--- a/gems/smithy-client/lib/smithy-client/stubbing/null_protocol.rb
+++ b/gems/smithy-client/lib/smithy-client/stubbing/null_protocol.rb
@@ -6,11 +6,11 @@ module Smithy
       # @api private
       class NullProtocol
         def stub_data(_config, _operation, _data)
-          HTTP::Response.new
+          Http::Response.new
         end
 
         def stub_error(_config, _error_code)
-          HTTP::Response.new
+          Http::Response.new
         end
       end
     end

--- a/gems/smithy-client/lib/smithy-client/stubbing/rpc_v2_cbor.rb
+++ b/gems/smithy-client/lib/smithy-client/stubbing/rpc_v2_cbor.rb
@@ -6,7 +6,7 @@ module Smithy
       # @api private
       class RpcV2Cbor
         def stub_data(config, operation, data)
-          response = HTTP::Response.new
+          response = Http::Response.new
           response.status_code = 200
           response.headers['Smithy-Protocol'] = 'rpc-v2-cbor'
           response.headers['Content-Type'] = 'application/cbor'
@@ -15,7 +15,7 @@ module Smithy
         end
 
         def stub_error(_config, error_code)
-          response = HTTP::Response.new
+          response = Http::Response.new
           response.status_code = 400
           response.headers['Smithy-Protocol'] = 'rpc-v2-cbor'
           response.headers['Content-Type'] = 'application/cbor'

--- a/gems/smithy-client/lib/smithy-client/stubs.rb
+++ b/gems/smithy-client/lib/smithy-client/stubs.rb
@@ -194,7 +194,7 @@ module Smithy
       end
 
       def hash_to_http_response(data)
-        http_response = HTTP::Response.new
+        http_response = Http::Response.new
         http_response.status_code = data[:status_code]
         http_response.headers.update(data[:headers])
         http_response.body = data[:body]

--- a/gems/smithy-client/sig/smithy-client/handler_context.rbs
+++ b/gems/smithy-client/sig/smithy-client/handler_context.rbs
@@ -7,8 +7,8 @@ module Smithy
       attr_accessor client: Base?
       attr_accessor params: Hash[Symbol | String, untyped]
       attr_accessor config: Struct[untyped]?
-      attr_accessor http_request: HTTP::Request | untyped
-      attr_accessor http_response: HTTP::Response | untyped
+      attr_accessor http_request: Http::Request | untyped
+      attr_accessor http_response: Http::Response | untyped
       attr_accessor auth: Hash[Symbol, untyped]
       attr_accessor retries: Integer
       attr_reader metadata: Hash[untyped, untyped]

--- a/gems/smithy-client/sig/smithy-client/http/headers.rbs
+++ b/gems/smithy-client/sig/smithy-client/http/headers.rbs
@@ -1,6 +1,6 @@
 module Smithy
   module Client
-    module HTTP
+    module Http
       class Headers
         include Enumerable[[String,String]]
 

--- a/gems/smithy-client/sig/smithy-client/http/request.rbs
+++ b/gems/smithy-client/sig/smithy-client/http/request.rbs
@@ -1,6 +1,6 @@
 module Smithy
   module Client
-    module HTTP
+    module Http
       class Request
 
         def initialize: (?Hash[Symbol, untyped]) -> void

--- a/gems/smithy-client/sig/smithy-client/http/response.rbs
+++ b/gems/smithy-client/sig/smithy-client/http/response.rbs
@@ -1,6 +1,6 @@
 module Smithy
   module Client
-    module HTTP
+    module Http
       class Response
 
         def initialize: (?Hash[Symbol, untyped]) -> void

--- a/gems/smithy-client/spec/smithy-client/handler_context_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/handler_context_spec.rb
@@ -67,8 +67,8 @@ module Smithy
       end
 
       describe '#http_request' do
-        it 'defaults to HTTP::Request' do
-          expect(subject.http_request).to be_a(HTTP::Request)
+        it 'defaults to Http::Request' do
+          expect(subject.http_request).to be_a(Http::Request)
         end
 
         it 'can be set in the constructor' do
@@ -79,8 +79,8 @@ module Smithy
       end
 
       describe '#http_response' do
-        it 'defaults to HTTP::Response' do
-          expect(subject.http_response).to be_a(HTTP::Response)
+        it 'defaults to Http::Response' do
+          expect(subject.http_response).to be_a(Http::Response)
         end
 
         it 'can be set in the constructor' do

--- a/gems/smithy-client/spec/smithy-client/http/error_inspector_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/http/error_inspector_spec.rb
@@ -2,10 +2,10 @@
 
 module Smithy
   module Client
-    module HTTP
+    module Http
       describe ErrorInspector do
         let(:error) { ServiceError.new(HandlerContext.new, Schema::EmptyStructure.new) }
-        let(:http_response) { HTTP::Response.new(status_code: status_code) }
+        let(:http_response) { Http::Response.new(status_code: status_code) }
         let(:status_code) { 404 }
 
         subject { ErrorInspector.new(error, http_response) }

--- a/gems/smithy-client/spec/smithy-client/http/headers_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/http/headers_spec.rb
@@ -4,7 +4,7 @@ require_relative '../../spec_helper'
 
 module Smithy
   module Client
-    module HTTP
+    module Http
       describe Headers do
         let(:headers) { Headers.new }
 

--- a/gems/smithy-client/spec/smithy-client/http/request_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/http/request_spec.rb
@@ -4,7 +4,7 @@ require_relative '../../spec_helper'
 
 module Smithy
   module Client
-    module HTTP
+    module Http
       describe Request do
         subject { Request.new }
 
@@ -55,7 +55,7 @@ module Smithy
         end
 
         describe '#headers' do
-          it 'defaults to a HTTP::Headers' do
+          it 'defaults to a Http::Headers' do
             expect(subject.headers).to be_kind_of(Headers)
           end
 

--- a/gems/smithy-client/spec/smithy-client/http/response_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/http/response_spec.rb
@@ -4,7 +4,7 @@ require_relative '../../spec_helper'
 
 module Smithy
   module Client
-    module HTTP
+    module Http
       describe Response do
         subject { Response.new }
 
@@ -20,7 +20,7 @@ module Smithy
         end
 
         describe '#headers' do
-          it 'is a HTTP::Headers' do
+          it 'is a Http::Headers' do
             expect(subject.headers).to be_kind_of(Headers)
           end
 

--- a/gems/smithy-client/spec/smithy-client/log_formatter_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/log_formatter_spec.rb
@@ -73,38 +73,38 @@ module Smithy
         end
 
         it 'can format the HTTP request endpoint' do
-          response.context.http_request = HTTP::Request.new(endpoint: 'https://example.com:8080')
+          response.context.http_request = Http::Request.new(endpoint: 'https://example.com:8080')
           expect(formatted(':http_request_endpoint')).to eq('https://example.com:8080')
         end
 
         it 'can format the HTTP request scheme' do
-          response.context.http_request = HTTP::Request.new(endpoint: 'https://example.com')
+          response.context.http_request = Http::Request.new(endpoint: 'https://example.com')
           expect(formatted(':http_request_scheme')).to eq('https')
         end
 
         it 'can format the HTTP request host' do
-          response.context.http_request = HTTP::Request.new(endpoint: 'https://example.com')
+          response.context.http_request = Http::Request.new(endpoint: 'https://example.com')
           expect(formatted(':http_request_host')).to eq('example.com')
         end
 
         it 'can format the HTTP request port' do
-          response.context.http_request = HTTP::Request.new(endpoint: 'https://example.com:8080')
+          response.context.http_request = Http::Request.new(endpoint: 'https://example.com:8080')
           expect(formatted(':http_request_port')).to eq('8080')
         end
 
         it 'can format the HTTP request method' do
-          response.context.http_request = HTTP::Request.new(http_method: 'GET')
+          response.context.http_request = Http::Request.new(http_method: 'GET')
           expect(formatted(':http_request_method')).to eq('GET')
         end
 
         it 'can format the HTTP request headers' do
           headers = { 'foo' => 'bar' }
-          response.context.http_request = HTTP::Request.new(headers: headers)
+          response.context.http_request = Http::Request.new(headers: headers)
           expect(formatted(':http_request_headers')).to eq(headers.inspect)
         end
 
         it 'can format the HTTP request body' do
-          response.context.http_request = HTTP::Request.new(body: 'This is the request body')
+          response.context.http_request = Http::Request.new(body: 'This is the request body')
           expect(formatted(':http_request_body', max_string_size: 20))
             .to eq('#<String "This is the request " ... (24 bytes)>')
         end
@@ -112,23 +112,23 @@ module Smithy
         it 'formats with a blank body when request body is not rewindable' do
           body = StringIO.new
           expect(body).to receive(:respond_to?).with(:rewind).and_return(false)
-          response.context.http_request = HTTP::Request.new(body: body)
+          response.context.http_request = Http::Request.new(body: body)
           expect(formatted(':http_request_body')).to eq('')
         end
 
         it 'can format the HTTP response status code' do
-          response.context.http_response = HTTP::Response.new(status_code: 200)
+          response.context.http_response = Http::Response.new(status_code: 200)
           expect(formatted(':http_response_status_code')).to eq('200')
         end
 
         it 'can format the HTTP response headers' do
           headers = { 'foo' => 'bar' }
-          response.context.http_response = HTTP::Response.new(headers: headers)
+          response.context.http_response = Http::Response.new(headers: headers)
           expect(formatted(':http_response_headers')).to eq(headers.inspect)
         end
 
         it 'can format the HTTP response body' do
-          response.context.http_response = HTTP::Response.new(body: 'This is the response body')
+          response.context.http_response = Http::Response.new(body: 'This is the response body')
           expect(formatted(':http_response_body', max_string_size: 20))
             .to eq('#<String "This is the response" ... (25 bytes)>')
         end
@@ -136,7 +136,7 @@ module Smithy
         it 'formats with a blank body when response body is not rewindable' do
           body = StringIO.new
           expect(body).to receive(:respond_to?).with(:rewind).and_return(false)
-          response.context.http_response = HTTP::Response.new(body: body)
+          response.context.http_response = Http::Response.new(body: body)
           expect(formatted(':http_response_body')).to eq('')
         end
 

--- a/gems/smithy-client/spec/smithy-client/plugins/response_target_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/response_target_spec.rb
@@ -52,7 +52,7 @@ module Smithy
             headers = nil
             proc = proc { |_chunk, header| headers = header }
             client.operation({}, target: proc)
-            expect(headers).to be_an_instance_of(HTTP::Headers)
+            expect(headers).to be_an_instance_of(Http::Headers)
           end
         end
 

--- a/gems/smithy-client/spec/smithy-client/plugins/stub_responses_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/stub_responses_spec.rb
@@ -54,29 +54,29 @@ module Smithy
         end
 
         it 'signals error for exceptions' do
-          expect_any_instance_of(HTTP::Response).to receive(:signal_error)
+          expect_any_instance_of(Http::Response).to receive(:signal_error)
           client.stub_responses(:operation, RuntimeError.new('error'))
           client.operation
         end
 
         it 'signals error for exception classes' do
-          expect_any_instance_of(HTTP::Response).to receive(:signal_error)
+          expect_any_instance_of(Http::Response).to receive(:signal_error)
           client.stub_responses(:operation, Timeout::Error)
           client.operation
         end
 
         it 'signals http for a service error' do
-          expect_any_instance_of(HTTP::Response).to receive(:signal_headers)
-          expect_any_instance_of(HTTP::Response).to receive(:signal_data)
-          expect_any_instance_of(HTTP::Response).to receive(:signal_done)
+          expect_any_instance_of(Http::Response).to receive(:signal_headers)
+          expect_any_instance_of(Http::Response).to receive(:signal_data)
+          expect_any_instance_of(Http::Response).to receive(:signal_done)
           client.stub_responses(:operation, 'Error')
           client.operation
         end
 
         it 'signals http for a data stub' do
-          expect_any_instance_of(HTTP::Response).to receive(:signal_headers)
-          expect_any_instance_of(HTTP::Response).to receive(:signal_data)
-          expect_any_instance_of(HTTP::Response).to receive(:signal_done)
+          expect_any_instance_of(Http::Response).to receive(:signal_headers)
+          expect_any_instance_of(Http::Response).to receive(:signal_data)
+          expect_any_instance_of(Http::Response).to receive(:signal_done)
           client.stub_responses(:operation, { string: 'stubbed-data' })
           client.operation
         end

--- a/gems/smithy-client/spec/smithy-client/response_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/response_spec.rb
@@ -77,7 +77,7 @@ module Smithy
         end
 
         it 'sets error using the http response listener' do
-          http_response = HTTP::Response.new
+          http_response = Http::Response.new
           response = Response.new(context: HandlerContext.new(http_response: http_response))
           error = StandardError.new
           http_response.signal_error(error)
@@ -87,7 +87,7 @@ module Smithy
 
       describe '#on_done' do
         it 'returns and yields self when done' do
-          http_response = HTTP::Response.new
+          http_response = Http::Response.new
           response = Response.new(context: HandlerContext.new(http_response: http_response))
           yielded = false
 

--- a/gems/smithy-json/lib/smithy-json.rb
+++ b/gems/smithy-json/lib/smithy-json.rb
@@ -5,8 +5,8 @@ require 'smithy-schema'
 require_relative 'smithy-json/codec'
 
 module Smithy
-  # Smithy::JSON is a purpose-built set of utilities for working with JSON.
-  module JSON
+  # Smithy::Json is a purpose-built set of utilities for working with JSON.
+  module Json
     VERSION = File.read(File.expand_path('../VERSION', __dir__.to_s)).strip
 
     # Raised when a JSON parsing error occurs.

--- a/gems/smithy-json/lib/smithy-json/codec.rb
+++ b/gems/smithy-json/lib/smithy-json/codec.rb
@@ -4,7 +4,7 @@ require_relative 'deserializer'
 require_relative 'serializer'
 
 module Smithy
-  module JSON
+  module Json
     # @api private
     class Codec
       # @param [Hash] options

--- a/gems/smithy-json/lib/smithy-json/deserializer.rb
+++ b/gems/smithy-json/lib/smithy-json/deserializer.rb
@@ -3,7 +3,7 @@
 require 'base64'
 
 module Smithy
-  module JSON
+  module Json
     # @api private
     class Deserializer
       include Smithy::Schema::Shapes
@@ -16,7 +16,7 @@ module Smithy
         return {} if bytes.empty?
 
         ref = shape.is_a?(ShapeRef) ? shape : ShapeRef.new(shape: shape)
-        shape(ref, Smithy::JSON.load(bytes), target)
+        shape(ref, Smithy::Json.load(bytes), target)
       end
 
       private

--- a/gems/smithy-json/lib/smithy-json/json_engine.rb
+++ b/gems/smithy-json/lib/smithy-json/json_engine.rb
@@ -3,7 +3,7 @@
 require 'json'
 
 module Smithy
-  module JSON
+  module Json
     # @api private
     module JsonEngine
       class << self

--- a/gems/smithy-json/lib/smithy-json/oj_engine.rb
+++ b/gems/smithy-json/lib/smithy-json/oj_engine.rb
@@ -3,7 +3,7 @@
 require 'oj'
 
 module Smithy
-  module JSON
+  module Json
     # @api private
     module OjEngine
       class << self

--- a/gems/smithy-json/lib/smithy-json/serializer.rb
+++ b/gems/smithy-json/lib/smithy-json/serializer.rb
@@ -3,7 +3,7 @@
 require 'base64'
 
 module Smithy
-  module JSON
+  module Json
     # @api private
     class Serializer
       include Smithy::Schema::Shapes
@@ -14,7 +14,7 @@ module Smithy
 
       def serialize(shape, data)
         ref = shape.is_a?(ShapeRef) ? shape : ShapeRef.new(shape: shape)
-        Smithy::JSON.dump(shape(ref, data))
+        Smithy::Json.dump(shape(ref, data))
       end
 
       private

--- a/gems/smithy-json/sig/smithy-json/codec.rbs
+++ b/gems/smithy-json/sig/smithy-json/codec.rbs
@@ -1,5 +1,5 @@
 module Smithy
-  module JSON
+  module Json
     class Codec
       def serialize: (Schema::Shapes::Shape shape, untyped data) -> (nil | String)
       def deserialize: (Schema::Shapes::Shape shape, String bytes, ?Struct[untyped] target) -> (nil | Hash[untyped, untyped] | Array[untyped] | Time | Numeric | String | ::Struct[untyped] | Schema::Union)

--- a/gems/smithy-json/spec/smithy-json/codec_spec.rb
+++ b/gems/smithy-json/spec/smithy-json/codec_spec.rb
@@ -3,7 +3,7 @@
 require_relative '../spec_helper'
 
 module Smithy
-  module JSON
+  module Json
     describe Codec do
       let(:shapes) { SchemaHelper.sample_shapes }
       let(:sample_schema) { SchemaHelper.sample_schema(shapes: shapes) }

--- a/gems/smithy-json/spec/smithy-json_spec.rb
+++ b/gems/smithy-json/spec/smithy-json_spec.rb
@@ -3,7 +3,7 @@
 require_relative 'spec_helper'
 
 module Smithy
-  describe JSON do
+  describe Json do
     %i[oj json].each do |engine|
       describe("ENGINE: #{engine},") do
         before do
@@ -25,7 +25,7 @@ module Smithy
             let(:raw_json) { '<ServiceUnavailableException/>' }
 
             it 'raises a ParseError' do
-              expect { subject.load(raw_json) }.to raise_error(Smithy::JSON::ParseError)
+              expect { subject.load(raw_json) }.to raise_error(Smithy::Json::ParseError)
             end
           end
 
@@ -33,7 +33,7 @@ module Smithy
             let(:raw_json) { '{ "steve": }' }
 
             it 'raises a ParseError' do
-              expect { subject.load(raw_json) }.to raise_error(Smithy::JSON::ParseError)
+              expect { subject.load(raw_json) }.to raise_error(Smithy::Json::ParseError)
             end
           end
         end


### PR DESCRIPTION
Safe renames of JSON -> Json and HTTP -> Http. This is because if the modules are not loaded, we attempt to call modules that are loaded, such as JSON and Net::HTTP.