### PR TITLE
Make endpoint a built in and do not generate built ins

### DIFF
--- a/gems/smithy-client/lib/smithy-client/api_key_signer.rb
+++ b/gems/smithy-client/lib/smithy-client/api_key_signer.rb
@@ -24,7 +24,7 @@ module Smithy
         end
       end
 
-      def presign_url(_context)
+      def presign_url(*args)
         raise NotImplementedError
       end
 

--- a/gems/smithy-client/lib/smithy-client/bearer_token_signer.rb
+++ b/gems/smithy-client/lib/smithy-client/bearer_token_signer.rb
@@ -10,7 +10,7 @@ module Smithy
         context.http_request.headers['Authorization'] = "Bearer #{provider.identity.token}"
       end
 
-      def presign_url(_context)
+      def presign_url(*args)
         raise NotImplementedError
       end
     end

--- a/gems/smithy-client/lib/smithy-client/login_signer.rb
+++ b/gems/smithy-client/lib/smithy-client/login_signer.rb
@@ -17,7 +17,7 @@ module Smithy
         sign_with_basic(context.http_request, context.config.login_provider)
       end
 
-      def presign_url(_context)
+      def presign_url(*args)
         raise NotImplementedError
       end
 

--- a/gems/smithy/lib/smithy/templates/client/endpoint_parameters.erb
+++ b/gems/smithy/lib/smithy/templates/client/endpoint_parameters.erb
@@ -9,9 +9,7 @@ module <%= module_name %>
 <% param.docstrings.each do |docstring| -%>
   #   <%= docstring %>
 <% end -%>
-  #
   #   @return [<%= param.documentation_type %>]
-  #
 <% end -%>
   EndpointParameters = Struct.new(
 <% parameters.each do |param| -%>
@@ -24,7 +22,7 @@ module <%= module_name %>
       self.<%= param.name %> = options.fetch(:<%= param.name %>, <%= param.default_value %>)
 <% end -%>
 <% parameters.select(&:validate_required?).each do |param| -%>
-      raise ArgumentError, "Missing required EndpointParameter: :<%= param.name %>" if <%= param.name %>.nil?
+      raise ArgumentError, "missing required parameter: :<%= param.name %>" if <%= param.name %>.nil?
 <% end -%>
     end
 

--- a/gems/smithy/lib/smithy/templates/client/endpoint_plugin.erb
+++ b/gems/smithy/lib/smithy/templates/client/endpoint_plugin.erb
@@ -7,6 +7,15 @@ module <%= module_name %>
     # @api private
     class Endpoint < Smithy::Client::Plugin
       option(
+        :endpoint,
+        doc_type: 'String',
+        docstring: <<~DOCS
+          The endpoint to send requests to.
+          The endpoint should be a URI formatted like "http://example.com:123"'
+        DOCS
+      )
+
+      option(
         :endpoint_provider,
         doc_type: '#resolve(parameters)',
         doc_default: '<%= module_name %>::EndpointProvider',
@@ -16,12 +25,6 @@ module <%= module_name %>
         EndpointProvider.new
       end
 
-<% parameters.select(&:built_in?).each do |param| -%>
-<% param.built_in_binding[:render_config].call(plan).split("\n").each do |line| -%>
-      <%= line %>
-<% end -%>
-
-<% end -%>
 <% parameters.select(&:client_context?).each do |param| -%>
       option(
         :<%= param.name %>,

--- a/gems/smithy/lib/smithy/views/client/endpoint_provider_spec.rb
+++ b/gems/smithy/lib/smithy/views/client/endpoint_provider_spec.rb
@@ -25,15 +25,14 @@ module Smithy
 
         def initialize_rules(service)
           @endpoint_rules = service['traits']['smithy.rules#endpointRuleSet']
-
-          @parameters = @endpoint_rules['parameters']
-                        .map { |id, data| EndpointParameter.new(id, data, @plan) }
+          @parameters = @endpoint_rules['parameters'].map { |id, data| EndpointParameter.new(id, data, @plan) }
         end
 
         def initialize_tests(service)
           @endpoint_tests = service['traits']['smithy.rules#endpointTests'] || {}
-          @test_cases = @endpoint_tests['testCases']
-                        &.map { |data| EndpointTestCase.new(data, @plan, @operations) } || []
+          @test_cases = @endpoint_tests.fetch('testCases', []).map do |data|
+            EndpointTestCase.new(data, @plan, @operations)
+          end
         end
 
         # @api private
@@ -100,10 +99,7 @@ module Smithy
           end
 
           def built_in_bindings
-            @built_in_bindings ||=
-              @plan.welds
-                   .map(&:endpoint_built_in_bindings)
-                   .reduce({}, :merge)
+            @built_in_bindings ||= @plan.welds.map(&:endpoint_built_in_bindings).reduce({}, :merge)
           end
 
           def built_in_to_param(built_in, value)

--- a/gems/smithy/lib/smithy/weld.rb
+++ b/gems/smithy/lib/smithy/weld.rb
@@ -50,8 +50,11 @@ module Smithy
 
     # Called when constructing endpoint parameters. Any bindings defined here will
     # be merged with other built-in bindings. The key is the name of the binding, and
-    # the value is the binding definition, which is a hash with keys :render_config,
-    # :render_build and :render_test_set.
+    # the value is the binding definition, which is a hash with keys :render_build and
+    # :render_test_set. :render_build is a proc that takes the plan as an argument and returns
+    # a string that is rendered in the endpoint parameters `.create` method. :render_test_set
+    # is a proc that takes the plan and the value of the built-in parameter as arguments,
+    # and returns a hash of parameters to be added to the test set.
     # @return [Hash<String, Hash>] endpoint built in bindings for use in endpoint rules.
     def endpoint_built_in_bindings
       {}

--- a/gems/smithy/lib/smithy/welds/transforms/endpoints.rb
+++ b/gems/smithy/lib/smithy/welds/transforms/endpoints.rb
@@ -15,15 +15,6 @@ module Smithy
       def endpoint_built_in_bindings
         {
           'SDK::Endpoint' => {
-            render_config: proc do |_plan|
-              <<~ADD_OPTION
-                option(
-                  :endpoint,
-                  doc_type: String,
-                  docstring: 'Custom Endpoint'
-                )
-              ADD_OPTION
-            end,
             render_build: proc do |_plan|
               'config.endpoint'
             end,

--- a/projections/shapes/lib/shapes/client.rb
+++ b/projections/shapes/lib/shapes/client.rb
@@ -67,7 +67,8 @@ module ShapeService
     # @option options [Boolean] :disable_request_compression
     #  When `true`, the request body will not be compressed for supported operations.
     # @option options [String] :endpoint
-    #  Custom Endpoint
+    #  The endpoint to send requests to.
+    #  The endpoint should be a URI formatted like "http://example.com:123"'
     # @option options [#resolve(parameters)] :endpoint_provider (ShapeService::EndpointProvider)
     #  An object that provides an endpoint to use for the request.
     # @option options [String] :http_ca_file

--- a/projections/shapes/lib/shapes/endpoint_parameters.rb
+++ b/projections/shapes/lib/shapes/endpoint_parameters.rb
@@ -6,9 +6,7 @@ module ShapeService
   # Endpoint parameters used to resolve endpoints per request.
   # @!attribute endpoint
   #   Endpoint used for making requests. Should be formatted as a URI.
-  #
   #   @return [String]
-  #
   EndpointParameters = Struct.new(
     :endpoint,
     keyword_init: true

--- a/projections/shapes/lib/shapes/plugins/endpoint.rb
+++ b/projections/shapes/lib/shapes/plugins/endpoint.rb
@@ -7,6 +7,15 @@ module ShapeService
     # @api private
     class Endpoint < Smithy::Client::Plugin
       option(
+        :endpoint,
+        doc_type: 'String',
+        docstring: <<~DOCS
+          The endpoint to send requests to.
+          The endpoint should be a URI formatted like "http://example.com:123"'
+        DOCS
+      )
+
+      option(
         :endpoint_provider,
         doc_type: '#resolve(parameters)',
         doc_default: 'ShapeService::EndpointProvider',
@@ -15,12 +24,6 @@ module ShapeService
       ) do |_config|
         EndpointProvider.new
       end
-
-      option(
-        :endpoint,
-        doc_type: String,
-        docstring: 'Custom Endpoint'
-      )
 
       option(:endpoint_auth_schemes) do
         {"bearer" => "smithy.api#httpBearerAuth", "none" => "smithy.api#noAuth"}

--- a/projections/weather/lib/weather/client.rb
+++ b/projections/weather/lib/weather/client.rb
@@ -67,7 +67,8 @@ module Weather
     # @option options [Boolean] :disable_request_compression
     #  When `true`, the request body will not be compressed for supported operations.
     # @option options [String] :endpoint
-    #  Custom Endpoint
+    #  The endpoint to send requests to.
+    #  The endpoint should be a URI formatted like "http://example.com:123"'
     # @option options [#resolve(parameters)] :endpoint_provider (Weather::EndpointProvider)
     #  An object that provides an endpoint to use for the request.
     # @option options [String] :http_ca_file

--- a/projections/weather/lib/weather/endpoint_parameters.rb
+++ b/projections/weather/lib/weather/endpoint_parameters.rb
@@ -6,9 +6,7 @@ module Weather
   # Endpoint parameters used to resolve endpoints per request.
   # @!attribute endpoint
   #   Endpoint used for making requests. Should be formatted as a URI.
-  #
   #   @return [String]
-  #
   EndpointParameters = Struct.new(
     :endpoint,
     keyword_init: true

--- a/projections/weather/lib/weather/plugins/endpoint.rb
+++ b/projections/weather/lib/weather/plugins/endpoint.rb
@@ -7,6 +7,15 @@ module Weather
     # @api private
     class Endpoint < Smithy::Client::Plugin
       option(
+        :endpoint,
+        doc_type: 'String',
+        docstring: <<~DOCS
+          The endpoint to send requests to.
+          The endpoint should be a URI formatted like "http://example.com:123"'
+        DOCS
+      )
+
+      option(
         :endpoint_provider,
         doc_type: '#resolve(parameters)',
         doc_default: 'Weather::EndpointProvider',
@@ -15,12 +24,6 @@ module Weather
       ) do |_config|
         EndpointProvider.new
       end
-
-      option(
-        :endpoint,
-        doc_type: String,
-        docstring: 'Custom Endpoint'
-      )
 
       option(:endpoint_auth_schemes) do
         {"bearer" => "smithy.api#httpBearerAuth", "none" => "smithy.api#noAuth"}


### PR DESCRIPTION
Do not generate built ins and rely on them being in a dependency (or code generated statically)