### PR TITLE
Do not default endpoint with stub responses

### DIFF
--- a/gems/smithy-client/spec/smithy-client/log_formatter_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/log_formatter_spec.rb
@@ -6,7 +6,7 @@ module Smithy
   module Client
     describe LogFormatter do
       let(:client_class) { ClientHelper.sample_client.const_get(:Client) }
-      let(:client) { client_class.new(stub_responses: true) }
+      let(:client) { client_class.new(stub_responses: true, endpoint: 'https://example.com') }
       let(:response) { client.operation }
 
       def formatted(pattern, options = {})

--- a/gems/smithy-client/spec/smithy-client/plugins/checksum_required_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/checksum_required_spec.rb
@@ -9,7 +9,7 @@ module Smithy
         let(:shapes) { ClientHelper.sample_shapes }
         let(:sample_client) { ClientHelper.sample_client(shapes: shapes) }
         let(:client_class) { sample_client.const_get(:Client) }
-        let(:client) { client_class.new(stub_responses: true) }
+        let(:client) { client_class.new(stub_responses: true, endpoint: 'https://example.com') }
 
         before do
           shapes['smithy.ruby.tests#Operation']['traits'] = { 'smithy.api#httpChecksumRequired' => {} }

--- a/gems/smithy-client/spec/smithy-client/plugins/default_params_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/default_params_spec.rb
@@ -8,7 +8,7 @@ module Smithy
       describe ParamValidator do
         let(:sample_client) { ClientHelper.sample_client }
         let(:client_class) { sample_client.const_get(:Client) }
-        let(:client) { client_class.new(stub_responses: true) }
+        let(:client) { client_class.new(stub_responses: true, endpoint: 'https://example.com') }
 
         it 'adds the handler' do
           expect(client.handlers).to include(DefaultParams::Handler)

--- a/gems/smithy-client/spec/smithy-client/plugins/http_api_key_auth_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/http_api_key_auth_spec.rb
@@ -15,7 +15,7 @@ module Smithy
           client_class
         end
 
-        let(:client) { client_class.new(stub_responses: true) }
+        let(:client) { client_class.new(stub_responses: true, endpoint: 'https://example.com') }
 
         before do
           shapes['smithy.ruby.tests#SampleClient']['traits']['smithy.api#httpApiKeyAuth'] = {}

--- a/gems/smithy-client/spec/smithy-client/plugins/http_basic_auth_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/http_basic_auth_spec.rb
@@ -15,7 +15,7 @@ module Smithy
           client_class
         end
 
-        let(:client) { client_class.new(stub_responses: true) }
+        let(:client) { client_class.new(stub_responses: true, endpoint: 'https://example.com') }
 
         before do
           shapes['smithy.ruby.tests#SampleClient']['traits']['smithy.api#httpBasicAuth'] = {}

--- a/gems/smithy-client/spec/smithy-client/plugins/http_bearer_auth_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/http_bearer_auth_spec.rb
@@ -15,7 +15,7 @@ module Smithy
           client_class
         end
 
-        let(:client) { client_class.new(stub_responses: true) }
+        let(:client) { client_class.new(stub_responses: true, endpoint: 'https://example.com') }
 
         before do
           shapes['smithy.ruby.tests#SampleClient']['traits']['smithy.api#httpBearerAuth'] = {}

--- a/gems/smithy-client/spec/smithy-client/plugins/http_digest_auth_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/http_digest_auth_spec.rb
@@ -15,7 +15,7 @@ module Smithy
           client_class
         end
 
-        let(:client) { client_class.new(stub_responses: true) }
+        let(:client) { client_class.new(stub_responses: true, endpoint: 'https://example.com') }
 
         before do
           shapes['smithy.ruby.tests#SampleClient']['traits']['smithy.api#httpDigestAuth'] = {}

--- a/gems/smithy-client/spec/smithy-client/plugins/idempotency_token_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/idempotency_token_spec.rb
@@ -9,7 +9,7 @@ module Smithy
         let(:shapes) { ClientHelper.sample_shapes }
         let(:sample_client) { ClientHelper.sample_client(shapes: shapes) }
         let(:client_class) { sample_client.const_get(:Client) }
-        let(:client) { client_class.new(stub_responses: true) }
+        let(:client) { client_class.new(stub_responses: true, endpoint: 'https://example.com') }
 
         before do
           shapes['smithy.ruby.tests#Structure']['members']['string'] = {

--- a/gems/smithy-client/spec/smithy-client/plugins/logging_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/logging_spec.rb
@@ -8,7 +8,8 @@ module Smithy
       describe Logging do
         let(:sample_client) { ClientHelper.sample_client }
         let(:client_class) { sample_client.const_get(:Client) }
-        let(:client) { client_class.new(stub_responses: true) }
+        let(:client_options) { { stub_responses: true, endpoint: 'https://example.com' } }
+        let(:client) { client_class.new(client_options) }
 
         let(:logger) { Logger.new(IO::NULL) }
         let(:log_level) { :info }
@@ -30,24 +31,24 @@ module Smithy
         end
 
         it 'adds the handler when a logger is provided' do
-          client = client_class.new(stub_responses: true, logger: logger)
+          client = client_class.new(client_options.merge(logger: logger))
           expect(client.handlers).to include(Logging::Handler)
         end
 
         it 'logs the output to the log level' do
-          client = client_class.new(stub_responses: true, logger: logger)
+          client = client_class.new(client_options.merge(logger: logger))
           expect(logger).to receive(client.config.log_level).with(instance_of(String))
           client.operation
         end
 
         it 'logs the output using the log formatter' do
-          client = client_class.new(stub_responses: true, logger: logger)
+          client = client_class.new(client_options.merge(logger: logger))
           expect(client.config.log_formatter).to receive(:format).with(instance_of(Response))
           client.operation
         end
 
         it 'sets start and end times in the context' do
-          client = client_class.new(stub_responses: true, logger: logger, log_level: log_level)
+          client = client_class.new(client_options.merge(logger: logger, log_level: log_level))
           response = client.operation
           expect(response.context[:logging_started_at]).to be_kind_of(Time)
           expect(response.context[:logging_completed_at]).to be_kind_of(Time)

--- a/gems/smithy-client/spec/smithy-client/plugins/pageable_response_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/pageable_response_spec.rb
@@ -55,7 +55,7 @@ module Smithy
 
         let(:sample_client) { ClientHelper.sample_client(shapes: shapes) }
         let(:client_class) { sample_client.const_get(:Client) }
-        let(:client) { client_class.new(stub_responses: true) }
+        let(:client) { client_class.new(stub_responses: true, endpoint: 'https://example.com') }
 
         context 'pagination' do
           it 'can paginate with next_page and next_page?' do

--- a/gems/smithy-client/spec/smithy-client/plugins/raise_response_errors_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/raise_response_errors_spec.rb
@@ -8,7 +8,8 @@ module Smithy
       describe RaiseResponseErrors do
         let(:sample_client) { ClientHelper.sample_client }
         let(:client_class) { sample_client.const_get(:Client) }
-        let(:client) { client_class.new(stub_responses: true) }
+        let(:client_options) { { stub_responses: true, endpoint: 'https://example.com' } }
+        let(:client) { client_class.new(client_options) }
 
         it 'adds a :raise_response_errors option to config' do
           expect(client.config).to respond_to(:raise_response_errors)
@@ -19,7 +20,7 @@ module Smithy
         end
 
         it 'does not add the handler if :raise_response_errors is false' do
-          client = client_class.new(raise_response_errors: false)
+          client = client_class.new(client_options.merge(raise_response_errors: false))
           expect(client.handlers).not_to include(RaiseResponseErrors::Handler)
         end
 
@@ -40,7 +41,7 @@ module Smithy
 
         it 'puts the error on the response when :raise_response_errors is false' do
           error = StandardError.new('msg')
-          client = client_class.new(raise_response_errors: false, stub_responses: true)
+          client = client_class.new(client_options.merge(raise_response_errors: false))
           client.stub_responses(:operation, error)
           response = client.operation
           expect(response.error).to be(error)

--- a/gems/smithy-client/spec/smithy-client/plugins/request_compression_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/request_compression_spec.rb
@@ -9,7 +9,7 @@ module Smithy
         let(:shapes) { ClientHelper.sample_shapes }
         let(:sample_client) { ClientHelper.sample_client(shapes: shapes) }
         let(:client_class) { sample_client.const_get(:Client) }
-        let(:client) { client_class.new(stub_responses: true) }
+        let(:client) { client_class.new(stub_responses: true, endpoint: 'https://example.com') }
 
         it 'adds a :disable_request_compression option to config' do
           expect(client.config).to respond_to(:disable_request_compression)

--- a/gems/smithy-client/spec/smithy-client/plugins/resolve_auth_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/resolve_auth_spec.rb
@@ -9,7 +9,8 @@ module Smithy
         let(:shapes) { ClientHelper.sample_shapes }
         let(:sample_client) { ClientHelper.sample_client(shapes: shapes) }
         let(:client_class) { sample_client.const_get(:Client) }
-        let(:client) { client_class.new(stub_responses: true) }
+        let(:client_options) { { stub_responses: true, endpoint: 'https://example.com' } }
+        let(:client) { client_class.new(client_options) }
 
         it 'adds an :auth_resolver option to config' do
           expect(client.config).to respond_to(:auth_resolver)
@@ -84,7 +85,7 @@ module Smithy
           shapes['smithy.ruby.tests#SampleClient']['traits']['smithy.api#httpBearerAuth'] = {}
           client_class.add_plugin(HttpApiKeyAuth)
           client_class.add_plugin(HttpBearerAuth)
-          client = client_class.new(stub_responses: true, bearer_token_provider: nil)
+          client = client_class.new(client_options.merge(bearer_token_provider: nil))
           resp = client.operation
           expect(resp.context.auth.scheme_id).to eq('smithy.api#httpApiKeyAuth')
         end
@@ -96,7 +97,7 @@ module Smithy
           shapes['smithy.ruby.tests#SampleClient']['traits']['smithy.api#httpBearerAuth'] = {}
           client_class.add_plugin(HttpApiKeyAuth)
           client_class.add_plugin(HttpBearerAuth)
-          client = client_class.new(stub_responses: true, bearer_token_provider: BearerTokenProvider.new)
+          client = client_class.new(client_options.merge(bearer_token_provider: BearerTokenProvider.new))
           resp = client.operation
           expect(resp.context.auth.scheme_id).to eq('smithy.api#httpApiKeyAuth')
         end
@@ -114,7 +115,7 @@ module Smithy
               ]
             end
           end
-          client = client_class.new(stub_responses: true, auth_resolver: auth_resolver.new)
+          client = client_class.new(client_options.merge(auth_resolver: auth_resolver.new))
           resp = client.operation
           expect(resp.context.auth.scheme_id).to eq('smithy.api#httpApiKeyAuth')
           expect(resp.context.auth.signer_properties).to eq('location' => 'query', 'name' => 'api_key')
@@ -128,7 +129,7 @@ module Smithy
               []
             end
           end
-          client = client_class.new(stub_responses: true, auth_resolver: auth_resolver.new)
+          client = client_class.new(client_options.merge(auth_resolver: auth_resolver.new))
           expect { client.operation }.to raise_error(/No auth options were resolved/)
         end
 
@@ -141,14 +142,14 @@ module Smithy
         it 'raises an error when identity provider is not configured' do
           shapes['smithy.ruby.tests#SampleClient']['traits']['smithy.api#httpApiKeyAuth'] = {}
           client_class.add_plugin(HttpApiKeyAuth)
-          client = client_class.new(stub_responses: true, api_key_provider: nil)
+          client = client_class.new(client_options.merge(api_key_provider: nil))
           expect { client.operation }.to raise_error(/did not have an identity provider configured/)
         end
 
         it 'raises an error when identity provider fails to resolve identity' do
           shapes['smithy.ruby.tests#SampleClient']['traits']['smithy.api#httpApiKeyAuth'] = {}
           client_class.add_plugin(HttpApiKeyAuth)
-          client = client_class.new(stub_responses: true, api_key_provider: ApiKeyProvider.new)
+          client = client_class.new(client_options.merge(api_key_provider: ApiKeyProvider.new))
           expect { client.operation }.to raise_error(/failed to resolve identity/)
         end
 
@@ -163,28 +164,21 @@ module Smithy
           end
 
           it 'uses the preferred auth scheme when multiple schemes are supported' do
-            client = client_class.new(
-              stub_responses: true,
-              auth_scheme_preference: ['smithy.api#httpBasicAuth']
-            )
+            client = client_class.new(client_options.merge(auth_scheme_preference: ['smithy.api#httpBasicAuth']))
             resp = client.operation
             expect(resp.context.auth.scheme_id).to eq('smithy.api#httpBasicAuth')
           end
 
           it 'ignores unsupported preferred auth schemes' do
             client = client_class.new(
-              stub_responses: true,
-              auth_scheme_preference: ['smithy.api#httpDigestAuth', 'smithy.api#httpBasicAuth']
+              client_options.merge(auth_scheme_preference: ['smithy.api#httpDigestAuth', 'smithy.api#httpBasicAuth'])
             )
             resp = client.operation
             expect(resp.context.auth.scheme_id).to eq('smithy.api#httpBasicAuth')
           end
 
           it 'falls back to modeled order when no preferred auth schemes are supported' do
-            client = client_class.new(
-              stub_responses: true,
-              auth_scheme_preference: ['smithy.api#httpDigestAuth']
-            )
+            client = client_class.new(client_options.merge(auth_scheme_preference: ['smithy.api#httpDigestAuth']))
             resp = client.operation
             expect(resp.context.auth.scheme_id).to eq('smithy.api#httpApiKeyAuth')
           end
@@ -228,7 +222,6 @@ module Smithy
             shapes['smithy.ruby.tests#SampleClient']['traits']['smithy.api#httpApiKeyAuth'] = {}
             client_class.add_plugin(HttpApiKeyAuth)
             client_class.add_plugin(HttpBearerAuth) # to register the endpoint auth scheme
-            client = client_class.new(stub_responses: true)
             resp = client.operation
             expect(resp.context.auth.scheme_id).to eq('smithy.api#httpBearerAuth')
           end
@@ -237,7 +230,6 @@ module Smithy
             shapes['smithy.ruby.tests#SampleClient']['traits']['smithy.rules#endpointRuleSet'] =
               endpoint_rules([{ 'name' => 'other' }, { 'name' => 'bearer' }])
             client_class.add_plugin(HttpBearerAuth) # to register the endpoint auth scheme
-            client = client_class.new(stub_responses: true)
             resp = client.operation
             expect(resp.context.auth.scheme_id).to eq('smithy.api#httpBearerAuth')
           end
@@ -246,7 +238,6 @@ module Smithy
             shapes['smithy.ruby.tests#SampleClient']['traits']['smithy.rules#endpointRuleSet'] =
               endpoint_rules([{ 'name' => 'bearer', 'foo' => 'bar' }])
             client_class.add_plugin(HttpBearerAuth) # to register the endpoint auth scheme
-            client = client_class.new(stub_responses: true)
             resp = client.operation
             expect(resp.context.auth.scheme_id).to eq('smithy.api#httpBearerAuth')
             expect(resp.context.auth.signer_properties).to eq('foo' => 'bar')
@@ -258,8 +249,7 @@ module Smithy
                 endpoint_rules([{ 'name' => 'other' }, { 'name' => 'bearer' }])
               client_class.add_plugin(HttpBearerAuth) # to register the endpoint auth scheme
               client = client_class.new(
-                stub_responses: true,
-                auth_scheme_preference: ['smithy.api#noAuth', 'smithy.api#httpBearerAuth']
+                client_options.merge(auth_scheme_preference: ['smithy.api#noAuth', 'smithy.api#httpBearerAuth'])
               )
               resp = client.operation
               expect(resp.context.auth.scheme_id).to eq('smithy.api#httpBearerAuth')
@@ -270,8 +260,7 @@ module Smithy
                 endpoint_rules([{ 'name' => 'other' }, { 'name' => 'bearer' }])
               client_class.add_plugin(HttpBearerAuth) # to register the endpoint auth scheme
               client = client_class.new(
-                stub_responses: true,
-                auth_scheme_preference: ['smithy.api#httpDigestAuth', 'smithy.api#httpBearerAuth']
+                client_options.merge(auth_scheme_preference: ['smithy.api#httpDigestAuth', 'smithy.api#httpBearerAuth'])
               )
               resp = client.operation
               expect(resp.context.auth.scheme_id).to eq('smithy.api#httpBearerAuth')
@@ -281,10 +270,7 @@ module Smithy
               shapes['smithy.ruby.tests#SampleClient']['traits']['smithy.rules#endpointRuleSet'] =
                 endpoint_rules([{ 'name' => 'bearer' }])
               client_class.add_plugin(HttpBearerAuth) # to register the endpoint auth scheme
-              client = client_class.new(
-                stub_responses: true,
-                auth_scheme_preference: ['smithy.api#httpDigestAuth']
-              )
+              client = client_class.new(client_options.merge(auth_scheme_preference: ['smithy.api#httpDigestAuth']))
               resp = client.operation
               expect(resp.context.auth.scheme_id).to eq('smithy.api#httpBearerAuth')
             end

--- a/gems/smithy-client/spec/smithy-client/plugins/stub_responses_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/stub_responses_spec.rb
@@ -10,7 +10,7 @@ module Smithy
       describe StubResponses do
         let(:sample_client) { ClientHelper.sample_client }
         let(:client_class) { sample_client.const_get(:Client) }
-        let(:client) { client_class.new(stub_responses: true) }
+        let(:client) { client_class.new(stub_responses: true, endpoint: 'https://example.com') }
 
         it 'adds a :stub_responses option to config' do
           expect(client.config).to respond_to(:stub_responses)
@@ -30,15 +30,6 @@ module Smithy
         it 'adds the handler if :stub_responses is true' do
           expect(client.handlers).to include(StubResponses::StubHandler)
           expect(client.handlers).to include(StubResponses::APIRequestsHandler)
-        end
-
-        it 'defaults the endpoint if :stub_responses is true' do
-          expect(client.config.endpoint).to eq('http://stubbed-endpoint')
-        end
-
-        it 'does not default the endpoint if a custom endpoint is set' do
-          client = client_class.new(stub_responses: true, endpoint: 'https://example.com')
-          expect(client.config.endpoint).to eq('https://example.com')
         end
 
         it 'signals error for exceptions' do

--- a/gems/smithy-client/spec/smithy-client/plugins/user_agent_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/user_agent_spec.rb
@@ -6,8 +6,10 @@ module Smithy
   module Client
     module Plugins
       describe UserAgent do
-        let(:client_class) { ClientHelper.sample_client.const_get(:Client) }
-        let(:client) { client_class.new(stub_responses: true) }
+        let(:sample_client) { ClientHelper.sample_client }
+        let(:client_class) { sample_client.const_get(:Client) }
+        let(:client_options) { { stub_responses: true, endpoint: 'https://example.com' } }
+        let(:client) { client_class.new(client_options) }
 
         it 'adds a user agent header to request' do
           resp = client.operation
@@ -19,7 +21,7 @@ module Smithy
         end
 
         it 'adds a user agent suffix to user agent string when configured' do
-          client = client_class.new(user_agent_suffix: 'test-suffix', stub_responses: true)
+          client = client_class.new(client_options.merge(user_agent_suffix: 'test-suffix'))
           resp = client.operation
           ua_header = resp.context.http_request.headers['user-agent']
           expect(ua_header).to end_with('test-suffix')

--- a/gems/smithy-client/spec/smithy-client/waiters_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/waiters_spec.rb
@@ -55,7 +55,8 @@ module Smithy
       end
 
       let(:sample_client) { ClientHelper.sample_client(shapes: shapes) }
-      let(:client) { sample_client.const_get(:Client).new(stub_responses: true) }
+      let(:client_class) { sample_client.const_get(:Client) }
+      let(:client) { client_class.new(stub_responses: true, endpoint: 'https://example.com') }
 
       before(:each) { allow_any_instance_of(Waiters::Waiter).to receive(:sleep) }
 

--- a/gems/smithy/lib/smithy/templates/client/endpoint_plugin.erb
+++ b/gems/smithy/lib/smithy/templates/client/endpoint_plugin.erb
@@ -37,12 +37,6 @@ module <%= module_name %>
         <%= endpoint_auth_scheme_bindings %>
       end
 
-      def before_initialize(_client_class, options)
-        return unless options[:stub_responses]
-
-        options[:endpoint] = 'http://stubbed-endpoint' unless options.key?(:endpoint)
-      end
-
       # @api private
       class Handler < Smithy::Client::Handler
         def call(context)

--- a/gems/smithy/lib/smithy/templates/client/protocol_spec.erb
+++ b/gems/smithy/lib/smithy/templates/client/protocol_spec.erb
@@ -4,7 +4,7 @@ require_relative '../spec_helper'
 
 module <%= module_name %>
   describe Client do
-    let(:client_options) { { stub_responses: true } }
+    let(:client_options) { { stub_responses: true, endpoint: 'https://example.com' } }
     let(:client) { Client.new(client_options) }
 
 <% all_operation_tests.each do |operation_tests| -%>

--- a/gems/smithy/spec/interfaces/client/stub_responses_spec.rb
+++ b/gems/smithy/spec/interfaces/client/stub_responses_spec.rb
@@ -42,7 +42,7 @@ describe 'Client: Stub Responses' do
         allow(Time).to receive(:at).and_return(now)
       end
 
-      subject { Shapes::Client.new(stub_responses: true) }
+      subject { Shapes::Client.new(stub_responses: true, endpoint: 'https://example.com') }
 
       describe '#stub_data' do
         it 'returns the correct type' do

--- a/gems/smithy/spec/interfaces/client/waiters_spec.rb
+++ b/gems/smithy/spec/interfaces/client/waiters_spec.rb
@@ -7,7 +7,7 @@ describe 'Client: Waiters' do
     context context do
       include_context context, 'Waiters'
 
-      let(:client) { Waiters::Client.new(stub_responses: true) }
+      let(:client) { Waiters::Client.new(stub_responses: true, endpoint: 'https://example.com') }
       let(:no_such_waiter_error) { Smithy::Client::Waiters::NoSuchWaiterError }
 
       it 'returns nil when successful' do


### PR DESCRIPTION
Do not default the endpoint with stub responses.

In AWS clients, we want to default to a stubbed region which should make a valid regional endpoint, used for presigning or signing tests.

Other solutions may involve wrapping the default endpoint provider with a stubbed one that checks stubbed responses?