### PR TITLE
fix: Fix response body corruption on retry by rewinding after truncate

### DIFF
--- a/gems/smithy-client/lib/smithy-client/http/response.rb
+++ b/gems/smithy-client/lib/smithy-client/http/response.rb
@@ -151,6 +151,7 @@ module Smithy
           @status_code = 0
           @headers.clear
           @body.truncate(0)
+          @body.rewind
           @error = nil
         end
 

--- a/gems/smithy-client/spec/smithy-client/http/response_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/http/response_spec.rb
@@ -72,6 +72,16 @@ module Smithy
             expect(response.status_code).to eq(0)
             expect(response.error).to be_nil
           end
+
+          it 'rewinds the body position so subsequent writes start at the beginning' do
+            subject.signal_data('first response body')
+            subject.signal_done
+            subject.body.read
+            subject.reset
+            subject.signal_data('second response body')
+            subject.signal_done
+            expect(subject.body.read).to eq('second response body')
+          end
         end
 
         describe '#signal_headers' do


### PR DESCRIPTION
`Http::Response#reset` calls `truncate(0)` to clear the body between retry attempts, but does not reset the position pointer. When the retry response is written, `StringIO` pads the gap from position 0 to the stale pointer with null bytes, corrupting the body and resulting in `Smithy::Xml::ParseError`. This PR calls `rewind` after `truncate` in the `reset` method to correctly reset the pointer.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
