### PR TITLE
fix: clamp Retry-After header value to max backoff delay

### DIFF
--- a/gems/smithy-client/lib/smithy-client/net_http/patches.rb
+++ b/gems/smithy-client/lib/smithy-client/net_http/patches.rb
@@ -9,6 +9,9 @@ module Smithy
           Net::HTTPGenericRequest.prepend(PatchDefaultContentType)
         end
 
+        # TODO: net-http v0.7.0 removes supply_default_content_type, breaking this patch.
+        #   Ruby 4 will ship with that version. Fix before then.
+        #   See: https://github.com/ruby/net-http/releases/tag/v0.7.0
         # For requests with bodies, Net::HTTP sets a default content type of:
         #     'application/x-www-form-urlencoded'
         # There are cases where we should not send content type at all.

--- a/gems/smithy-client/lib/smithy-client/retry/adaptive.rb
+++ b/gems/smithy-client/lib/smithy-client/retry/adaptive.rb
@@ -51,8 +51,7 @@ module Smithy
           @capacity_amount = @quota.checkout_capacity(error_info)
           return unless @capacity_amount.positive?
 
-          delay = error_info.hints[:retry_after]
-          delay ||= @backoff.call(retry_token.retry_count)
+          delay = compute_delay(error_info, retry_token.retry_count)
           retry_token.retry_count += 1
           retry_token.retry_delay = delay
           retry_token
@@ -62,6 +61,14 @@ module Smithy
           @client_rate_limiter.update_sending_rate(false)
           @quota.release(@capacity_amount)
           retry_token
+        end
+
+        private
+
+        def compute_delay(error_info, retry_count)
+          return @backoff.call(retry_count) unless error_info.hints[:retry_after]
+
+          [error_info.hints[:retry_after], @backoff.max_delay].min
         end
       end
     end

--- a/gems/smithy-client/lib/smithy-client/retry/standard.rb
+++ b/gems/smithy-client/lib/smithy-client/retry/standard.rb
@@ -38,8 +38,7 @@ module Smithy
           @capacity_amount = @quota.checkout_capacity(error_info)
           return unless @capacity_amount.positive?
 
-          delay = error_info.hints[:retry_after]
-          delay ||= @backoff.call(retry_token.retry_count)
+          delay = compute_delay(error_info, retry_token.retry_count)
           retry_token.retry_count += 1
           retry_token.retry_delay = delay
           retry_token
@@ -48,6 +47,14 @@ module Smithy
         def record_success(retry_token)
           @quota.release(@capacity_amount)
           retry_token
+        end
+
+        private
+
+        def compute_delay(error_info, retry_count)
+          return @backoff.call(retry_count) unless error_info.hints[:retry_after]
+
+          [error_info.hints[:retry_after], @backoff.max_delay].min
         end
       end
     end

--- a/gems/smithy-client/spec/smithy-client/plugins/retry_errors_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugins/retry_errors_spec.rb
@@ -232,6 +232,26 @@ module Smithy
               handle_with_retry(test_case_def)
             end
 
+            it 'clamps retry_after hint to max_delay' do
+              config.retry_strategy = Retry::Standard.new(max_delay: 3)
+              allow(Kernel).to receive(:rand).and_return(1)
+
+              response.context.http_response.headers['retry-after'] = '9999'
+
+              test_case_def = [
+                {
+                  response: { status_code: 503, error: service_error },
+                  expect: { available_capacity: 495, retries: 1, delay: 3 }
+                },
+                {
+                  response: { status_code: 200, error: nil },
+                  expect: { available_capacity: 500, retries: 1 }
+                }
+              ]
+
+              handle_with_retry(test_case_def)
+            end
+
             it 'fails due to retry quota bucket exhaustion' do
               config.retry_max_attempts = 5
               quota.instance_variable_set(:@available_capacity, 10)
@@ -296,6 +316,26 @@ module Smithy
               # Needs to be smaller than 't' in the iterations
               client_rate_limiter.instance_variable_set(:@last_tx_rate_bucket, 4.5)
               client_rate_limiter.instance_variable_set(:@last_max_rate, 10)
+            end
+
+            it 'clamps retry_after hint to max_delay' do
+              config.retry_strategy = Retry::Adaptive.new(max_delay: 3)
+              allow(Kernel).to receive(:rand).and_return(1)
+
+              response.context.http_response.headers['retry-after'] = '9999'
+
+              test_case_def = [
+                {
+                  response: { status_code: 503, error: service_error },
+                  expect: { retries: 1, delay: 3 }
+                },
+                {
+                  response: { status_code: 200, error: nil },
+                  expect: { retries: 1 }
+                }
+              ]
+
+              handle_with_retry(test_case_def)
             end
 
             it 'verifies cubic calculations for successes' do


### PR DESCRIPTION
## Summary
- Standard and Adaptive retry strategies now cap the server-supplied `Retry-After` hint against `@backoff.max_delay` (default 20s)
- Previously, a server could return `Retry-After: 99999999` and the client would sleep indefinitely, bypassing the configured max delay
- Adds `compute_delay` helper to both strategies for clarity

## Context
Taken care of as part of oncall. All other Smithy runtimes already clamp. 

V3 is not affected since its `Handler#backoff` already caps via `[backoff_duration, exp_backoff + 5].min`: [source](https://github.com/aws/aws-sdk-ruby/blob/version-3/gems/aws-sdk-core/lib/aws-sdk-core/plugins/retry_errors.rb#L372-L379)
