### PR TITLE
fix: disable Net::HTTP automatic gzip decompression

### DIFF
--- a/gems/smithy-client/lib/smithy-client/net_http/handler.rb
+++ b/gems/smithy-client/lib/smithy-client/net_http/handler.rb
@@ -137,7 +137,9 @@ module Smithy
         # @param [Http::Request] request
         # @return [Hash<String, String>]
         def net_headers_for(request)
-          headers = {}
+          # Net::HTTP defaults decode_content=true and adds Accept-Encoding: gzip.
+          # Setting an empty value prevents automatic decompression.
+          headers = { 'accept-encoding' => '' }
           request.headers.each_pair do |key, value|
             headers[key] = value
           end

--- a/gems/smithy-client/lib/smithy-client/net_http/handler.rb
+++ b/gems/smithy-client/lib/smithy-client/net_http/handler.rb
@@ -138,8 +138,8 @@ module Smithy
         # @return [Hash<String, String>]
         def net_headers_for(request)
           # Net::HTTP defaults decode_content=true and adds Accept-Encoding: gzip.
-          # Setting an empty value prevents automatic decompression.
-          headers = { 'accept-encoding' => '' }
+          # Setting 'identity' prevents automatic decompression.
+          headers = { 'accept-encoding' => 'identity' }
           request.headers.each_pair do |key, value|
             headers[key] = value
           end

--- a/gems/smithy-client/spec/smithy-client/net_http/handler_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/net_http/handler_spec.rb
@@ -88,7 +88,7 @@ module Smithy
 
             it 'populates a default accept-encoding header' do
               # this prevents net/http from setting accept-encoding on our behalf
-              stub_request(:any, endpoint).with(headers: { 'accept-encoding' => '' })
+              stub_request(:any, endpoint).with(headers: { 'accept-encoding' => 'identity' })
               make_request
             end
 

--- a/gems/smithy-client/spec/smithy-client/net_http/handler_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/net_http/handler_spec.rb
@@ -86,19 +86,17 @@ module Smithy
               make_request
             end
 
-            # it 'populates a default accept-encoding header' do
-            #   # this prevents net/http from setting accept-encoding on our behalf
-            #   stub_request(:any, endpoint).
-            #     with(:headers => { 'accept-encoding' => '' })
-            #   make_request
-            # end
-            #
-            # it 'does not clobber a custom accept-encoding' do
-            #   http_request.headers['Accept-Encoding'] = 'text/plain'
-            #   stub_request(:any, endpoint).
-            #     with(headers: { 'accept-encoding' => 'text/plain' })
-            #   make_request
-            # end
+            it 'populates a default accept-encoding header' do
+              # this prevents net/http from setting accept-encoding on our behalf
+              stub_request(:any, endpoint).with(headers: { 'accept-encoding' => '' })
+              make_request
+            end
+
+            it 'does not clobber a custom accept-encoding' do
+              http_request.headers['Accept-Encoding'] = 'text/plain'
+              stub_request(:any, endpoint).with(headers: { 'accept-encoding' => 'text/plain' })
+              make_request
+            end
           end
 
           describe 'request path' do


### PR DESCRIPTION
## Summary
- Sets a default empty `accept-encoding` header in `net_headers_for`, preventing Net::HTTP from adding `Accept-Encoding: gzip` and enabling automatic decompression
- Uncomments existing tests that were written for this behavior in #222

## Context
Taken care of as part of oncall. V3 already does this at [`seahorse/client/net_http/handler.rb:185`](https://github.com/aws/aws-sdk-ruby/blob/version-3/gems/aws-sdk-core/lib/seahorse/client/net_http/handler.rb#L185)