### PR TITLE
fix: add maximum nesting depth to CBOR decoder

### DIFF
--- a/gems/smithy-cbor/lib/smithy-cbor/decoder.rb
+++ b/gems/smithy-cbor/lib/smithy-cbor/decoder.rb
@@ -11,10 +11,12 @@ module Smithy
       TAG_TYPE_BIGNUM = 2
       TAG_TYPE_NEG_BIGNUM = 3
       TAG_TYPE_BIGDEC = 4
+      MAX_DEPTH = 128 # Value chosen to match other Smithy-based SDKs
 
       def initialize(bytes)
         @buffer = bytes
         @pos = 0
+        @depth = 0
       end
 
       def decode
@@ -31,6 +33,9 @@ module Smithy
       # high level, generic decode. Based on the next type.
       # Consumes and returns the next item as a ruby object.
       def decode_item # rubocop:disable Metrics
+        @depth += 1
+        raise ParseError, "Maximum nesting depth (#{MAX_DEPTH}) exceeded" if @depth > MAX_DEPTH
+
         case (next_type = peek_type)
         when :array
           read_array.times.map { decode_item }
@@ -44,6 +49,8 @@ module Smithy
         when :break_stop_code then raise ParseError, 'Unexpected break code'
         else send("read_#{next_type}")
         end
+      ensure
+        @depth -= 1
       end
 
       def peek(n_bytes)

--- a/gems/smithy-cbor/spec/smithy-cbor/decoder_spec.rb
+++ b/gems/smithy-cbor/spec/smithy-cbor/decoder_spec.rb
@@ -84,6 +84,19 @@ module Smithy
             Decoder.new(['c48321196ab3'].pack('H*')).decode
           end.to raise_error(ParseError, /Expected array of length 2 but length is: 3/)
         end
+
+        it 'raises ParseError when nesting depth exceeds MAX_DEPTH' do
+          # 0xc6 = CBOR tag(6), each one recurses into decode_item.
+          # 128 tags + terminal value = 129 calls to decode_item.
+          payload = ("\xc6".b * 128) + "\x00".b
+          expect { Decoder.new(payload).decode }.to raise_error(ParseError, /Maximum nesting depth/)
+        end
+
+        it 'decodes payloads within the depth limit' do
+          # 127 tags + terminal value = 128 calls to decode_item (at the limit).
+          payload = ("\xc6".b * 127) + "\x00".b
+          expect { Decoder.new(payload).decode }.not_to raise_error
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary
- Adds a depth counter to `decode_item` that raises `ParseError` when
  nesting exceeds 128 levels
- Without this, a crafted payload of nested CBOR containers causes unbounded recursion, raising `SystemStackError` which escapes our `rescue StandardError` handler and crashes the process
- `ParseError` inherits from `StandardError`, so it is caught cleanly

## Context
Taken care of as part of oncall. Value of 128 chosen to match other Smithy-based SDKs (e.g. smithy-rs `max_depth`). No AWS service currently uses rpcv2Cbor, so practical exposure is zero today so this is a proactive fix before any service adopts it.
