### PR TITLE
fix: Restore member xmlName resolution in XML builder root entry pt

### DIFF
--- a/gems/smithy-xml/lib/smithy-xml/builder.rb
+++ b/gems/smithy-xml/lib/smithy-xml/builder.rb
@@ -16,7 +16,8 @@ module Smithy
       def build(shape, data, output = nil)
         output ||= []
         @builder = DocBuilder.new(output: output, indent: @indent, pad: @pad)
-        structure(shape.target.traits['smithy.api#xmlName'] || shape.target.name, shape, data)
+        xml_name = shape.traits['smithy.api#xmlName'] || shape.target.traits['smithy.api#xmlName'] || shape.target.name
+        structure(xml_name, shape, data)
         output.join
       end
 


### PR DESCRIPTION
## Summary

The `build` entry point only checks `shape.target.traits['smithy.api#xmlName']` for the root element name, but doesn't check `shape.traits['smithy.api#xmlName']` (the member-level xmlName). This was a regression introduced in #342 — the old code checked `ref.location_name` first, which callers used to pass the resolved member xmlName.

This matters for REST XML `httpPayload` members where the member's `xmlName` overrides the target shape's `xmlName` (e.g., member has `xmlName: "Hola"`, target has `xmlName: "Hello"` — should serialize as `<Hola>`).

## Changes

- Check `shape.traits['smithy.api#xmlName']` before `shape.target.traits['smithy.api#xmlName']` in the builder's root resolution — consistent with how nested members are already resolved via the `location_name` helper.

## Test case

`HttpPayloadWithMemberXmlName` protocol test — member xmlName should win over target xmlName for the root element. All protocol tests passes.