### PR TITLE
feat: Restore instance-level plugins

### DIFF
--- a/gems/smithy-client/lib/smithy-client/base.rb
+++ b/gems/smithy-client/lib/smithy-client/base.rb
@@ -47,6 +47,7 @@ module Smithy
       def build_config(plugins, options)
         config = Configuration.new
         config.add_option(:service)
+        config.add_option(:plugins)
         plugins.each do |plugin|
           plugin.add_options(config) if plugin.respond_to?(:add_options)
         end
@@ -87,9 +88,8 @@ module Smithy
 
       class << self
         def new(options = {})
-          plugins = build_plugins
           options = options.dup
-          options[:plugins]&.freeze
+          plugins = build_plugins(options[:plugins])
           before_initialize(plugins, options)
           client = allocate
           client.send(:initialize, plugins, options)
@@ -180,8 +180,10 @@ module Smithy
 
         private
 
-        def build_plugins
-          plugins.map { |plugin| plugin.is_a?(Class) ? plugin.new : plugin }
+        def build_plugins(instance_plugins = nil)
+          list = PluginList.new(@plugins)
+          Array(instance_plugins).each { |plugin| list.add(plugin) }
+          list.map { |plugin| plugin.is_a?(Class) ? plugin.new : plugin }.freeze
         end
 
         def before_initialize(plugins, options)

--- a/gems/smithy-client/lib/smithy-client/plugin_list.rb
+++ b/gems/smithy-client/lib/smithy-client/plugin_list.rb
@@ -129,7 +129,7 @@ module Smithy
         # @return [Class<Plugin>]
         def require_plugin
           require(@gem_name) if @gem_name
-          plugin_class = Plugin
+          plugin_class = Kernel
           @canonical_name.split('::').each do |const_name|
             plugin_class = plugin_class.const_get(const_name)
           end

--- a/gems/smithy-client/spec/smithy-client/base_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/base_spec.rb
@@ -144,6 +144,42 @@ module Smithy
             client_class.new
           end
         end
+
+        context 'instance level plugins' do
+          it 'applies plugins passed via :plugins' do
+            client = client_class.new(plugins: [DummySendPlugin])
+            expect(client.handlers).to include(DummySendPlugin::Handler)
+          end
+
+          it 'does not mutate the class plugin list' do
+            client_class.new(plugins: [DummySendPlugin])
+            expect(client_class.plugins).not_to include(DummySendPlugin)
+          end
+
+          it 'does not affect other clients built from the same class' do
+            with_plugin = client_class.new(plugins: [DummySendPlugin])
+            without = client_class.new
+            expect(with_plugin.handlers).to include(DummySendPlugin::Handler)
+            expect(without.handlers).not_to include(DummySendPlugin::Handler)
+          end
+
+          it 'de-duplicates a plugin already on the class (same class form)' do
+            client_class.add_plugin(DummySendPlugin)
+            client = client_class.new(plugins: [DummySendPlugin])
+            handler_count = client.handlers.to_a.count(DummySendPlugin::Handler)
+            expect(handler_count).to eq(1)
+          end
+
+          it 'resolves the plugin set once and freezes it' do
+            expect(client_class).to receive(:build_plugins).once.and_call_original
+            client_class.new(plugins: [DummySendPlugin])
+          end
+
+          it 'exposes the passed plugins on the config' do
+            client = client_class.new(plugins: [DummySendPlugin])
+            expect(client.config.plugins).to eq([DummySendPlugin])
+          end
+        end
       end
 
       describe '.add_plugin' do

--- a/gems/smithy-client/spec/smithy-client/plugin_list_spec.rb
+++ b/gems/smithy-client/spec/smithy-client/plugin_list_spec.rb
@@ -76,11 +76,35 @@ module Smithy
           expect(subject.to_a).to eq([plugin])
         end
 
+        # TODO: address with team offline
+        # A class and an instance of it are NOT de-duplicated: a class
+        # canonicalizes by name, an instance by object_id. This matches V3
+        # behavior.
+        it 'does not de-duplicate a class against an instance of it' do
+          subject.add(Plugin1)
+          subject.add(Plugin1.new)
+          expect(subject.to_a.size).to eq(2)
+        end
+
+        it 'does not de-duplicate distinct instances of the same class' do
+          subject.add(Plugin1.new)
+          subject.add(Plugin1.new)
+          expect(subject.to_a.size).to eq(2)
+        end
+
         it 'does not require plugins when added' do
           subject.add('Smithy::Client::LazyPlugin::Add')
           expect(LazyPlugin.const_defined?(:Add)).to eq(false)
           expect(subject.to_a).to eq([LazyPlugin::Add])
           expect(LazyPlugin.const_defined?(:Add)).to eq(true)
+        end
+
+        it 'resolves a plugin name from the global namespace, not under Plugin' do
+          top_level = Class.new
+          stub_const('CollidingPlugin', top_level)
+          stub_const('Smithy::Client::Plugin::CollidingPlugin', Class.new)
+          subject.add('CollidingPlugin')
+          expect(subject.to_a).to eq([top_level])
         end
       end
 


### PR DESCRIPTION
## Context

Restores V3 behavior lost in the V4 rewrite:

```ruby
client = Service::Client.new(plugins: [MyPlugin])  # scoped to this client
```

* Single-pass only; plugins can't inject other plugins (deliberate vs V3).
* **String-name fix** — `require_plugin` resolves constants from the global namespace (`Kernel`) instead of `Smithy::Client::Plugin`, so a string-named plugin colliding with a constant under `Plugin` no longer mis-resolves.


## Other Notes
- De-dup matches V3 (by object identity): a class vs. its instance, and two instances of one class, are not deduped. Per-class uniqueness is a separate discussion, out of scope here. I made a TODO for a visit later with the team.